### PR TITLE
Reframe Lab A tasks as standalone-by-default with skip-ahead notes

### DIFF
--- a/Instructions/Exercises/A-build-and-extend-ai-agents.md
+++ b/Instructions/Exercises/A-build-and-extend-ai-agents.md
@@ -60,15 +60,17 @@ The **Optional** tasks let you additionally:
 
 ## How this lab is organized
 
-This lab is **modular**. Every task shares one starter folder, one virtual environment, and
-one `.env`, so you can work through it end to end **or complete any single task on its own**.
+This lab is **modular**. Each task is written to be completed **on its own, starting fresh** —
+so you can pick a single task and do just that one. Every task also shares one starter folder,
+one virtual environment, and one `.env`, so if you'd rather work straight through, you can.
 
 1. **Start with [Getting started](A0-getting-started.md)** — create your Microsoft Foundry
    project (in the portal or with one `azd up` command), get the starter code, and set up
-   your `.env`. You only do this once.
-2. **Do any task below.** Each task page opens with a *"Starting here on its own?"* callout
-   that tells you exactly what it needs and how to fast-forward past earlier tasks (for
-   example, a script that creates the grounded agent for you), so you can jump straight in.
+   your `.env`. Every task begins from here; if you're doing the whole lab in one sitting, you
+   only need to do this once.
+2. **Do any task.** Each task lists the setup it needs so you can start it independently. If
+   you're moving straight from the previous task, a short *"Continuing from a previous task?"*
+   note at the top lets you skip the repeated setup and keep going.
 
 ## Lab at a glance
 

--- a/Instructions/Exercises/A0-getting-started.md
+++ b/Instructions/Exercises/A0-getting-started.md
@@ -9,9 +9,9 @@ lab:
 
 # Getting started
 
-This page sets up everything the **Build and extend AI agents** lab needs. Complete it
-**once**, then do any task — [Task 1](A1-create-and-ground-an-agent.md) through
-[Task 5](A5-capstone-build-your-own-mcp-server.md) — on its own or in order.
+This page sets up everything the **Build and extend AI agents** lab needs. **Every task begins
+here** — complete this page first. Each task is written so you can then do it on its own; if
+you're working through the whole lab in one sitting, you only need to do this setup once.
 
 **Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that
 also runs guided trips. Across the lab you'll build the staff assistant that powers the

--- a/Instructions/Exercises/A1-create-and-ground-an-agent.md
+++ b/Instructions/Exercises/A1-create-and-ground-an-agent.md
@@ -12,10 +12,10 @@ lab:
 
 *Part of the **Build and extend AI agents** lab. New here? Start with [Getting started](A0-getting-started.md).*
 
-> **Starting here on its own?** You need a Microsoft Foundry project with a deployed model.
-> If you don't have one yet, complete [Getting started](A0-getting-started.md) first
-> (Option A creates it in the portal). Task 1 is completed entirely in the portal — no local
-> code or `.env` file is required.
+> **What you need:** a **Microsoft Foundry project with a deployed model**. Don't have one
+> yet? Complete [Getting started](A0-getting-started.md) first (Option A creates it in the
+> portal). This task is completed entirely in the portal — no local code or `.env` file is
+> required, so there's nothing to carry over from other tasks.
 
 ---
 

--- a/Instructions/Exercises/A2-connect-a-remote-mcp-server.md
+++ b/Instructions/Exercises/A2-connect-a-remote-mcp-server.md
@@ -12,15 +12,18 @@ lab:
 
 *Part of the **Build and extend AI agents** lab. New here? Start with [Getting started](A0-getting-started.md).*
 
-> **Starting here on its own?** First complete [Getting started](A0-getting-started.md) to
-> create your Foundry project, clone the starter code, and set up your `.env`.
->
-> **This task needs** `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. From the
-> `Labfiles/A-build-and-extend-ai-agents` folder, verify you're ready:
+> **Set up (start here):** This task needs a Foundry project and the starter code. If you
+> haven't already, complete [Getting started](A0-getting-started.md) to create your project,
+> clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
+> Then, from the `Labfiles/A-build-and-extend-ai-agents` folder, verify you're ready:
 >
 > ```
 > python setup/check_env.py --task 2
 > ```
+>
+> > **Continuing from a previous task?** If you just finished an earlier task in the same
+> > `Python` folder, your project, virtual environment, and `.env` are already set — go
+> > straight to **Connect the agent to the MCP server** below.
 
 ---
 
@@ -30,7 +33,7 @@ online store on Azure — so in this task you'll connect an agent to the **Micro
 Docs** remote MCP server, giving the team an assistant that can pull trusted, up-to-date
 Azure documentation on demand.
 
-Open the shared `Python` folder and virtual environment you created in [Getting started](A0-getting-started.md), then continue below.
+Open the `Python` folder and activate the virtual environment from [Getting started](A0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
 
 ### Connect the agent to the MCP server
 

--- a/Instructions/Exercises/A3-call-your-agent-from-a-client-app.md
+++ b/Instructions/Exercises/A3-call-your-agent-from-a-client-app.md
@@ -12,24 +12,27 @@ lab:
 
 *Part of the **Build and extend AI agents** lab. New here? Start with [Getting started](A0-getting-started.md).*
 
-> **Starting here on its own?** First complete [Getting started](A0-getting-started.md) to set
-> up your Foundry project and `.env`.
+> **Set up (start here):** This task needs a Foundry project and the starter code. If you
+> haven't already, complete [Getting started](A0-getting-started.md) to create your project,
+> clone the code, and set `PROJECT_ENDPOINT` in `Python/.env`.
 >
-> Task 3 drives the **grounded agent** you build in [Task 1](A1-create-and-ground-an-agent.md).
-> If you didn't do Task 1, create that agent in code with one command (from the
-> `Labfiles/A-build-and-extend-ai-agents` folder):
+> This task drives a **grounded agent**. The quickest way to get one is to create it in code —
+> from the `Labfiles/A-build-and-extend-ai-agents` folder, run:
 >
 > ```
 > python setup/bootstrap_agent.py
 > ```
 >
 > That creates and grounds `tailwind-agent` — including the **Code Interpreter** tool with the
-> sales data already attached — and writes `AGENT_NAME` into your `.env`. If you used it, you can
-> skip the portal "Set up" step below that adds Code Interpreter. Then verify you're ready:
+> sales data already attached — and writes `AGENT_NAME` into your `.env`. Then verify you're ready:
 >
 > ```
 > python setup/check_env.py --task 3
 > ```
+>
+> > **Already built the agent in [Task 1](A1-create-and-ground-an-agent.md)?** Use it instead
+> > of the script: open your `tailwind-agent` in the portal, add the **Code interpreter** tool
+> > with the sales data (step 1 below), and set `AGENT_NAME=tailwind-agent` in `.env`.
 
 ---
 
@@ -44,6 +47,12 @@ not the interface.
 
 **Set up:**
 
+If you ran `python setup/bootstrap_agent.py` above, your agent, its **Code Interpreter** tool,
+and `AGENT_NAME` are already configured — activate your virtual environment
+(`.\labenv\Scripts\Activate.ps1`) and skip to **Try it first**.
+
+**If you built the agent yourself in Task 1**, finish wiring it up:
+
 1. In the portal, open your `tailwind-agent`, add a **Code interpreter** tool, and upload
     a data file so there's something to analyze. Download and attach:
 
@@ -53,10 +62,9 @@ not the interface.
 
     Save the agent.
 
-1. Use the same `Labfiles/A-build-and-extend-ai-agents/Python` folder and virtual environment
-    you set up in [Getting started](A0-getting-started.md) (if you closed the terminal, reactivate with
-    `.\labenv\Scripts\Activate.ps1`). Then open **.env** and add `AGENT_NAME=tailwind-agent`
-    alongside the `PROJECT_ENDPOINT` you already set. Save the file.
+1. In the `Labfiles/A-build-and-extend-ai-agents/Python` folder, activate the virtual
+    environment (`.\labenv\Scripts\Activate.ps1`). Then open **.env** and add
+    `AGENT_NAME=tailwind-agent` alongside the `PROJECT_ENDPOINT` you already set. Save the file.
 
 > **Try it first**: The `agent_with_functions.py` file already contains a complete client
 > that launches a web chat window. Before running it, predict: which SDK call loads your

--- a/Instructions/Exercises/A4-add-custom-function-tools.md
+++ b/Instructions/Exercises/A4-add-custom-function-tools.md
@@ -12,15 +12,18 @@ lab:
 
 *Part of the **Build and extend AI agents** lab. New here? Start with [Getting started](A0-getting-started.md).*
 
-> **Starting here on its own?** First complete [Getting started](A0-getting-started.md) to
-> create your Foundry project, clone the starter code, and set up your `.env`.
->
-> **This task needs** `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. The helper
-> file `functions.py` is already in the starter folder. Verify you're ready:
+> **Set up (start here):** This task needs a Foundry project and the starter code. If you
+> haven't already, complete [Getting started](A0-getting-started.md) to create your project,
+> clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. The
+> helper file `functions.py` is already in the starter folder. Then verify you're ready:
 >
 > ```
 > python setup/check_env.py --task 4
 > ```
+>
+> > **Continuing from a previous task?** If you just finished an earlier task in the same
+> > `Python` folder, your project, virtual environment, and `.env` are already set — go
+> > straight to reviewing **functions.py** in **Set up** below.
 
 ---
 
@@ -32,10 +35,10 @@ call and with *what* arguments; your code executes it and returns the result.
 
 **Set up:**
 
-1. Use the same `Labfiles/A-build-and-extend-ai-agents/Python` folder and virtual environment
-    you set up in [Getting started](A0-getting-started.md) (reactivate with `.\labenv\Scripts\Activate.ps1` if needed); your
-    `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in **.env** are already set. Review
-    **functions.py**, which contains the trip planner's helper functions.
+1. In the `Labfiles/A-build-and-extend-ai-agents/Python` folder, activate the virtual
+    environment (`.\labenv\Scripts\Activate.ps1`) and confirm `PROJECT_ENDPOINT` and
+    `MODEL_DEPLOYMENT_NAME` are set in **.env** (see [Getting started](A0-getting-started.md)).
+    Then review **functions.py**, which contains the trip planner's helper functions.
 
 > **Try it first**: Look at `next_available_trip(region)` in **functions.py**. How would
 > you describe its single `region` parameter to the model so it knows when and how to

--- a/Instructions/Exercises/A5-capstone-build-your-own-mcp-server.md
+++ b/Instructions/Exercises/A5-capstone-build-your-own-mcp-server.md
@@ -12,17 +12,19 @@ lab:
 
 *Part of the **Build and extend AI agents** lab. New here? Start with [Getting started](A0-getting-started.md).*
 
-> **Starting here on its own?** This is the **capstone**. First complete
-> [Getting started](A0-getting-started.md) to create your Foundry project, clone the starter
-> code, and set up your `.env`.
->
-> **This task needs** `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. It reuses
-> `functions.py` from [Task 4](A4-add-custom-function-tools.md) — already in the starter folder,
-> so you don't need to have finished Task 4. Verify you're ready:
+> **Set up (start here):** This is the **capstone**. It needs a Foundry project and the
+> starter code. If you haven't already, complete [Getting started](A0-getting-started.md) to
+> create your project, clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`
+> in `Python/.env`. It reuses `functions.py` from [Task 4](A4-add-custom-function-tools.md) —
+> already in the starter folder, so you don't need to have finished Task 4. Then verify:
 >
 > ```
 > python setup/check_env.py --task 5
 > ```
+>
+> > **Continuing from a previous task?** If you just finished an earlier task in the same
+> > `Python` folder, your project, virtual environment, and `.env` are already set — go
+> > straight to **Set up** below to start editing `server.py` and `client.py`.
 
 ---
 
@@ -36,16 +38,18 @@ you host here).
 once. In `respond()` you *route* each call to the right place: local Python functions run
 in-process, MCP tools run over the server session.
 
-> **Prerequisite**: This capstone builds directly on **Task 4** — complete it first. The
-> trip-planner tools you wrote there (`next_available_trip`, `calculate_rental_cost`,
-> `generate_booking_report`) are provided ready-made in `client.py` so you can focus on the
-> new work: hosting your MCP server and *combining* both tool sets on one agent.
+> **How this builds on Task 4**: This capstone *combines* the trip-planner tools from Task 4
+> with a new MCP server. You don't need to have finished Task 4 — those tools
+> (`next_available_trip`, `calculate_rental_cost`, `generate_booking_report`) are provided
+> ready-made in `client.py` — so you can focus on the new work: hosting your MCP server and
+> *combining* both tool sets on one agent. (Already did Task 4? Even better — you'll recognize them.)
 
 **Set up:**
 
-1. Use the same `Labfiles/A-build-and-extend-ai-agents/Python` folder and virtual environment
-    you set up in [Getting started](A0-getting-started.md) (reactivate with `.\labenv\Scripts\Activate.ps1` if needed; your
-    **.env** is already configured). You'll edit **server.py** and **client.py**.
+1. In the `Labfiles/A-build-and-extend-ai-agents/Python` folder, activate the virtual
+    environment (`.\labenv\Scripts\Activate.ps1`) and confirm your **.env** has
+    `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` (see [Getting started](A0-getting-started.md)).
+    You'll edit **server.py** and **client.py**.
 
 > **Try it first**: Wire up **server.py** and **client.py** using the comments in each file.
 > As you go, consider: why must diagnostic output go to `stderr` (or be suppressed) rather

--- a/Labfiles/A-build-and-extend-ai-agents/Python/tailwind_ui.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/tailwind_ui.py
@@ -51,7 +51,7 @@ def run_chat_app(
 
         return history, ""
 
-    with gr.Blocks(title=title, css="footer {visibility: hidden}") as demo:
+    with gr.Blocks(title=title) as demo:
         gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
         if subtitle:
             gr.Markdown(subtitle)
@@ -65,4 +65,4 @@ def run_chat_app(
         for trigger in (textbox.submit, send.click):
             trigger(handle, [textbox, chatbot], [chatbot, textbox])
 
-    demo.launch(server_port=server_port, inbrowser=True, show_api=False, theme=gr.themes.Soft())
+    demo.launch(server_port=server_port, inbrowser=True, css="footer {visibility: hidden}", theme=gr.themes.Soft())

--- a/Labfiles/A-build-and-extend-ai-agents/Python/tailwind_ui.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/tailwind_ui.py
@@ -51,7 +51,7 @@ def run_chat_app(
 
         return history, ""
 
-    with gr.Blocks(title=title) as demo:
+    with gr.Blocks(title=title, css="footer {visibility: hidden}") as demo:
         gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
         if subtitle:
             gr.Markdown(subtitle)
@@ -65,4 +65,4 @@ def run_chat_app(
         for trigger in (textbox.submit, send.click):
             trigger(handle, [textbox, chatbot], [chatbot, textbox])
 
-    demo.launch(server_port=server_port, inbrowser=True, theme=gr.themes.Soft())
+    demo.launch(server_port=server_port, inbrowser=True, show_api=False, theme=gr.themes.Soft())

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/tailwind_ui.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/tailwind_ui.py
@@ -51,7 +51,7 @@ def run_chat_app(
 
         return history, ""
 
-    with gr.Blocks(title=title, css="footer {visibility: hidden}") as demo:
+    with gr.Blocks(title=title) as demo:
         gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
         if subtitle:
             gr.Markdown(subtitle)
@@ -65,4 +65,4 @@ def run_chat_app(
         for trigger in (textbox.submit, send.click):
             trigger(handle, [textbox, chatbot], [chatbot, textbox])
 
-    demo.launch(server_port=server_port, inbrowser=True, show_api=False, theme=gr.themes.Soft())
+    demo.launch(server_port=server_port, inbrowser=True, css="footer {visibility: hidden}", theme=gr.themes.Soft())

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/tailwind_ui.py
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/tailwind_ui.py
@@ -51,7 +51,7 @@ def run_chat_app(
 
         return history, ""
 
-    with gr.Blocks(title=title) as demo:
+    with gr.Blocks(title=title, css="footer {visibility: hidden}") as demo:
         gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
         if subtitle:
             gr.Markdown(subtitle)
@@ -65,4 +65,4 @@ def run_chat_app(
         for trigger in (textbox.submit, send.click):
             trigger(handle, [textbox, chatbot], [chatbot, textbox])
 
-    demo.launch(server_port=server_port, inbrowser=True, theme=gr.themes.Soft())
+    demo.launch(server_port=server_port, inbrowser=True, show_api=False, theme=gr.themes.Soft())


### PR DESCRIPTION
## Summary

A framing tweak based on lab feedback: make each task read as though the learner is **starting fresh** (doing that one task on its own), and add a short **"Continuing from a previous task?"** skip-ahead note so someone working straight through can bypass the repeated setup.

This is a **wording/structure change only** — no code, solutions, or setup scripts are touched.

## What changed

- **Landing page + Getting started (A0):** state the standalone-first assumption up front; the one-time environment setup is only repeated if you're doing the whole lab in one sitting.
- **A1 (portal, no code):** reframed to a plain prerequisite ("what you need") since there's nothing to carry over from other tasks.
- **A2 / A4 / A5:** each **Set up** section is now self-contained (points to Getting started for the one-time bits), with a nested *"Continuing from a previous task?"* note that jumps straight to the first work section.
- **A3 (notable reorder):** `python setup/bootstrap_agent.py` is now the **default** way to get the grounded agent; the portal steps become the *"already built the agent in Task 1?"* alternative.
- **A5:** softened the hard "complete Task 4 first" prerequisite — the Task 4 tools are provided ready-made in `client.py`, so the capstone can be done on its own.

## Callout wording

Standardized on **"Continuing from a previous task?"** for the skip-ahead note (and an *"Already built the agent in Task 1?"* variant on A3).

## Base
Targets `consolidate-labs-idea`. Left open for your review.