### PR TITLE
Removed unused variable

### DIFF
--- a/Labfiles/08-build-workflow-ms-foundry/Python/workflow.py
+++ b/Labfiles/08-build-workflow-ms-foundry/Python/workflow.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 endpoint = os.environ["PROJECT_ENDPOINT"]
-model = os.environ["MODEL_DEPLOYMENT_NAME"]
 
 # Connect to the AI Project client
 


### PR DESCRIPTION
The exercise does not use the model at all, and having it in here breaks the flow

# Module: 00
## Lab/Demo: 08-build-workflow-ms-foundry

Fixes # .

Changes proposed in this pull request:

- removed unused model variable.

Since we're not setting it in the `.env` file it breaks the exercise.
