### PR TITLE
Fix mcp.run() to suppress banner on stdio transport

### DIFF
--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -329,10 +329,10 @@ In addition to connecting to remote MCP servers, you can also create your own cu
 
     ```python
    # Run the MCP server
-   mcp.run()
+   mcp.run(show_banner=False)
     ```
 
-    This code starts the MCP server, making your tools available for discovery and use by the agent.
+    This code starts the MCP server, making your tools available for discovery and use by the agent. Setting `show_banner=False` prevents the startup banner from being printed to stdout, which would corrupt the MCP stdio protocol.
 
 1. Save the file (*CTRL+S*).
 


### PR DESCRIPTION
## Summary

Fixes the first issue reported in #188 — the `mcp.run()` call in the MCP integration lab exercise prints a startup banner to stdout, which corrupts the MCP stdio protocol.

## Changes

Updated the exercise instructions to use `mcp.run(show_banner=False)` instead of `mcp.run()`.

## Issue #188 assessment

- **`mcp.run()` banner corrupts stdio** ✅ Valid — fixed in this PR
- **`client.py` uses wrong `agents.create()` API** ❌ Not valid — the code already correctly uses `agents.create_version()`