### PR TITLE
Remove space in function call

### DIFF
--- a/Labfiles/07-agent-framework/python/agent-framework.py
+++ b/Labfiles/07-agent-framework/python/agent-framework.py
@@ -20,7 +20,7 @@ async def main():
     user_prompt = input(f"Here is the expenses data in your file:\n\n{data}\n\nWhat would you like me to do with it?\n\n")
     
     # Run the async agent code
-    await process_expenses_data (user_prompt, data)
+    await process_expenses_data(user_prompt, data)
     
 async def process_expenses_data(prompt, expenses_data):
 


### PR DESCRIPTION
I spotted an extra space in function call of process_expenses_data on line 23 of this lab, it results in an error when running the exercise.

# Module: 02 - Develop AI Agents on Azure
## Lab/Demo: 07 - Develop an Azure AI chat agent with the Microsoft Agent Framework SDK

Changes proposed in this pull request:
- remove the space in the function call of process_expenses_data.