### PR TITLE
Import correct module for azure.ai.agents namespace

### DIFF
--- a/Instructions/03c-use-agent-tools-with-mcp.md
+++ b/Instructions/03c-use-agent-tools-with-mcp.md
@@ -94,7 +94,7 @@ Now that you've created your project in AI Foundry, let's develop an app that in
     ```
    python -m venv labenv
    ./labenv/bin/Activate.ps1
-   pip install -r requirements.txt --pre azure-ai-projects mcp
+   pip install -r requirements.txt --pre azure-ai-agents mcp
     ```
 
     >**Note:** You can ignore any warning or error messages displayed during the library installation.


### PR DESCRIPTION
# Module: azure-ai-agents
## Lab/Demo: 03c - Connect AI Agents to a remote MCP server

Changes proposed in this pull request:

- import correct module for azure.ai.agents namespace
-
-