### PR TITLE
Add openai to requirements.txt

### DIFF
--- a/Labfiles/03c-use-agent-tools-with-mcp/Python/requirements.txt
+++ b/Labfiles/03c-use-agent-tools-with-mcp/Python/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 azure-identity
 azure-ai-projects==2.0.0b1
 uvicorn
+openai


### PR DESCRIPTION
# Module: 03
## Lab/Demo: 03c-use-agent-tools-with-mcp

Updated the requirements.txt file for lab 03c-use-agent-tools-with-mcp with missing module openai 
Without this module it's not possible to run the client.py script