### PR TITLE
Backfill missing lab metadata (21 files)

### DIFF
--- a/Instructions/01-agent-fundamentals.md
+++ b/Instructions/01-agent-fundamentals.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Explore AI Agent development (deprecated)'
-    description: 'Take your first steps in developing AI agents by exploring the Azure AI Agent service in the Microsoft Foundry portal.'
+  title: Explore AI Agent development (deprecated)
+  description: Take your first steps in developing AI agents by exploring the Azure AI Agent service in the Microsoft Foundry portal.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
+    - Microsoft Foundry
 ---
 
 # Explore AI Agent development (deprecated)

--- a/Instructions/02-build-ai-agent.md
+++ b/Instructions/02-build-ai-agent.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Develop an AI agent (deprecated)'
-    description: 'Use the Azure AI Agent Service to develop an agent that uses built-in tools.'
+  title: Develop an AI agent (deprecated)
+  description: Use the Azure AI Agent Service to develop an agent that uses built-in tools.
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Develop an AI agent (deprecated)

--- a/Instructions/03-agent-custom-functions.md
+++ b/Instructions/03-agent-custom-functions.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Use a custom function in an AI agent (deprecated)'
-    description: 'Learn how to use functions to add custom capabilities to your agents.'
+  title: Use a custom function in an AI agent (deprecated)
+  description: Learn how to use functions to add custom capabilities to your agents.
+  duration: 30 minutes
+  level: 400
+  islab: true
 ---
 
 # Use a custom function in an AI agent (deprecated)

--- a/Instructions/03b-build-multi-agent-solution.md
+++ b/Instructions/03b-build-multi-agent-solution.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Develop a multi-agent solution with Microsoft Foundry (deprecated)'
-    description: 'Learn to configure multiple agents to collaborate using Microsoft Foundry Agent Service'
+  title: Develop a multi-agent solution with Microsoft Foundry (deprecated)
+  description: Learn to configure multiple agents to collaborate using Microsoft Foundry Agent Service
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
+    - Microsoft Foundry Agent Service
 ---
 
 # Develop a multi-agent solution (deprecated)

--- a/Instructions/03c-use-agent-tools-with-mcp.md
+++ b/Instructions/03c-use-agent-tools-with-mcp.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Connect AI Agents to a remote MCP server (deprecated)'
-    description: 'Learn how to integrate Model Context Protocol tools with AI agents'
+  title: Connect AI Agents to a remote MCP server (deprecated)
+  description: Learn how to integrate Model Context Protocol tools with AI agents
+  duration: 30 minutes
+  level: 300
+  islab: true
 ---
 
 # Connect AI agents to tools using Model Context Protocol (MCP) (deprecated)

--- a/Instructions/04-semantic-kernel.md
+++ b/Instructions/04-semantic-kernel.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Develop an Azure AI agent with the Microsoft Agent Framework SDK (deprecated)'
-    description: 'Learn how to use the Microsoft Agent Framework SDK to create and use an Azure AI chat agent.'
+  title: Develop an Azure AI agent with the Microsoft Agent Framework SDK (deprecated)
+  description: Learn how to use the Microsoft Agent Framework SDK to create and use an Azure AI chat agent.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Develop an Azure AI chat agent with the Microsoft Agent Framework SDK (deprecated)

--- a/Instructions/05-agent-orchestration.md
+++ b/Instructions/05-agent-orchestration.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Develop a multi-agent solution with Microsoft Agent Framework (deprecated)'
-    description: 'Learn to configure multiple agents to collaborate using the Microsoft Agent Framework SDK'
+  title: Develop a multi-agent solution with Microsoft Agent Framework (deprecated)
+  description: Learn to configure multiple agents to collaborate using the Microsoft Agent Framework SDK
+  duration: 30 minutes
+  level: 400
+  islab: true
 ---
 
 # Develop a multi-agent solution (deprecated)

--- a/Instructions/06-multi-remote-agents-with-a2a.md
+++ b/Instructions/06-multi-remote-agents-with-a2a.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Connect to remote agents with A2A protocol (deprecated)'
-    description: 'Use the A2A protocol to collaborate with remote agents.'
+  title: Connect to remote agents with A2A protocol (deprecated)
+  description: Use the A2A protocol to collaborate with remote agents.
+  duration: 30 minutes
+  level: 400
+  islab: true
 ---
 
 # Connect to remote agents with A2A protocol (deprecated)

--- a/Instructions/07-build-agent-in-vs-code.md
+++ b/Instructions/07-build-agent-in-vs-code.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Develop an AI agent with VS Code extension (deprecated)'
-    description: 'Use the Microsoft Foundry VS Code extension to create an AI agent.'
+  title: Develop an AI agent with VS Code extension (deprecated)
+  description: Use the Microsoft Foundry VS Code extension to create an AI agent.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Develop an AI agent with VS Code extension (deprecated)

--- a/Instructions/08-build-workflow-ms-foundry.md
+++ b/Instructions/08-build-workflow-ms-foundry.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Build a workflow in Microsoft Foundry (deprecated)'
-    description: 'Use the Microsoft Foundry portal to create workflows for AI agents.'
+  title: Build a workflow in Microsoft Foundry (deprecated)
+  description: Use the Microsoft Foundry portal to create workflows for AI agents.
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Build a workflow in Microsoft Foundry (deprecated)

--- a/Instructions/09-integrate-agent-with-foundry-iq.md
+++ b/Instructions/09-integrate-agent-with-foundry-iq.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Integrate an AI agent with Foundry IQ (deprecated)'
-    description: 'Use Azure AI Agent Service to develop an agent that uses Foundry IQ to search knowledge bases.'
+  title: Integrate an AI agent with Foundry IQ (deprecated)
+  description: Use Azure AI Agent Service to develop an agent that uses Foundry IQ to search knowledge bases.
+  duration: 45 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Integrate an AI agent with Foundry IQ (deprecated)

--- a/Instructions/Exercises/01-build-agent-portal-and-vscode.md
+++ b/Instructions/Exercises/01-build-agent-portal-and-vscode.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Build AI agents with portal and VS Code'
-    description: 'Create an AI agent using both Microsoft Foundry portal and VS Code extension with built-in tools like file search and code interpreter.'
-    level: 300
-    duration: 45
+  title: Build AI agents with portal and VS Code
+  description: Create an AI agent using both Microsoft Foundry portal and VS Code extension with built-in tools like file search and code interpreter.
+  level: 300
+  duration: 45
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Build AI agents with portal and VS Code

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Use a custom function in an AI agent'
-    description: 'Learn how to use functions to add custom capabilities to your agents.'
-    level: 300
-    duration: 50
+  title: Use a custom function in an AI agent
+  description: Learn how to use functions to add custom capabilities to your agents.
+  level: 300
+  duration: 50
+  islab: true
 ---
 
 # Use a custom function in an AI agent

--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Extend agents with Model Context Protocol (MCP) tools'
-    description: 'Extend agent capabilities by integrating Model Context Protocol (MCP) server tools.'
-    level: 300
-    duration: 60
+  title: Extend agents with Model Context Protocol (MCP) tools
+  description: Extend agent capabilities by integrating Model Context Protocol (MCP) server tools.
+  level: 300
+  duration: 60
+  islab: true
 ---
 
 # Develop an AI agent with Model Context Protocol (MCP) tools

--- a/Instructions/Exercises/04-integrate-agent-with-foundry-iq.md
+++ b/Instructions/Exercises/04-integrate-agent-with-foundry-iq.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Integrate an AI agent with Foundry IQ'
-    description: 'Use Azure AI Agent Service to develop an agent that uses Foundry IQ to search knowledge bases.'
-    level: 300
-    duration: 45
+  title: Integrate an AI agent with Foundry IQ
+  description: Use Azure AI Agent Service to develop an agent that uses Foundry IQ to search knowledge bases.
+  level: 300
+  duration: 45
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Integrate an AI agent with Foundry IQ

--- a/Instructions/Exercises/05a-m365-teams-integration.md
+++ b/Instructions/Exercises/05a-m365-teams-integration.md
@@ -1,9 +1,14 @@
 ---
 lab:
-    title: 'Deploy agents to Microsoft Teams and Copilot'
-    description: 'Publish AI agents to Microsoft Teams and Microsoft 365 Copilot for enterprise access'
-    level: 300
-    duration: 40
+  title: Deploy agents to Microsoft Teams and Copilot
+  description: Publish AI agents to Microsoft Teams and Microsoft 365 Copilot for enterprise access
+  level: 300
+  duration: 40
+  islab: true
+  primarytopics:
+    - Microsoft 365
+    - Microsoft 365 Copilot
+    - Microsoft Teams
 ---
 
 # Deploy agents to Microsoft Teams and Copilot

--- a/Instructions/Exercises/05b-work-iq-integration.md
+++ b/Instructions/Exercises/05b-work-iq-integration.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Work IQ - Workplace intelligence for AI agents (optional)'
-    description: 'Build AI agents that access Microsoft 365 workplace data using Work IQ and the Model Context Protocol for meeting prep, project tracking, and action items.'
-    level: 300
-    duration: 40
+  title: Work IQ - Workplace intelligence for AI agents (optional)
+  description: Build AI agents that access Microsoft 365 workplace data using Work IQ and the Model Context Protocol for meeting prep, project tracking, and action items.
+  level: 300
+  duration: 40
+  islab: true
+  primarytopics:
+    - Microsoft 365
 ---
 
 # Work IQ - Workplace intelligence for AI agents

--- a/Instructions/Exercises/06-build-workflow-ms-foundry.md
+++ b/Instructions/Exercises/06-build-workflow-ms-foundry.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Build a workflow in Microsoft Foundry'
-    description: 'Use the Microsoft Foundry portal to create workflows for AI agents.'
-    level: 300
-    duration: 45
+  title: Build a workflow in Microsoft Foundry
+  description: Use the Microsoft Foundry portal to create workflows for AI agents.
+  level: 300
+  duration: 45
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Build a workflow in Microsoft Foundry

--- a/Instructions/Exercises/07-agent-framework.md
+++ b/Instructions/Exercises/07-agent-framework.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Develop an Azure AI agent with the Microsoft Agent Framework SDK'
-    description: 'Learn how to use the Microsoft Agent Framework SDK to create and use an Azure AI chat agent.'
-    level: 300
-    duration: 30
+  title: Develop an Azure AI agent with the Microsoft Agent Framework SDK
+  description: Learn how to use the Microsoft Agent Framework SDK to create and use an Azure AI chat agent.
+  level: 300
+  duration: 30
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Develop an Azure AI chat agent with the Microsoft Agent Framework SDK

--- a/Instructions/Exercises/08-agent-framework-multi-agents.md
+++ b/Instructions/Exercises/08-agent-framework-multi-agents.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Develop a multi-agent solution with Microsoft Agent Framework'
-    description: 'Learn to configure multiple agents to collaborate using the Microsoft Agent Framework SDK'
-    level: 300
-    duration: 30
+  title: Develop a multi-agent solution with Microsoft Agent Framework
+  description: Learn to configure multiple agents to collaborate using the Microsoft Agent Framework SDK
+  level: 300
+  duration: 30
+  islab: true
 ---
 
 # Develop a multi-agent solution

--- a/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
+++ b/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Connect to remote agents with A2A protocol'
-    description: 'Use the A2A protocol to collaborate with remote agents.'
-    level: 300
-    duration: 30
+  title: Connect to remote agents with A2A protocol
+  description: Use the A2A protocol to collaborate with remote agents.
+  level: 300
+  duration: 30
+  islab: true
 ---
 
 # Connect to remote agents with A2A protocol


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 21

- `Instructions/01-agent-fundamentals.md` (duration,level,islab,primarytopics)
- `Instructions/02-build-ai-agent.md` (duration,level,islab,primarytopics)
- `Instructions/03-agent-custom-functions.md` (duration,level,islab)
- `Instructions/03b-build-multi-agent-solution.md` (duration,level,islab,primarytopics)
- `Instructions/03c-use-agent-tools-with-mcp.md` (duration,level,islab)
- `Instructions/04-semantic-kernel.md` (duration,level,islab,primarytopics)
- `Instructions/05-agent-orchestration.md` (duration,level,islab)
- `Instructions/06-multi-remote-agents-with-a2a.md` (duration,level,islab)
- `Instructions/07-build-agent-in-vs-code.md` (duration,level,islab,primarytopics)
- `Instructions/08-build-workflow-ms-foundry.md` (duration,level,islab,primarytopics)
- `Instructions/09-integrate-agent-with-foundry-iq.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/01-build-agent-portal-and-vscode.md` (islab,primarytopics)
- `Instructions/Exercises/02-agent-custom-tools.md` (islab)
- `Instructions/Exercises/03-mcp-integration.md` (islab)
- `Instructions/Exercises/04-integrate-agent-with-foundry-iq.md` (islab,primarytopics)
- `Instructions/Exercises/05a-m365-teams-integration.md` (islab,primarytopics)
- `Instructions/Exercises/05b-work-iq-integration.md` (islab,primarytopics)
- `Instructions/Exercises/06-build-workflow-ms-foundry.md` (islab,primarytopics)
- `Instructions/Exercises/07-agent-framework.md` (islab,primarytopics)
- `Instructions/Exercises/08-agent-framework-multi-agents.md` (islab)
- `Instructions/Exercises/09-multi-remote-agents-with-a2a.md` (islab)
