### PR TITLE
Lab 05 - update create_agent to as_agent for agent-framework API compatibility

### DIFF
--- a/Instructions/05-agent-orchestration.md
+++ b/Instructions/05-agent-orchestration.md
@@ -151,17 +151,17 @@ Now you're ready to create the agents for your multi-agent solution! Let's get s
 
     ```python
    # Create agents
-   summarizer = chat_client.create_agent(
+   summarizer = chat_client.as_agent(
        instructions=summarizer_instructions,
        name="summarizer",
    )
 
-   classifier = chat_client.create_agent(
+   classifier = chat_client.as_agent(
        instructions=classifier_instructions,
        name="classifier",
    )
 
-   action = chat_client.create_agent(
+   action = chat_client.as_agent(
        instructions=action_instructions,
        name="action",
    )


### PR DESCRIPTION

## Lab/Demo: 05-agent-ochestration


**Problem:** The lab instructions for Exercise 05 (Agent Orchestration) used an outdated API method from the `agent-framework` library.

**Error:** The code referenced `chat_client.create_agent()` which no longer exists in the current version of the `agent-framework` package.

**Fix:** Updated all three agent creation calls to use the new method name `chat_client.as_agent()`:

```python
# Before (broken)
summarizer = chat_client.create_agent(...)

# After (fixed)
summarizer = chat_client.as_agent(...)
```

**Files changed:**
- 05-agent-orchestration.md - Updated code samples in the lab instructions



