### PR TITLE
Change Python version from 3.13.12 to 3.12

### DIFF
--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -24,7 +24,7 @@ Before starting this exercise, ensure you have:
 - [Python 3.13](https://www.python.org/downloads/) or later installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 


### PR DESCRIPTION
Updated Python version compatibility note in the instructions.

## Exercises: all

Fixes #162.

Changes proposed in this pull request:

- Tested on version 3.13.12 ==> 13.12 