### PR TITLE
Fix formatting and SDK references in documentation

### DIFF
--- a/Instructions/02-build-ai-agent.md
+++ b/Instructions/02-build-ai-agent.md
@@ -8,7 +8,7 @@ lab:
 
 In this exercise, you'll use Azure AI Agent Service to create a simple agent that analyzes data and creates charts. The agent can use the built-in *Code Interpreter* tool to dynamically generate any code required to analyze data.
 
-> **Tip**: The code used in this exercise is based on the for Microsoft Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Microsoft Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
+> **Tip**: The code used in this exercise is based on the Microsoft Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Microsoft Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
 
 This exercise should take approximately **30** minutes to complete.
 

--- a/Instructions/03-agent-custom-functions.md
+++ b/Instructions/03-agent-custom-functions.md
@@ -8,7 +8,7 @@ lab:
 
 In this exercise you'll explore creating an agent that can use custom functions as a tool to complete tasks. You'll build a simple technical support agent that can collect details of a technical problem and generate a support ticket.
 
-> **Tip**: The code used in this exercise is based on the for Microsoft Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Microsoft Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
+> **Tip**: The code used in this exercise is based on the Microsoft Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Microsoft Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
 
 This exercise should take approximately **30** minutes to complete.
 

--- a/Instructions/03b-build-multi-agent-solution.md
+++ b/Instructions/03b-build-multi-agent-solution.md
@@ -8,7 +8,7 @@ lab:
 
 In this exercise, you'll create a project that orchestrates multiple AI agents using Microsoft Foundry Agent Service. You'll design an AI solution that assists with ticket triage. The connected agents will assess the ticket's priority, suggest a team assignment, and determine the level of effort required to complete the ticket. Let's get started!
 
-> **Tip**: The code used in this exercise is based on the for Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
+> **Tip**: The code used in this exercise is based on the Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
 
 This exercise should take approximately **30** minutes to complete.
 

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -10,7 +10,7 @@ lab:
 
 In this exercise you'll explore creating an agent that can use custom functions as a tool to complete tasks. The agent will act as an astronomy assistant that can provide information about astronomical events and calculate the cost of telescope rentals based on user inputs. You'll define the function tools and implement the logic to process function calls made by the agent.
 
-> **Tip**: The code used in this exercise is based on the for Microsoft Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Microsoft Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
+> **Tip**: The code used in this exercise is based on the Microsoft Foundry SDK for Python. You can develop similar solutions using the SDKs for Microsoft .NET, JavaScript, and Java. Refer to [Microsoft Foundry SDK client libraries](https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview) for details.
 
 This exercise should take approximately **50** minutes to complete.
 

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -381,7 +381,7 @@ Now that you've created the agent with the function tools, you can send messages
    if input_list:
        response = openai_client.responses.create(
            input=input_list,
-           previous_response_id=response.id,
+           conversation=conversation.id,
            extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
        )
    # Display the agent's response

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -106,7 +106,7 @@ For this exercise, you'll use starter code that will help you connect to your Fo
 
 1. Create a new folder and choose **Select as Repository Destination**, then open the cloned repository when prompted.
 
-1. In the Explorer view, navigate to the **Labfiles/02-agent-custom-tools/Python** folder to find the starter code for this exercise.
+1. In the Explorer view, navigate to the **Labfiles/03-agent-custom-tools/Python** folder to find the starter code for this exercise.
 
 1. Right-click on the **requirements.txt** file and select **Open in Integrated Terminal**.
 
@@ -313,7 +313,7 @@ Now that you've created the agent with the function tools, you can send messages
 1. Find the comment **Create an input list to hold function call outputs to send back to the model** and add the following code:
 
     ```python
-   # Create a list to hold function call outputs that will be sent back as input to the agent
+   # Create a input list to hold function call outputs that will be sent back as input to the agent
    input_list: ResponseInputParam = []
    ```
 

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -381,7 +381,7 @@ Now that you've created the agent with the function tools, you can send messages
    if input_list:
        response = openai_client.responses.create(
            input=input_list,
-           conversation=conversation.id,
+           previous_response_id=response.id,
            extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
        )
    # Display the agent's response

--- a/Labfiles/03-agent-custom-tools/Python/agent.py
+++ b/Labfiles/03-agent-custom-tools/Python/agent.py
@@ -32,7 +32,7 @@ def main():
         # Create a thread for the chat session
         
 
-        # Create a list to hold function call outputs that will be sent back as input to the agent
+        # Create an input list to hold function call outputs that will be sent back as input to the agent
         
         
         while True:


### PR DESCRIPTION
This pull request fixes a minor typo in several instructional files, improving clarity by correcting the phrasing in the "Tip" sections. The change removes the unnecessary word "for" from the description of the Microsoft Foundry SDK.

Documentation improvements:

* Corrected the "Tip" in `Instructions/02-build-ai-agent.md`, `Instructions/03-agent-custom-functions.md`, and `Instructions/Exercises/02-agent-custom-tools.md` to read "based on the Microsoft Foundry SDK for Python" instead of "based on the for Microsoft Foundry SDK for Python". [[1]](diffhunk://#diff-a23fc9e6c5d0158e6a09396e99ed49f1622e625d260c0eb59ccd254cef61c190L11-R11) [[2]](diffhunk://#diff-27fb3fcef2e3ed05416f7b94b5f7b3bdf2253cb29527010bf46e6823c634b70bL11-R11) [[3]](diffhunk://#diff-35821ee2ea96babcec03ad0412e087faee03af8de22cd4ecfe6ba89955aa70c5L13-R13)
* Fixed the "Tip" in `Instructions/03b-build-multi-agent-solution.md` to read "based on the Foundry SDK for Python" instead of "based on the for Foundry SDK for Python".# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-