### PR TITLE
Rebrand Lab A to Tailwind Traders + fix multi-turn tool bug

### DIFF
--- a/Instructions/Exercises/A-build-and-extend-ai-agents.md
+++ b/Instructions/Exercises/A-build-and-extend-ai-agents.md
@@ -1,7 +1,7 @@
 ---
 lab:
     title: 'Build and extend AI agents'
-    description: 'Build the Trailhead Adventure Works assistant: ground it in store policy, then extend it with tools using remote MCP servers, custom functions, and a client app. A modular lab you can complete end to end or one task at a time.'
+    description: 'Build the Tailwind Traders assistant: ground it in store policy, then extend it with tools using remote MCP servers, custom functions, and a client app. A modular lab you can complete end to end or one task at a time.'
     level: 300
     concepts: 'agent creation and grounding, tools, Model Context Protocol (MCP)'
     duration: 35
@@ -28,7 +28,7 @@ An agent becomes genuinely useful when it can *do* things — look up live infor
 call your business logic, and act on a user's behalf. In this lab you'll build a
 grounded agent and then give it capabilities using **tools**.
 
-**Your scenario:** you work at **Trailhead Adventure Works**, an outdoor-gear retailer that
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that
 also runs guided trips. Across this lab you'll build the staff assistant that powers the
 business, adding one capability per task: first grounding it in the store's own policies,
 then connecting it to live documentation, letting it analyze sales data, take trip
@@ -91,9 +91,9 @@ including all optional tasks, takes about **1 hour 55 minutes**.
 - **Everything (~1h 55m):** add **Task 5** (the capstone builds on Task 4, so do Task 4 first).
 
 > **One assistant, growing capabilities**: Tasks 3–5 all run behind the same provided web
-> chat window (`trailhead_ui.py`) — the **Trailhead Adventure Works Assistant**. You focus only
+> chat window (`tailwind_ui.py`) — the **Tailwind Traders Assistant**. You focus only
 > on the agent code; each task gives the same assistant a new capability (analyzing sales
-> data, planning trips, and checking warehouse stock). You don't edit `trailhead_ui.py`; you
+> data, planning trips, and checking warehouse stock). You don't edit `tailwind_ui.py`; you
 > just write a `respond()` function and hand it to `run_chat_app()`.
 
 ## Two ways to build the same agent

--- a/Instructions/Exercises/A0-getting-started.md
+++ b/Instructions/Exercises/A0-getting-started.md
@@ -13,7 +13,7 @@ This page sets up everything the **Build and extend AI agents** lab needs. Compl
 **once**, then do any task — [Task 1](A1-create-and-ground-an-agent.md) through
 [Task 5](A5-capstone-build-your-own-mcp-server.md) — on its own or in order.
 
-**Your scenario:** you work at **Trailhead Adventure Works**, an outdoor-gear retailer that
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that
 also runs guided trips. Across the lab you'll build the staff assistant that powers the
 business, adding one capability per task.
 
@@ -60,7 +60,7 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
 
 1. Select **Create** and wait for your project to be created. When prompted, continue through the welcome dialog and select **Create agent**.
 
-1. Set the **Agent name** to `trailhead-agent` and create the agent. The playground opens with a deployed model already selected for you.
+1. Set the **Agent name** to `tailwind-agent` and create the agent. The playground opens with a deployed model already selected for you.
 
 Keep this browser tab open — you'll use it in Task 1.
 

--- a/Instructions/Exercises/A1-create-and-ground-an-agent.md
+++ b/Instructions/Exercises/A1-create-and-ground-an-agent.md
@@ -1,7 +1,7 @@
 ---
 lab:
     title: 'Task 1 – Create and ground an agent'
-    description: 'Create an agent in the Microsoft Foundry portal and ground it in Trailhead Adventure Works store policy so it answers from your data.'
+    description: 'Create an agent in the Microsoft Foundry portal and ground it in Tailwind Traders store policy so it answers from your data.'
     level: 300
     concepts: 'agent creation, grounding, file search'
     islab: true
@@ -25,7 +25,7 @@ guessing.
 1. In the agent playground, set the **Instructions** to:
 
     ```prompt
-    You are the Trailhead Adventure Works store assistant.
+    You are the Tailwind Traders store assistant.
     You help customers and store staff with questions about products, orders, returns, rentals, and guided trips.
 
     Guidelines:

--- a/Instructions/Exercises/A2-connect-a-remote-mcp-server.md
+++ b/Instructions/Exercises/A2-connect-a-remote-mcp-server.md
@@ -25,7 +25,7 @@ lab:
 ---
 
 The **Model Context Protocol (MCP)** lets an agent discover and call tools hosted by a
-server. Behind the scenes, the Trailhead Adventure Works platform team is rebuilding the
+server. Behind the scenes, the Tailwind Traders platform team is rebuilding the
 online store on Azure — so in this task you'll connect an agent to the **Microsoft Learn
 Docs** remote MCP server, giving the team an assistant that can pull trusted, up-to-date
 Azure documentation on demand.
@@ -78,7 +78,7 @@ Open **remote_mcp_agent.py** and add code at each commented placeholder.
         agent_name="platform-docs-agent",
         definition=PromptAgentDefinition(
             model=model_deployment,
-            instructions="You are a platform engineering assistant for Trailhead Adventure Works. Use the available MCP tools to look up trusted Azure documentation and help the team build and operate the online store.",
+            instructions="You are a platform engineering assistant for Tailwind Traders. Use the available MCP tools to look up trusted Azure documentation and help the team build and operate the online store.",
             tools=[mcp_tool],
         ),
     )

--- a/Instructions/Exercises/A3-call-your-agent-from-a-client-app.md
+++ b/Instructions/Exercises/A3-call-your-agent-from-a-client-app.md
@@ -23,7 +23,7 @@ lab:
 > python setup/bootstrap_agent.py
 > ```
 >
-> That creates and grounds `trailhead-agent` — including the **Code Interpreter** tool with the
+> That creates and grounds `tailwind-agent` — including the **Code Interpreter** tool with the
 > sales data already attached — and writes `AGENT_NAME` into your `.env`. If you used it, you can
 > skip the portal "Set up" step below that adds Code Interpreter. Then verify you're ready:
 >
@@ -39,12 +39,12 @@ the playground — including charts the agent produces (from code interpreter), 
 
 **Concept reinforced**: consuming an agent programmatically with the Foundry SDK — loading
 an existing agent by name and driving it with the Responses API. A provided UI shell
-(`trailhead_ui.py`) turns your agent into a browser chat app, so you focus on the agent code,
+(`tailwind_ui.py`) turns your agent into a browser chat app, so you focus on the agent code,
 not the interface.
 
 **Set up:**
 
-1. In the portal, open your `trailhead-agent`, add a **Code interpreter** tool, and upload
+1. In the portal, open your `tailwind-agent`, add a **Code interpreter** tool, and upload
     a data file so there's something to analyze. Download and attach:
 
     ```
@@ -55,7 +55,7 @@ not the interface.
 
 1. Use the same `Labfiles/A-build-and-extend-ai-agents/Python` folder and virtual environment
     you set up in [Getting started](A0-getting-started.md) (if you closed the terminal, reactivate with
-    `.\labenv\Scripts\Activate.ps1`). Then open **.env** and add `AGENT_NAME=trailhead-agent`
+    `.\labenv\Scripts\Activate.ps1`). Then open **.env** and add `AGENT_NAME=tailwind-agent`
     alongside the `PROJECT_ENDPOINT` you already set. Save the file.
 
 > **Try it first**: The `agent_with_functions.py` file already contains a complete client
@@ -92,7 +92,7 @@ The provided `agent_with_functions.py` already implements the client and hands i
 4. **Launch the app**: the file ends by starting the browser chat window:
 
     ```python
-    run_chat_app(respond, title="Trailhead Adventure Works Assistant")
+    run_chat_app(respond, title="Tailwind Traders Assistant")
     ```
 
 Sign in and run it:

--- a/Instructions/Exercises/A4-add-custom-function-tools.md
+++ b/Instructions/Exercises/A4-add-custom-function-tools.md
@@ -81,7 +81,7 @@ same pattern as Task 2). The file is structured so your agent setup runs once, t
         agent_name="trip-planner-agent",
         definition=PromptAgentDefinition(
             model=model_deployment,
-            instructions="""You are a trip planning assistant for Trailhead Adventure Works that helps
+            instructions="""You are a trip planning assistant for Tailwind Traders that helps
                 customers find guided trips and calculate gear rental costs.
                 Use the available tools to assist users with their inquiries.""",
             tools=[trip_tool, cost_tool, report_tool],
@@ -113,14 +113,17 @@ same pattern as Task 2). The file is structured so your agent setup runs once, t
     ```
 
     The rest of `respond()` (already provided) sends the outputs back and returns the final
-    answer to the chat window:
+    answer to the chat window. Note that it attaches the outputs to the same **conversation**
+    so the tool calls are resolved in conversation state — sending them back with
+    `previous_response_id` instead would make the *next* message fail with *"No tool output
+    found for function call"*:
 
     ```python
     # Send function call outputs back to the model and retrieve a response
     if input_list:
         response = openai_client.responses.create(
+            conversation=conversation.id,
             input=input_list,
-            previous_response_id=response.id,
             extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
         )
 
@@ -185,7 +188,7 @@ agent = Agent(
         credential=AzureCliCredential(),
     ),
     name="trip-planner-agent",
-    instructions="You are a trip planning assistant for Trailhead Adventure Works...",
+    instructions="You are a trip planning assistant for Tailwind Traders...",
     tools=[next_available_trip, calculate_rental_cost, generate_booking_report],
 )
 

--- a/Instructions/Exercises/A5-capstone-build-your-own-mcp-server.md
+++ b/Instructions/Exercises/A5-capstone-build-your-own-mcp-server.md
@@ -1,7 +1,7 @@
 ---
 lab:
     title: 'Task 5 – Capstone: build your own MCP server'
-    description: 'Capstone: build your own MCP server and combine it with your function tools into one Trailhead Adventure Works assistant.'
+    description: 'Capstone: build your own MCP server and combine it with your function tools into one Tailwind Traders assistant.'
     level: 300
     concepts: 'MCP server, tool orchestration, Microsoft Agent Framework'
     islab: true
@@ -27,7 +27,7 @@ lab:
 ---
 
 **Goal**: Host your **own** tools on an MCP server, then bring the lab together into a single
-**Trailhead Adventure Works Assistant** — one agent that both **plans trips and prices gear**
+**Tailwind Traders Assistant** — one agent that both **plans trips and prices gear**
 (the function tools from Task 4) *and* **checks live warehouse stock and sales** (the tools
 you host here).
 
@@ -126,11 +126,11 @@ the first message.
 
     ```python
     agent = project_client.agents.create_version(
-        agent_name="trailhead-assistant",
+        agent_name="tailwind-assistant",
         definition=PromptAgentDefinition(
             model=model_deployment,
             instructions="""
-            You are the Trailhead Adventure Works assistant. You help customers plan guided
+            You are the Tailwind Traders assistant. You help customers plan guided
             trips and price gear rentals, and you help warehouse staff check live stock and sales.
 
             Trip planning and rentals:
@@ -210,8 +210,8 @@ from agent_framework import tool, Agent, MCPStdioTool
 
 agent = Agent(
     client=FoundryChatClient(...),
-    name="trailhead-assistant",
-    instructions="You are the Trailhead Adventure Works assistant...",
+    name="tailwind-assistant",
+    instructions="You are the Tailwind Traders assistant...",
     tools=[next_available_trip, calculate_rental_cost, generate_booking_report],
 )
 

--- a/Labfiles/A-build-and-extend-ai-agents/Python/.env.example
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/.env.example
@@ -10,4 +10,4 @@ PROJECT_ENDPOINT=your_project_endpoint_here
 MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here
 
 # The portal agent name you create in Task 1 — used by Task 3
-AGENT_NAME=trailhead-agent
+AGENT_NAME=tailwind-agent

--- a/Labfiles/A-build-and-extend-ai-agents/Python/Store_Policy.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/Store_Policy.txt
@@ -1,4 +1,4 @@
-TRAILHEAD ADVENTURE WORKS
+TAILWIND TRADERS
 CUSTOMER SERVICE & STORE POLICY
 
 Effective Date: January 2026
@@ -11,7 +11,7 @@ Version: 2.0
 We want you to be confident in your gear. Most items can be returned within 60 days of purchase.
 
 Process:
-1. Start a return in your account at https://returns.trailheadadventureworks.com or in any store
+1. Start a return in your account at https://returns.tailwindtraders.com or in any store
 2. Items must be unused, with original tags and packaging
 3. Bring your order number or receipt
 4. Refunds are issued to the original payment method within 5-7 business days
@@ -59,7 +59,7 @@ Damage and Loss:
 3. GUIDED TRIPS AND BOOKINGS
 ====================
 
-Trailhead Adventure Works runs guided trips across the world's great ranges.
+Tailwind Traders runs guided trips across the world's great ranges.
 
 Booking:
 - Reserve a spot online or with a store trip specialist
@@ -94,7 +94,7 @@ Shipping Options:
 
 Order Tracking:
 - Tracking is emailed when your order ships
-- Track any order at https://orders.trailheadadventureworks.com
+- Track any order at https://orders.tailwindtraders.com
 - In-store pickup is usually ready within 2 hours
 
 Delivery Issues:
@@ -109,9 +109,9 @@ Manufacturer Warranty:
 - Most brands we carry cover defects in materials and workmanship
 - Warranty length varies by brand; check the product page or ask a specialist
 
-Trailhead Guarantee:
-- Trailhead-brand gear is guaranteed against defects for the life of the product
-- We will repair, replace, or refund defective Trailhead-brand items
+Tailwind Guarantee:
+- Tailwind-brand gear is guaranteed against defects for the life of the product
+- We will repair, replace, or refund defective Tailwind-brand items
 
 Repairs:
 - We offer in-store repair for zippers, straps, and tent poles
@@ -123,7 +123,7 @@ Repairs:
 ====================
 
 Trailblazer Rewards:
-- Free to join at https://rewards.trailheadadventureworks.com
+- Free to join at https://rewards.tailwindtraders.com
 - Earn 1 point per dollar; 100 points = $5 in trail credit
 - Members get early access to sales and free standard shipping
 
@@ -142,8 +142,8 @@ Store Hours:
 
 Contact Methods:
 - Phone: +1-800-555-TRAIL (87245)
-- Email: support@trailheadadventureworks.com
-- Portal: https://support.trailheadadventureworks.com
+- Email: support@tailwindtraders.com
+- Portal: https://support.tailwindtraders.com
 - Chat: Available on our website and mobile app
 
 Response Times:

--- a/Labfiles/A-build-and-extend-ai-agents/Python/agent_with_functions.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/agent_with_functions.py
@@ -7,7 +7,7 @@ from azure.identity import DefaultAzureCredential
 from dotenv import load_dotenv
 
 # The shared chat UI shell (provided – you don't edit this file)
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 
 OUTPUT_DIR = Path("agent_outputs")
@@ -94,7 +94,7 @@ def format_output_text(content_item, openai_client, downloaded_files):
 # Initialize the project client
 load_dotenv()
 project_endpoint = os.environ.get("PROJECT_ENDPOINT")
-agent_name = os.environ.get("AGENT_NAME", "trailhead-agent")
+agent_name = os.environ.get("AGENT_NAME", "tailwind-agent")
 
 if not project_endpoint:
     raise SystemExit(
@@ -175,6 +175,6 @@ def respond(user_message):
 # Launch the browser chat window (replaces the old console loop)
 run_chat_app(
     respond,
-    title="Trailhead Adventure Works Assistant",
+    title="Tailwind Traders Assistant",
     subtitle="Ask about store policy or request an analysis of the weekly sales data.",
 )

--- a/Labfiles/A-build-and-extend-ai-agents/Python/client.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/client.py
@@ -7,7 +7,7 @@ from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import PromptAgentDefinition, FunctionTool
 from azure.identity import DefaultAzureCredential
 from openai.types.responses.response_input_param import FunctionCallOutput, ResponseInputParam
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Add references
 
@@ -153,11 +153,14 @@ async def respond(user_message):
     # Process function calls — route each one: local Python function or MCP server tool
 
 
-    # Send function call outputs back to the model and retrieve a response
+    # Send function call outputs back to the model and retrieve a response.
+    # Attach them to the same conversation so the tool calls are resolved in
+    # conversation state — otherwise the next turn fails with "No tool output
+    # found for function call".
     if input_list:
         response = openai_client.responses.create(
+            conversation=conversation.id,
             input=input_list,
-            previous_response_id=response.id,
             extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
         )
 
@@ -168,7 +171,7 @@ if __name__ == "__main__":
     try:
         run_chat_app(
             respond,
-            title="Trailhead Adventure Works Assistant",
+            title="Tailwind Traders Assistant",
             subtitle="Plan trips, price gear, and check warehouse stock",
         )
     finally:
@@ -176,4 +179,4 @@ if __name__ == "__main__":
         if agent is not None:
             print("Cleaning up agents:")
             project_client.agents.delete_version(agent_name=agent.name, agent_version=agent.version)
-            print("Deleted Trailhead assistant.")
+            print("Deleted Tailwind assistant.")

--- a/Labfiles/A-build-and-extend-ai-agents/Python/client_maf.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/client_maf.py
@@ -33,7 +33,7 @@ from pydantic import Field
 # The Task 4 trip-planner logic, reused so the capstone agent can plan trips AND
 # check the warehouse (the tools your MCP server hosts).
 import functions
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Load environment variables from .env file
 load_dotenv()
@@ -99,9 +99,9 @@ async def setup():
     # The agent holds the local trip-planner tools; the MCP tools are supplied per run.
     agent = Agent(
         client=client,
-        name="trailhead-assistant",
+        name="tailwind-assistant",
         instructions="""
-        You are the Trailhead Adventure Works assistant. You help customers plan guided
+        You are the Tailwind Traders assistant. You help customers plan guided
         trips and price gear rentals, and you help warehouse staff check live stock and sales.
 
         Trip planning and rentals:
@@ -132,6 +132,6 @@ async def respond(user_message):
 if __name__ == "__main__":
     run_chat_app(
         respond,
-        title="Trailhead Adventure Works Assistant",
+        title="Tailwind Traders Assistant",
         subtitle="Plan trips, price gear, and check warehouse stock (Microsoft Agent Framework edition)",
     )

--- a/Labfiles/A-build-and-extend-ai-agents/Python/functions.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/functions.py
@@ -103,7 +103,7 @@ def generate_booking_report(trip_name: str, region: str, gear_tier: str, days: f
     filename = f"report_{trip_name.replace(' ', '_').lower()}_{timestamp.replace(':', '').replace(' ', '_')}.txt"
 
     report = f"""======================================
-  TRAILHEAD ADVENTURE WORKS - BOOKING REPORT
+  TAILWIND TRADERS - BOOKING REPORT
 ======================================
 Date:           {timestamp}
 Customer:       {customer_name}

--- a/Labfiles/A-build-and-extend-ai-agents/Python/functions_agent.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/functions_agent.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Import the local functions the agent can call, and the shared chat UI
 from functions import next_available_trip, calculate_rental_cost, generate_booking_report
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Load environment variables from .env file
 load_dotenv()
@@ -58,11 +58,14 @@ with (
         # Process function calls
 
 
-        # Send function call outputs back to the model and retrieve a response
+        # Send function call outputs back to the model and retrieve a response.
+        # Attach them to the same conversation so the tool calls are resolved in
+        # conversation state — otherwise the next turn fails with "No tool output
+        # found for function call".
         if input_list:
             response = openai_client.responses.create(
+                conversation=conversation.id,
                 input=input_list,
-                previous_response_id=response.id,
                 extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
             )
 
@@ -73,7 +76,7 @@ with (
     try:
         run_chat_app(
             respond,
-            title="Trailhead Adventure Works Assistant",
+            title="Tailwind Traders Assistant",
             subtitle="Plan a guided trip and price your gear rental.",
         )
     finally:

--- a/Labfiles/A-build-and-extend-ai-agents/Python/functions_agent_maf.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/functions_agent_maf.py
@@ -30,7 +30,7 @@ from pydantic import Field
 
 # Reuse the same trip-planner logic from Task 4, plus the shared chat UI
 import functions
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Load environment variables from .env file
 load_dotenv()
@@ -80,7 +80,7 @@ client = FoundryChatClient(
 agent = Agent(
     client=client,
     name="trip-planner-agent",
-    instructions="""You are a trip planning assistant for Trailhead Adventure Works that helps
+    instructions="""You are a trip planning assistant for Tailwind Traders that helps
         customers find guided trips and calculate gear rental costs.
         Use the available tools to assist users with their inquiries.""",
     tools=[next_available_trip, calculate_rental_cost, generate_booking_report],
@@ -101,6 +101,6 @@ async def respond(user_message):
 if __name__ == "__main__":
     run_chat_app(
         respond,
-        title="Trailhead Adventure Works Assistant",
+        title="Tailwind Traders Assistant",
         subtitle="Plan a guided trip and price your gear rental. (Microsoft Agent Framework edition)",
     )

--- a/Labfiles/A-build-and-extend-ai-agents/Python/tailwind_ui.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/tailwind_ui.py
@@ -1,5 +1,5 @@
 """
-Trailhead Adventure Works – shared chat UI shell (provided).
+Tailwind Traders – shared chat UI shell (provided).
 
 You don't need to edit this file. It gives every task in the lab the same simple
 web chat window so your agent feels like a real app instead of a console script.
@@ -26,7 +26,7 @@ class AgentReply:
 
 def run_chat_app(
     respond: Callable,
-    title: str = "Trailhead Adventure Works Assistant",
+    title: str = "Tailwind Traders Assistant",
     subtitle: str = "",
     placeholder: str = "Ask the assistant...",
     server_port: int = 7860,

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/.env.example
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/.env.example
@@ -10,4 +10,4 @@ PROJECT_ENDPOINT=your_project_endpoint_here
 MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here
 
 # The portal agent name you create in Task 1 — used by Task 3
-AGENT_NAME=trailhead-agent
+AGENT_NAME=tailwind-agent

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/Store_Policy.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/Store_Policy.txt
@@ -1,4 +1,4 @@
-TRAILHEAD ADVENTURE WORKS
+TAILWIND TRADERS
 CUSTOMER SERVICE & STORE POLICY
 
 Effective Date: January 2026
@@ -11,7 +11,7 @@ Version: 2.0
 We want you to be confident in your gear. Most items can be returned within 60 days of purchase.
 
 Process:
-1. Start a return in your account at https://returns.trailheadadventureworks.com or in any store
+1. Start a return in your account at https://returns.tailwindtraders.com or in any store
 2. Items must be unused, with original tags and packaging
 3. Bring your order number or receipt
 4. Refunds are issued to the original payment method within 5-7 business days
@@ -59,7 +59,7 @@ Damage and Loss:
 3. GUIDED TRIPS AND BOOKINGS
 ====================
 
-Trailhead Adventure Works runs guided trips across the world's great ranges.
+Tailwind Traders runs guided trips across the world's great ranges.
 
 Booking:
 - Reserve a spot online or with a store trip specialist
@@ -94,7 +94,7 @@ Shipping Options:
 
 Order Tracking:
 - Tracking is emailed when your order ships
-- Track any order at https://orders.trailheadadventureworks.com
+- Track any order at https://orders.tailwindtraders.com
 - In-store pickup is usually ready within 2 hours
 
 Delivery Issues:
@@ -109,9 +109,9 @@ Manufacturer Warranty:
 - Most brands we carry cover defects in materials and workmanship
 - Warranty length varies by brand; check the product page or ask a specialist
 
-Trailhead Guarantee:
-- Trailhead-brand gear is guaranteed against defects for the life of the product
-- We will repair, replace, or refund defective Trailhead-brand items
+Tailwind Guarantee:
+- Tailwind-brand gear is guaranteed against defects for the life of the product
+- We will repair, replace, or refund defective Tailwind-brand items
 
 Repairs:
 - We offer in-store repair for zippers, straps, and tent poles
@@ -123,7 +123,7 @@ Repairs:
 ====================
 
 Trailblazer Rewards:
-- Free to join at https://rewards.trailheadadventureworks.com
+- Free to join at https://rewards.tailwindtraders.com
 - Earn 1 point per dollar; 100 points = $5 in trail credit
 - Members get early access to sales and free standard shipping
 
@@ -142,8 +142,8 @@ Store Hours:
 
 Contact Methods:
 - Phone: +1-800-555-TRAIL (87245)
-- Email: support@trailheadadventureworks.com
-- Portal: https://support.trailheadadventureworks.com
+- Email: support@tailwindtraders.com
+- Portal: https://support.tailwindtraders.com
 - Chat: Available on our website and mobile app
 
 Response Times:

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/agent_with_functions.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/agent_with_functions.py
@@ -7,7 +7,7 @@ from azure.identity import DefaultAzureCredential
 from dotenv import load_dotenv
 
 # The shared chat UI shell (provided – you don't edit this file)
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 
 OUTPUT_DIR = Path("agent_outputs")
@@ -94,7 +94,7 @@ def format_output_text(content_item, openai_client, downloaded_files):
 # Initialize the project client
 load_dotenv()
 project_endpoint = os.environ.get("PROJECT_ENDPOINT")
-agent_name = os.environ.get("AGENT_NAME", "trailhead-agent")
+agent_name = os.environ.get("AGENT_NAME", "tailwind-agent")
 
 if not project_endpoint:
     raise SystemExit(
@@ -175,6 +175,6 @@ def respond(user_message):
 # Launch the browser chat window (replaces the old console loop)
 run_chat_app(
     respond,
-    title="Trailhead Adventure Works Assistant",
+    title="Tailwind Traders Assistant",
     subtitle="Ask about store policy or request an analysis of the weekly sales data.",
 )

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/client.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/client.py
@@ -7,7 +7,7 @@ from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import PromptAgentDefinition, FunctionTool
 from azure.identity import DefaultAzureCredential
 from openai.types.responses.response_input_param import FunctionCallOutput, ResponseInputParam
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Add references
 from mcp import ClientSession, StdioServerParameters
@@ -147,11 +147,11 @@ async def setup():
 
     # Create the capstone agent with BOTH tool sets: trip planning + warehouse tools
     agent = project_client.agents.create_version(
-        agent_name="trailhead-assistant",
+        agent_name="tailwind-assistant",
         definition=PromptAgentDefinition(
             model=model_deployment,
             instructions="""
-            You are the Trailhead Adventure Works assistant. You help customers plan guided
+            You are the Tailwind Traders assistant. You help customers plan guided
             trips and price gear rentals, and you help warehouse staff check live stock and sales.
 
             Trip planning and rentals:
@@ -213,11 +213,14 @@ async def respond(user_message):
                 )
             )
 
-    # Send function call outputs back to the model and retrieve a response
+    # Send function call outputs back to the model and retrieve a response.
+    # Attach them to the same conversation so the tool calls are resolved in
+    # conversation state — otherwise the next turn fails with "No tool output
+    # found for function call".
     if input_list:
         response = openai_client.responses.create(
+            conversation=conversation.id,
             input=input_list,
-            previous_response_id=response.id,
             extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
         )
 
@@ -228,7 +231,7 @@ if __name__ == "__main__":
     try:
         run_chat_app(
             respond,
-            title="Trailhead Adventure Works Assistant",
+            title="Tailwind Traders Assistant",
             subtitle="Plan trips, price gear, and check warehouse stock",
         )
     finally:
@@ -236,4 +239,4 @@ if __name__ == "__main__":
         if agent is not None:
             print("Cleaning up agents:")
             project_client.agents.delete_version(agent_name=agent.name, agent_version=agent.version)
-            print("Deleted Trailhead assistant.")
+            print("Deleted Tailwind assistant.")

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/client_maf.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/client_maf.py
@@ -33,7 +33,7 @@ from pydantic import Field
 # The Task 4 trip-planner logic, reused so the capstone agent can plan trips AND
 # check the warehouse (the tools your MCP server hosts).
 import functions
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Load environment variables from .env file
 load_dotenv()
@@ -99,9 +99,9 @@ async def setup():
     # The agent holds the local trip-planner tools; the MCP tools are supplied per run.
     agent = Agent(
         client=client,
-        name="trailhead-assistant",
+        name="tailwind-assistant",
         instructions="""
-        You are the Trailhead Adventure Works assistant. You help customers plan guided
+        You are the Tailwind Traders assistant. You help customers plan guided
         trips and price gear rentals, and you help warehouse staff check live stock and sales.
 
         Trip planning and rentals:
@@ -132,6 +132,6 @@ async def respond(user_message):
 if __name__ == "__main__":
     run_chat_app(
         respond,
-        title="Trailhead Adventure Works Assistant",
+        title="Tailwind Traders Assistant",
         subtitle="Plan trips, price gear, and check warehouse stock (Microsoft Agent Framework edition)",
     )

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/functions.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/functions.py
@@ -103,7 +103,7 @@ def generate_booking_report(trip_name: str, region: str, gear_tier: str, days: f
     filename = f"report_{trip_name.replace(' ', '_').lower()}_{timestamp.replace(':', '').replace(' ', '_')}.txt"
 
     report = f"""======================================
-  TRAILHEAD ADVENTURE WORKS - BOOKING REPORT
+  TAILWIND TRADERS - BOOKING REPORT
 ======================================
 Date:           {timestamp}
 Customer:       {customer_name}

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/functions_agent.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/functions_agent.py
@@ -10,7 +10,7 @@ from openai.types.responses.response_input_param import FunctionCallOutput
 
 # Import the local functions the agent can call, and the shared chat UI
 from functions import next_available_trip, calculate_rental_cost, generate_booking_report
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Load environment variables from .env file
 load_dotenv()
@@ -111,7 +111,7 @@ with (
         agent_name="trip-planner-agent",
         definition=PromptAgentDefinition(
             model=model_deployment,
-            instructions="""You are a trip planning assistant for Trailhead Adventure Works that helps
+            instructions="""You are a trip planning assistant for Tailwind Traders that helps
                 customers find guided trips and calculate gear rental costs.
                 Use the available tools to assist users with their inquiries.""",
             tools=[trip_tool, cost_tool, report_tool],
@@ -159,11 +159,14 @@ with (
                     )
                 )
 
-        # Send function call outputs back to the model and retrieve a response
+        # Send function call outputs back to the model and retrieve a response.
+        # Attach them to the same conversation so the tool calls are resolved in
+        # conversation state — otherwise the next turn fails with "No tool output
+        # found for function call".
         if input_list:
             response = openai_client.responses.create(
+                conversation=conversation.id,
                 input=input_list,
-                previous_response_id=response.id,
                 extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
             )
 
@@ -174,7 +177,7 @@ with (
     try:
         run_chat_app(
             respond,
-            title="Trailhead Adventure Works Assistant",
+            title="Tailwind Traders Assistant",
             subtitle="Plan a guided trip and price your gear rental.",
         )
     finally:

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/functions_agent_maf.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/functions_agent_maf.py
@@ -30,7 +30,7 @@ from pydantic import Field
 
 # Reuse the same trip-planner logic from Task 4, plus the shared chat UI
 import functions
-from trailhead_ui import run_chat_app, AgentReply
+from tailwind_ui import run_chat_app, AgentReply
 
 # Load environment variables from .env file
 load_dotenv()
@@ -80,7 +80,7 @@ client = FoundryChatClient(
 agent = Agent(
     client=client,
     name="trip-planner-agent",
-    instructions="""You are a trip planning assistant for Trailhead Adventure Works that helps
+    instructions="""You are a trip planning assistant for Tailwind Traders that helps
         customers find guided trips and calculate gear rental costs.
         Use the available tools to assist users with their inquiries.""",
     tools=[next_available_trip, calculate_rental_cost, generate_booking_report],
@@ -101,6 +101,6 @@ async def respond(user_message):
 if __name__ == "__main__":
     run_chat_app(
         respond,
-        title="Trailhead Adventure Works Assistant",
+        title="Tailwind Traders Assistant",
         subtitle="Plan a guided trip and price your gear rental. (Microsoft Agent Framework edition)",
     )

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/remote_mcp_agent.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/remote_mcp_agent.py
@@ -31,7 +31,7 @@ with (
         agent_name="platform-docs-agent",
         definition=PromptAgentDefinition(
             model=model_deployment,
-            instructions="You are a platform engineering assistant for Trailhead Adventure Works. Use the available MCP tools to look up trusted Azure documentation and help the team build and operate the online store.",
+            instructions="You are a platform engineering assistant for Tailwind Traders. Use the available MCP tools to look up trusted Azure documentation and help the team build and operate the online store.",
             tools=[mcp_tool],
         ),
     )

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/tailwind_ui.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/tailwind_ui.py
@@ -1,5 +1,5 @@
 """
-Trailhead Adventure Works – shared chat UI shell (provided).
+Tailwind Traders – shared chat UI shell (provided).
 
 You don't need to edit this file. It gives every task in the lab the same simple
 web chat window so your agent feels like a real app instead of a console script.
@@ -26,7 +26,7 @@ class AgentReply:
 
 def run_chat_app(
     respond: Callable,
-    title: str = "Trailhead Adventure Works Assistant",
+    title: str = "Tailwind Traders Assistant",
     subtitle: str = "",
     placeholder: str = "Ask the assistant...",
     server_port: int = 7860,

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/README.md
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/README.md
@@ -18,7 +18,7 @@ Solution/
    ├─ server.py               # Task 5 — your MCP server (inventory + sales tools)
    ├─ client.py               # Task 5 — capstone: MCP client that combines Task 4 + Task 5 tools
    ├─ client_maf.py           #   Task 5 — same capstone, Microsoft Agent Framework edition
-   ├─ trailhead_ui.py         # shared Gradio chat shell (provided; not edited by learners)
+   ├─ tailwind_ui.py         # shared Gradio chat shell (provided; not edited by learners)
    ├─ Store_Policy.txt        # Task 1 grounding doc (uploaded to the portal agent)
    ├─ weekly_sales.csv        # Task 3 code-interpreter data (uploaded to the portal agent)
    └─ data/                   #   Task 4 lookup data (trips, rental rates, service multipliers)
@@ -26,7 +26,7 @@ Solution/
 
 Because everything lives in one folder, the two `agent.py` files from the source labs were
 renamed to avoid a collision: **`remote_mcp_agent.py`** (Task 2) and **`functions_agent.py`**
-(Task 4). `trailhead_ui.py` (the shared Gradio chat shell) appears once and is **not**
+(Task 4). `tailwind_ui.py` (the shared Gradio chat shell) appears once and is **not**
 something learners edit.
 
 ---
@@ -43,7 +43,7 @@ This lab can be completed end to end **or one task at a time**. Two things make 
 - **Setup scripts** in `Labfiles/A-build-and-extend-ai-agents/setup/`:
   - `check_env.py --task N` — preflight-checks that `.env` has the keys task *N* needs.
   - `bootstrap_agent.py` — **fast-forwards Task 1 in code**: creates and grounds
-    `trailhead-agent` (File Search on `Store_Policy.txt` + Code Interpreter on `weekly_sales.csv`)
+    `tailwind-agent` (File Search on `Store_Policy.txt` + Code Interpreter on `weekly_sales.csv`)
     and writes `AGENT_NAME` to `.env`, so learners can start at **Task 3** without the portal.
     Idempotent; pass `--force` to recreate.
 
@@ -89,17 +89,17 @@ traceback prints in the terminal**.
 
 ### 3. Create the portal agent (Task 1 — required for Task 3)
 The Task 3 client loads an agent **by name** that you create in the portal:
-1. In the Foundry portal, create an agent named **`trailhead-agent`**.
+1. In the Foundry portal, create an agent named **`tailwind-agent`**.
 2. Ground it: upload **`Store_Policy.txt`** (from `Python/`) and give it instructions to
    answer from store policy.
 3. For Task 3's chart demo, add the **Code interpreter** tool and upload **`weekly_sales.csv`**
    (from the same folder). Save the agent.
 
-> Tasks 4 and 5 create their own agents in code (`trip-planner-agent`, `trailhead-assistant`)
+> Tasks 4 and 5 create their own agents in code (`trip-planner-agent`, `tailwind-assistant`)
 > and delete them on exit — no portal work needed for those.
 
 > **Shortcut**: instead of the portal steps above, run `python setup/bootstrap_agent.py` from
-> the `Python/` folder to create and ground `trailhead-agent` in code and write `AGENT_NAME`.
+> the `Python/` folder to create and ground `tailwind-agent` in code and write `AGENT_NAME`.
 
 ### 4. Set up the environment once (shared by all tasks)
 From the `Python/` folder:
@@ -111,7 +111,7 @@ pip install -r requirements.txt
 Then copy `.env.example` to `.env` and fill in the values (all tasks read the same file):
 - `PROJECT_ENDPOINT` — used by every task
 - `MODEL_DEPLOYMENT_NAME` — used by Tasks 2, 4, and 5
-- `AGENT_NAME=trailhead-agent` — used by Task 3
+- `AGENT_NAME=tailwind-agent` — used by Task 3
 
 ### 5. Run each task
 All commands run from the single `Python/` folder:

--- a/Labfiles/A-build-and-extend-ai-agents/azure.yaml
+++ b/Labfiles/A-build-and-extend-ai-agents/azure.yaml
@@ -1,4 +1,4 @@
-# azd configuration for the Trailhead Adventure Works lab (OPTIONAL infra path).
+# azd configuration for the Tailwind Traders lab (OPTIONAL infra path).
 #
 # This is a convenience for learners/instructors who want to provision the
 # Foundry project + model deployment with a single command instead of creating
@@ -20,7 +20,7 @@
 # After provisioning, the postprovision hook writes PROJECT_ENDPOINT and
 # MODEL_DEPLOYMENT_NAME into Python/.env for you.
 
-name: trailhead-adventure-works-lab
+name: tailwind-traders-lab
 metadata:
   template: mslearn-ai-agents/A-build-and-extend-ai-agents
 

--- a/Labfiles/A-build-and-extend-ai-agents/infra/main.bicep
+++ b/Labfiles/A-build-and-extend-ai-agents/infra/main.bicep
@@ -1,4 +1,4 @@
-// Optional azd infrastructure for the Trailhead Adventure Works lab.
+// Optional azd infrastructure for the Tailwind Traders lab.
 //
 // Provisions a Microsoft Foundry (Azure AI Services) resource, a Foundry
 // project, and one chat model deployment — the same resources you would

--- a/Labfiles/A-build-and-extend-ai-agents/setup/bootstrap_agent.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/bootstrap_agent.py
@@ -1,5 +1,5 @@
 """
-Fast-forward setup for the Trailhead Adventure Works lab.
+Fast-forward setup for the Tailwind Traders lab.
 
 Task 3 needs the grounded agent you would normally build by hand in Task 1
 (and extend at the start of Task 3). If you're starting at Task 3 on its own,
@@ -9,10 +9,10 @@ run this once to create that agent for you:
 
 It reproduces, in code, exactly what Tasks 1 and 3 have you do in the portal:
 
-  * creates an agent named 'trailhead-agent'
+  * creates an agent named 'tailwind-agent'
   * grounds it on Store_Policy.txt with the File Search tool
   * adds the Code Interpreter tool with weekly_sales.csv attached
-  * writes AGENT_NAME=trailhead-agent into Python/.env
+  * writes AGENT_NAME=tailwind-agent into Python/.env
 
 Prerequisites: PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME set in Python/.env
 (run 'azd up', or fill them in from the portal), and 'az login' completed.
@@ -38,10 +38,10 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from dotenv import load_dotenv
 
-AGENT_NAME = "trailhead-agent"
+AGENT_NAME = "tailwind-agent"
 
 # The same instructions Task 1 has you paste into the portal.
-INSTRUCTIONS = """You are the Trailhead Adventure Works store assistant.
+INSTRUCTIONS = """You are the Tailwind Traders store assistant.
 You help customers and store staff with questions about products, orders, returns, rentals, and guided trips.
 
 Guidelines:
@@ -76,7 +76,7 @@ def build_vector_store(openai_client, file_id):
     """Create a vector store for File Search and wait until it's indexed."""
     print("  Creating vector store for Store_Policy.txt ...")
     vector_store = openai_client.vector_stores.create(
-        name="trailhead-store-policy",
+        name="tailwind-store-policy",
         file_ids=[file_id],
     )
 
@@ -117,7 +117,7 @@ def set_env_value(key, value):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Create and ground the trailhead-agent for Task 3."
+        description="Create and ground the tailwind-agent for Task 3."
     )
     parser.add_argument(
         "--force",

--- a/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
@@ -1,5 +1,5 @@
 """
-Preflight check for the Trailhead Adventure Works lab.
+Preflight check for the Tailwind Traders lab.
 
 Each task in this lab can be completed on its own. Before you start a task,
 run this script to confirm your .env file has everything that task needs:
@@ -57,7 +57,7 @@ FIX_HINTS = {
     ),
     "AGENT_NAME": (
         "Task 3 needs the grounded portal agent from Task 1. Either complete Task 1 in "
-        "the portal and set AGENT_NAME=trailhead-agent, or fast-forward past Task 1 by "
+        "the portal and set AGENT_NAME=tailwind-agent, or fast-forward past Task 1 by "
         "running: python setup/bootstrap_agent.py"
     ),
 }


### PR DESCRIPTION
## Summary

Two changes to the **Build and extend AI agents** (Lab A) lab:

### 1. Rebrand the scenario: Trailhead Adventure Works → **Tailwind Traders**
Renames the fictitious company consistently across the whole lab:
- Instruction pages (`A-build-and-extend-ai-agents.md` landing + `A0`–`A5`)
- Starter and Solution code
- The shared chat UI file: `trailhead_ui.py` → `tailwind_ui.py` (and all imports)
- Agent / vector-store names (`trailhead-agent` → `tailwind-agent`, `trailhead-assistant` → `tailwind-assistant`, `trailhead-store-policy` → `tailwind-store-policy`)
- azd config (`azure.yaml`, `infra/main.bicep`) and store-policy data (domains/emails)

No remaining `trailhead` references anywhere in the lab.

### 2. Fix a multi-turn tool bug in the web-app tasks (Task 4 + Task 5 capstone)
Function-call outputs were sent back with `previous_response_id` instead of being attached to the `conversation`, so the **second** user message failed with:

> `No tool output found for function call ...`

Fixed by attaching the outputs to the same conversation in the starter and Solution `client.py` / `functions_agent.py`, and updated the A4 instruction snippet to match (Task 2's single-turn console loop correctly keeps `previous_response_id`).

## Validation
Ran the capstone live end to end against Foundry (venv + `az login`): both tool paths work across a **multi-turn** conversation — warehouse MCP tools (restock/clearance analysis) and trip-planner functions (`$1,875` rental, the known-good value). All solution + starter files compile.

## Notes
- The azd infra path remains bicep-validated only (not deployment-tested).