### PR TITLE
Add missing parameters to `DefaultAzureCredential`

### DIFF
--- a/Instructions/08-build-workflow-ms-foundry.md
+++ b/Instructions/08-build-workflow-ms-foundry.md
@@ -396,7 +396,9 @@ Now that you've built and tested your workflow in the Foundry portal, you can al
     ```python
    # Connect to the AI Project client
    with (
-       DefaultAzureCredential() as credential,
+       DefaultAzureCredential(
+           exclude_environment_credential=True,
+           exclude_managed_identity_credential=True) as credential,
        AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
        project_client.get_openai_client() as openai_client,
    ):


### PR DESCRIPTION
Add missing parameters/arguments
```
DefaultAzureCredential(
       exclude_environment_credential=True,
       exclude_managed_identity_credential=True) as credential,
```
Without them you get the following error:
>EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.

# Module: Develop AI Agents in Azure
## Lab/Demo: Build a workflow in Microsoft Foundry

Fixes # Add missing parameters to DefaultAzureCredential.

Changes proposed in this pull request:

- See above