### PR TITLE
Fix extra_body Parameter in response creation

### DIFF
--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -327,7 +327,7 @@ Now that you've created the agent with the function tools, you can send messages
    # Retrieve the agent's response, which may include function calls
    response = openai_client.responses.create(
        conversation=conversation.id,
-       extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+       extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
        input=input_list,
    )
 

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -376,7 +376,7 @@ Now that you've created the agent with the function tools, you can send messages
        response = openai_client.responses.create(
            input=input_list,
            previous_response_id=response.id,
-           extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+           extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
        )
    # Display the agent's response
    print(f"AGENT: {response.output_text}")


### PR DESCRIPTION
The 'agent' property is deprecated. Using 'agent_reference' instead.

# Module: Develop AI Agents in Azure
## Lab/Demo: Use a custom function in an AI agent

Fixes # . 
The 'agent' property is deprecated. Using 'agent_reference' instead.
Changes proposed in this pull request:

- Updated Properties to fix errors
-
-