### PR TITLE
Fix Exercise 3: Update FastMCP import to standalone package

### DIFF
--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -292,7 +292,7 @@ In addition to connecting to remote MCP servers, you can also create your own cu
 
     ```python
    # Add references
-   from mcp.server.fastmcp import FastMCP
+   from fastmcp import FastMCP
     ```
 
 1. Under the comment **Create an MCP server**, add the following code to create a new MCP server instance:

--- a/Labfiles/03-mcp-integration/Python/requirements.txt
+++ b/Labfiles/03-mcp-integration/Python/requirements.txt
@@ -4,3 +4,4 @@ uvicorn
 azure-ai-projects==2.0.0b4
 openai
 mcp
+fastmcp


### PR DESCRIPTION
## Summary

`fastmcp` is now a standalone package and no longer ships as part of `mcp`. This PR updates Exercise 3 to use the correct import path and adds `fastmcp` to `requirements.txt`.

### Changes
- **`Labfiles/03-mcp-integration/Python/requirements.txt`** — Added `fastmcp` dependency
- **`Instructions/Exercises/03-mcp-integration.md`** — Changed import from `from mcp.server.fastmcp import FastMCP` to `from fastmcp import FastMCP`

Fixes #173
Fixes #179