### PR TITLE
Updated requirements.txt for lab 06 with missing modules

### DIFF
--- a/Labfiles/06-build-remote-agents-with-a2a/python/requirements.txt
+++ b/Labfiles/06-build-remote-agents-with-a2a/python/requirements.txt
@@ -2,3 +2,6 @@ python-dotenv
 httpx
 azure-identity
 uvicorn
+starlette
+sse-starlette
+fastapi


### PR DESCRIPTION

# Module: 06
## Lab/Demo: 06-build-remote-agents-with-a2a

# Fixes

Changes proposed in this pull request:
Updated the requirements.txt file for lab 06-build-remote-agents-with-a2a with missing modules starlette, sse-starlette and fastapi Without those modules it's not possible to run all
-
-
-