### PR TITLE
docs: add missing az login step to foundry iq tutorial

### DIFF
--- a/Instructions/09-integrate-agent-with-foundry-iq.md
+++ b/Instructions/09-integrate-agent-with-foundry-iq.md
@@ -321,6 +321,18 @@ Now you'll create a Python application to interact with your agent programmatica
 
 Now you'll run your application and test the agent's ability to retrieve information from the knowledge base.
 
+1. In the cloud shell command-line pane, enter the following command to sign into Azure.
+
+    ```
+    az login
+    ```
+
+    **<font color="red">You must sign into Azure - even though the cloud shell session is already authenticated.</font>**
+
+    > **Note**: In most scenarios, just using *az login* will be sufficient. However, if you have subscriptions in multiple tenants, you may need to specify the tenant by using the *--tenant* parameter. See [Sign into Azure interactively using the Azure CLI](https://learn.microsoft.com/cli/azure/authenticate-azure-cli-interactively) for details.
+
+1. When prompted, follow the instructions to open the sign-in page in a new tab and enter the authentication code provided and your Azure credentials. Then complete the sign in process in the command line, selecting the subscription containing your Foundry hub if prompted.
+
 1. In the cloud shell command-line pane, run your application:
 
     ```


### PR DESCRIPTION
# Module: Develop AI Agents in Azure - Foundry IQ
## Lab/Demo: 09

Fixes # N/A

Changes proposed in this pull request:
- Add missing `az login` step to Foundry IQ tutorial documentation
- Prevent authentication errors when following the tutorial
