### PR TITLE
Update labs 02 and 03 to azure-ai-projects==2.0.0b4

### DIFF
--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -186,7 +186,7 @@ In this task, you'll connect to a remote MCP server, prepare the AI agent, and r
    response = openai_client.responses.create(
        conversation=conversation.id,
        input="Give me the Azure CLI commands to create an Azure Container App with a managed identity.",
-       extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+      extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
    )
     ```
 
@@ -220,7 +220,7 @@ In this task, you'll connect to a remote MCP server, prepare the AI agent, and r
    response = openai_client.responses.create(
        input=input_list,
        previous_response_id=response.id,
-       extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+       extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
    )
 
    print(f"\nAgent response: {response.output_text}")
@@ -477,7 +477,7 @@ In this task, you'll connect the MCP server tools to your agent so that it can c
       response = openai_client.responses.create(
             input=input_list,
             previous_response_id=response.id,
-            extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+            extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
       )
    print(f"Agent response: {response.output_text}")
     ```

--- a/Labfiles/02-agent-custom-tools/Python/requirements.txt
+++ b/Labfiles/02-agent-custom-tools/Python/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 azure-identity
-azure-ai-projects==2.0.0b3
+azure-ai-projects==2.0.0b4
 openai

--- a/Labfiles/03-mcp-integration/Python/client.py
+++ b/Labfiles/03-mcp-integration/Python/client.py
@@ -81,7 +81,7 @@ async def chat_loop(session):
             # Retrieve the agent's response, which may include function calls to the MCP server tools
             response = openai_client.responses.create(
                 conversation=conversation.id,
-                extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+                extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
                 input=input_list,
             )
 

--- a/Labfiles/03-mcp-integration/Python/requirements.txt
+++ b/Labfiles/03-mcp-integration/Python/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 azure-identity
 uvicorn
-azure-ai-projects==2.0.0b3
+azure-ai-projects==2.0.0b4
 openai
 mcp


### PR DESCRIPTION
Fixes #167

## Changes

- **`Labfiles/02-agent-custom-tools/Python/requirements.txt`**: Bump `azure-ai-projects` from `2.0.0b3` to `2.0.0b4`
- **`Labfiles/03-mcp-integration/Python/requirements.txt`**: Bump `azure-ai-projects` from `2.0.0b3` to `2.0.0b4`
- **`Labfiles/03-mcp-integration/Python/client.py`**: Fix deprecated `extra_body={"agent": ...}` to `extra_body={"agent_reference": ...}`
- **`Instructions/Exercises/03-mcp-integration.md`**: Fix all 3 code snippet occurrences of the same deprecated key

The `Instructions/Exercises/02-agent-custom-tools.md` and the `agent.py` skeleton for lab 02 already used the correct `"agent_reference"` key, so no changes were needed there beyond the package version bump.