### PR TITLE
Add consolidated Labs B, C, and D (Tailwind Traders scenario)

### DIFF
--- a/Instructions/Exercises/B-integrate-agents-with-enterprise-knowledge-and-m365.md
+++ b/Instructions/Exercises/B-integrate-agents-with-enterprise-knowledge-and-m365.md
@@ -1,0 +1,149 @@
+---
+lab:
+    title: 'Integrate agents with enterprise knowledge and Microsoft 365'
+    description: 'Build the Tailwind Traders staff knowledge assistant: ground it on enterprise documents with Foundry IQ, then deliver it through Microsoft Teams, Microsoft 365 Copilot, and Work IQ. A modular lab you can complete end to end or one task at a time.'
+    level: 300
+    concepts: 'enterprise knowledge grounding, Foundry IQ, Microsoft 365, Model Context Protocol (MCP)'
+    duration: 35
+    islab: true
+    status: 'draft'
+---
+
+<!--
+PILOT NOTE (remove before publishing):
+This is a pilot of the new lab template (Core + Optional tasks) applied to
+"Lab B" = a consolidation of the current exercises 04, 05a, and 05b.
+Starter code lives in a single folder — Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/ —
+shared by every code task (one virtual environment, one .env). The completed reference code is
+in Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/.
+
+This landing page is the lab overview. Setup lives in B0-getting-started.md and each task is
+its own page (B1–B4) so it can be completed on its own. Optional per-task fast-forward and
+provisioning scripts live in Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/ and infra/.
+-->
+
+# Integrate agents with enterprise knowledge and Microsoft 365
+
+An agent becomes genuinely useful to a business when it answers from the company's *own*
+knowledge and shows up where employees already work. In this lab you'll build a **grounded
+enterprise-knowledge agent** and then **deliver it through Microsoft 365**.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is enterprise knowledge grounding?</summary>
+<div class="concept-body" markdown="1">
+
+Grounding an agent on **enterprise knowledge** means connecting it to your organization's own
+documents — policies, catalogs, procedures — so it answers from that trusted material instead of
+guessing. **Foundry IQ** does this at scale: it indexes a knowledge base and performs *agentic
+retrieval*, and it can require an **approval** step before each lookup so your app stays in control.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-foundry/)
+
+</div>
+</details>
+
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that also runs
+guided trips. Store staff constantly field questions about products, store operations, returns,
+rentals, and suppliers — and the answers all live in internal documents. In this lab you'll build
+the **Tailwind Traders staff knowledge assistant**: first grounding it on those enterprise docs
+with Foundry IQ, then publishing it to Microsoft Teams and Microsoft 365 Copilot so staff can use
+it where they already work, and finally exploring **Work IQ** to bring live Microsoft 365 signals
+into an agent.
+
+You'll start with the **Core** task that gets you to a working, grounded enterprise-knowledge
+agent. From there, a set of **Optional** tasks lets you deliver and extend it.
+
+> **Note**: Some of the technologies used in this exercise are in preview or in active
+> development. You may experience some unexpected behavior, warnings, or errors.
+
+## What you'll learn
+
+By completing the **Core** task of this exercise, you'll be able to:
+
+- **Create and ground an enterprise-knowledge agent** with **Foundry IQ** in the Microsoft
+  Foundry portal, and require **approval** before it searches the knowledge base.
+- **Connect to the agent from code** and handle the knowledge-tool approval flow yourself.
+
+The **Optional** tasks let you additionally:
+
+- **Publish the agent to Microsoft Teams** so staff can chat with it in Teams.
+- **Publish the agent to Microsoft 365 Copilot** as a Copilot agent.
+- **Bring Microsoft 365 workplace signals into an agent with Work IQ** over MCP.
+
+## How this lab is organized
+
+This lab is **modular**. Each task is written to be completed **on its own, starting fresh** —
+so you can pick a single task and do just that one. Every code task also shares one starter
+folder, one virtual environment, and one `.env`, so if you'd rather work straight through, you can.
+
+1. **Start with [Getting started](B0-getting-started.md)** — create your Microsoft Foundry
+   project (in the portal or with one `azd up` command), get the starter code, and set up
+   your `.env`. Every task begins from here; if you're doing the whole lab in one sitting, you
+   only need to do this once.
+2. **Do any task.** Each task lists the setup it needs so you can start it independently. If
+   you're moving straight from the previous task, a short *"Continuing from a previous task?"*
+   note at the top lets you skip the repeated setup and keep going.
+
+## Lab at a glance
+
+Complete the **Core** task first (about **35 minutes**) — it ends with a working, grounded
+enterprise-knowledge agent you can call from code. Then expand any **Optional** tasks that
+interest you. The full lab, including all optional tasks, takes about **1 hour 50 minutes**.
+
+| Section | Task | Difficulty | Time |
+| --- | --- | --- | --- |
+| **Core** | [Task 1 – Create a Foundry IQ knowledge agent and connect from code](B1-create-a-foundry-iq-knowledge-agent.md) | ★★☆ | ~35 min |
+| *Optional* | [Task 2 – Publish your agent to Microsoft Teams](B2-publish-to-microsoft-teams.md) | ★☆☆ | ~20 min |
+| *Optional* | [Task 3 – Publish your agent to Microsoft 365 Copilot](B3-publish-to-microsoft-365-copilot.md) | ★☆☆ | ~15 min |
+| *Optional* | [Task 4 – Work IQ: bring Microsoft 365 signals into an agent](B4-work-iq-workplace-intelligence.md) | ★★★ | ~40 min |
+
+**Choosing your path** — pick the tasks that fit the time you have:
+
+- **Core only (~35 min):** do Task 1.
+- **Core + delivery (~1h 10m):** also do **Task 2** and **Task 3** to publish the agent to M365.
+- **Everything (~1h 50m):** add **Task 4** (Work IQ) for live workplace intelligence.
+
+> **One assistant, delivered everywhere**: Tasks 1–3 all revolve around the **same** grounded
+> agent (`tailwind-knowledge-agent`). You build and ground it once (Task 1), then Tasks 2 and 3
+> simply *publish* that same agent to Teams and Copilot — no new code. Task 4 explores a
+> different Microsoft 365 capability (Work IQ) with its own agent.
+
+## Summary
+
+Across this lab you:
+
+- Created and **grounded** an enterprise-knowledge agent with **Foundry IQ** in the Foundry
+  portal, requiring approval before each knowledge lookup.
+- **Connected to the agent from code** and handled the approval flow yourself.
+- (Optionally) **published** the agent to **Microsoft Teams** and **Microsoft 365 Copilot**, and
+  explored **Work IQ** to bring live Microsoft 365 signals into an agent.
+
+Together these show how to take an agent from a grounded knowledge base all the way to the
+Microsoft 365 surfaces your organization uses every day.
+
+## Clean up
+
+If you're finished, delete the resources you created to avoid unnecessary Azure costs.
+
+1. In the [Azure portal](https://portal.azure.com), navigate to the resource group that contains your Foundry and Azure AI Search resources.
+1. On the toolbar, select **Delete resource group**, enter the resource group name, and confirm.
+
+> The code you run in Task 4 already deletes the agent version it creates. Portal agents are
+> removed when you delete the resource group. If you provisioned with `azd`, run `azd down`
+> instead to remove everything it created.

--- a/Instructions/Exercises/B0-getting-started.md
+++ b/Instructions/Exercises/B0-getting-started.md
@@ -1,0 +1,132 @@
+---
+lab:
+    title: 'Getting started: set up your environment'
+    description: 'Shared setup for the Integrate agents with enterprise knowledge and Microsoft 365 lab: create a Microsoft Foundry project, get the starter code, and configure your environment. Complete this once before any task.'
+    level: 300
+    concepts: 'environment setup, Microsoft Foundry project'
+    status: 'draft'
+---
+
+# Getting started
+
+This page sets up everything the **Integrate agents with enterprise knowledge and Microsoft 365**
+lab needs. **Every task begins here** — complete this page first. Each task is written so you can
+then do it on its own; if you're working through the whole lab in one sitting, you only need to do
+this setup once.
+
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that also runs
+guided trips. Across the lab you'll build the staff knowledge assistant, ground it on enterprise
+documents, and deliver it through Microsoft 365.
+
+> **Note**: Some of the technologies used in this lab are in preview or in active
+> development. You may experience some unexpected behavior, warnings, or errors.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
+- [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
+- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Git](https://git-scm.com/downloads) installed on your local machine
+- Basic familiarity with Python
+
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+
+Some optional tasks have extra prerequisites (a Microsoft 365 account for Teams, a Microsoft 365
+Copilot license and Node.js for Work IQ). Each optional task page lists what it needs.
+
+## Create a Microsoft Foundry project
+
+You need a Foundry project and a deployed model for every code task. You can create these
+in the portal (the default), or provision them with one command using the Azure Developer
+CLI (`azd`).
+
+### Option A — Create the project in the portal (default)
+
+Microsoft Foundry uses projects to organize models, resources, data, and other assets.
+
+1. In a web browser, open the [Foundry portal](https://ai.azure.com) at `https://ai.azure.com` and sign in using your Azure credentials. Close any tips or quick start panes, and if necessary use the **Foundry** logo at the top left to navigate to the home page.
+
+    > **Important**: For this lab, you're using the **New** Foundry experience.
+
+1. In the top banner, select **Start building**.
+
+1. When prompted, create a **new** project and enter a valid name (for example, `tailwind-knowledge-project`).
+
+1. Expand **Advanced options** and specify:
+    - **Microsoft Foundry resource**: *A valid name for your Foundry resource*
+    - **Region**: *Select one available near you*\*
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *Select or create a resource group*
+
+    > \* Some Azure AI resources are constrained by regional model quotas. If you hit a quota limit later, you may need to create another resource in a different region.
+
+1. Select **Create** and wait for your project to be created. When prompted, continue through the welcome dialog and select **Create agent**.
+
+1. Set the **Agent name** to `tailwind-knowledge-agent` and create the agent. The playground opens with a deployed model already selected for you.
+
+Keep this browser tab open — you'll use it in Task 1.
+
+### Option B — Provision with azd (optional, one command)
+
+If you'd rather not click through the portal, the lab ships an optional `azd` template that
+creates the Foundry resource, a project, and a model deployment for you.
+
+1. Install the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd).
+
+1. From the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365` folder, run:
+
+    ```
+    azd auth login
+    azd up
+    ```
+
+1. Answer the prompts (environment name, region). When it finishes, `azd` writes
+    `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` into `Python/.env` for you.
+
+    > **Note**: This provisions the resources but does **not** create the grounded knowledge
+    > agent — Task 1 does that in the portal. If you want a grounded agent in code instead, run
+    > `python setup/bootstrap_agent.py` after `azd up`. When you're done with the lab, run
+    > `azd down` to delete everything it created.
+
+## Get the starter code
+
+1. In VS Code, open the Command Palette (**Ctrl+Shift+P**), run **Git: Clone**, and enter:
+
+    ```
+    https://github.com/MicrosoftLearning/mslearn-ai-agents.git
+    ```
+
+1. Open the cloned repo, then **File > Open Folder** and select `mslearn-ai-agents/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python`. This single folder holds the starter code for the code tasks in this lab — you use one virtual environment and one `.env` throughout.
+
+1. Right-click **requirements.txt** and choose **Open in Integrated Terminal**. Then create a virtual environment and install packages:
+
+    ```
+    python -m venv labenv
+    .\labenv\Scripts\Activate.ps1
+    pip install -r requirements.txt
+    ```
+
+1. Copy **.env.example** to **.env**, then set `PROJECT_ENDPOINT` to your project endpoint and `MODEL_DEPLOYMENT_NAME` to your model deployment name. Save the file. (If you used `azd up`, these are already filled in.)
+
+    > **Tip**: In the Foundry Toolkit VS Code extension, right-click your project deployment and select **Copy Project Endpoint** to get the endpoint URL.
+
+## Check you're ready for a task
+
+Each task needs specific values in your `.env`. Before starting a task, run the preflight
+check from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365` folder — it reads
+your `.env` and tells you what (if anything) is missing:
+
+```
+python setup/check_env.py --task 1
+```
+
+Swap `1` for the task number you're about to start. That's it — head to any task:
+
+| Task | Page |
+| --- | --- |
+| Task 1 – Create a Foundry IQ knowledge agent and connect from code | [B1](B1-create-a-foundry-iq-knowledge-agent.md) |
+| Task 2 – Publish your agent to Microsoft Teams | [B2](B2-publish-to-microsoft-teams.md) |
+| Task 3 – Publish your agent to Microsoft 365 Copilot | [B3](B3-publish-to-microsoft-365-copilot.md) |
+| Task 4 – Work IQ: bring Microsoft 365 signals into an agent | [B4](B4-work-iq-workplace-intelligence.md) |

--- a/Instructions/Exercises/B1-create-a-foundry-iq-knowledge-agent.md
+++ b/Instructions/Exercises/B1-create-a-foundry-iq-knowledge-agent.md
@@ -1,0 +1,408 @@
+---
+lab:
+    title: 'Task 1 – Create a Foundry IQ knowledge agent and connect from code'
+    description: 'Create an enterprise-knowledge agent in the Microsoft Foundry portal, ground it on the Tailwind Traders knowledge base with Foundry IQ, require approval before knowledge lookups, then connect from code and handle the approval flow.'
+    level: 300
+    concepts: 'Foundry IQ, enterprise knowledge grounding, tool approvals, conversations API'
+    islab: true
+    status: 'draft'
+---
+
+# Task 1 — Create a Foundry IQ knowledge agent and connect from code
+
+*Part of the **Integrate agents with enterprise knowledge and Microsoft 365** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Foundry project (with a deployed model) and the
+> starter code. If you haven't already, complete [Getting started](B0-getting-started.md) to
+> create your project, clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`
+> in `Python/.env`. Then, from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365`
+> folder, verify you're ready:
+
+```
+python setup/check_env.py --task 1
+```
+
+> **Continuing from a previous task?** If your project, virtual environment, and `.env` are
+> already set, you can skip the setup and go straight to **Create an agent** below.
+
+---
+
+You'll build the **Tailwind Traders staff knowledge assistant**: an agent grounded on the
+company's internal documents (store operations, product catalog, returns and rentals, suppliers)
+using **Foundry IQ**, then connect to it from a Python app that controls each knowledge lookup with
+an approval step.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is Foundry IQ?</summary>
+<div class="concept-body" markdown="1">
+
+**Foundry IQ** connects an agent to a **knowledge base** — a searchable index built from your
+own documents backed by Azure AI Search. When the agent needs facts, it performs *agentic
+retrieval* against that knowledge base and cites what it finds. You can require **approval**
+before each lookup so your application reviews and controls every knowledge-base access.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-foundry/)
+
+</div>
+</details>
+
+## Create an agent
+
+If you created the `tailwind-knowledge-agent` during Getting started, open it now
+(**Build** → **Agents** → **tailwind-knowledge-agent**) and skip to **Configure your data and
+Foundry IQ**. Otherwise:
+
+1. On the home page, select the **Build** tab, then on the **Agents** tab select **Create agent**.
+1. Create your agent with the name `tailwind-knowledge-agent`.
+
+When creating an agent, it deploys the default model (like `gpt-5`). Once your agent is created, you'll see the agent playground with that default model automatically selected for you.
+
+## Configure your data and Foundry IQ
+
+Now you'll configure your agent to use Foundry IQ to search the Tailwind Traders knowledge base.
+
+1. First, give your agent the following instructions:
+
+    ```
+    You are the Tailwind Traders staff knowledge assistant, specializing in our outdoor-gear
+    products, store operations, returns and rentals, and suppliers. You must ALWAYS search the
+    knowledge base to answer questions about our products, policies, or procedures. Provide
+    detailed, accurate information and always cite your sources.
+    If you don't find relevant information in the knowledge base, say so clearly.
+    ```
+
+1. Select **Save** to save your current agent configuration.
+1. Then, in the **Knowledge** section, expand the **Add** dropdown, and select **Connect to Foundry IQ**.
+1. In the Foundry IQ setup window, select **Connect to an AI Search resource** and then **Create new resource** which should open up a dialog to create the resource.
+1. Create a search resource with the default settings:
+    - **Resource name**: *A globally unique name*
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *Use the same resource group as your project*
+    - **Region**: *The same location as your project*
+    - **Pricing tier**: Free *if available, otherwise choose Basic*
+
+Now you'll upload the Tailwind Traders knowledge documents to connect to with Foundry IQ.
+
+1. Download the sample knowledge documents. These are the Markdown files in the starter code under `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/`:
+    - `tailwind-store-operations.md`
+    - `tailwind-tents-catalog.md`
+    - `tailwind-backpacks-guide.md`
+    - `tailwind-camping-accessories.md`
+    - `tailwind-returns-and-rentals-policy.md`
+    - `tailwind-supplier-guide.md`
+
+    > **Tip**: You already have these locally from Getting started. If you'd rather download them directly, browse to the `data` folder in the [repository](https://github.com/MicrosoftLearning/mslearn-ai-agents/tree/main/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data) and save each file.
+
+1. Open a new tab and navigate to the Azure portal at `https://portal.azure.com`. In the top search bar, search for **Storage accounts** and select **Storage accounts** from the services section.
+1. Create a storage account with the following settings:
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *Use the same resource group as your project*
+    - **Storage account name**: *A unique storage account name*
+    - **Region**: *The same location as your project*
+    - **Primary service**: *Azure Blob Storage or Azure Data Lake Storage*
+    - **Performance**: *Standard*
+    - **Redundancy**: *Locally-redundant storage (LRS)*
+1. Once created, go to the storage account you created and select **Upload** from the top bar.
+1. In the **Upload blob** blade, create a new container named `tailwindproducts`.
+1. Browse for the six Tailwind Traders Markdown files from the `data` folder, select all of them, and select **Upload**.
+1. Once your files are uploaded, navigate to the search service you created.
+1. On the left pane, under **Security + networking** > **Keys**, select **Both** for API Access control and confirm the selection. Once complete, leave the Azure Portal tab open and navigate back to the Foundry portal tab and refresh the page.
+1. Verify you are on the **Knowledge** page, select **Create a knowledge base**, choosing **Azure Blob Storage** as your knowledge source, then select **Connect**.
+1. Configure your knowledge source with the following settings:
+    - **Name**: `ks-tailwindproducts`
+    - **Description**: `Tailwind Traders staff knowledge base`
+    - **Storage account name**: *Select your storage account*
+    - **Container name**: `tailwindproducts`
+    - **Authentication type**: *API Key*
+    - **Content extraction mode**: *minimal*
+    - **Embedding model**: *Select the available deployed model, likely text-embedding-3-small*
+    - **Chat completions model**: *Select the available deployed model, likely gpt-5*
+1. Select **Create**.
+1. On the knowledge base creation page, select the `gpt-5` model from the **Chat completions model** dropdown, leaving the rest of the field defaults as is.
+1. Select **Save knowledge base**, and then refresh your browser to verify the knowledge source status is *active*. If it isn't yet, wait a minute and refresh your page until it is.
+1. Select the back button to return to the **Knowledge** page, then select the **Manage** link next to the *Connection* drop-down.
+1. Scroll down to the **Connected resources**, where you should see your search service. Select that row, find the **Authentication** section.
+1. Select **Key authentication** and then select **Edit authentication**.
+1. Leaving the dialog open, return to the Azure portal tab which should still be on your search service **Keys** page. Copy one of those keys into the dialog in Foundry and select **Save**.
+
+Your Foundry IQ settings should now be complete.
+
+## Test the agent in the playground
+
+Before connecting from code, test your agent in the portal playground.
+
+1. Navigate back to your agent on the **Build** > **Agents** page, and select the agent you created.
+2. In the agent page, you should see a playground tab selected. Find the knowledge section and add Foundry IQ, selecting the connection and knowledge base you created.
+1. Try the following test queries to verify the agent can retrieve information from the knowledge base:
+    - `What types of tents does Tailwind Traders offer?`
+    - `Tell me about which backpacks are available in XL.`
+    - `What is the return window for a tent?`
+
+1. Review the responses and notice:
+    - The agent provides specific information from the knowledge base
+    - Citations or references to the source documents may be included
+    - The agent stays focused on Tailwind Traders information
+
+1. In the agent details page, locate and copy the following information to a notepad (you'll need these later):
+    - **Agent name**: This is the name you created (`tailwind-knowledge-agent`)
+    - **Project endpoint**: Found in the project settings or home page
+
+### Configure the agent to require approval for tool calls
+
+When you create an agent in the portal, its Foundry IQ (knowledge) tool runs **without** asking for approval by default. To ensure your app can review and control each knowledge base lookup, you'll change the agent to require approval before it uses tools with the Foundry Toolkit for VS Code extension.
+
+> **Note**: The Foundry portal doesn't currently expose a setting to change this approval behavior, so you'll configure it from the Foundry Toolkit extension instead.
+
+1. In Visual Studio Code, select **Extensions** from the left pane (or press **Ctrl+Shift+X**), then search the marketplace for the `Foundry Toolkit for VS Code` extension from Microsoft and select **Install** (if it isn't already installed).
+
+    > **Note**: The extension is currently listed as **Foundry Toolkit**, but some VS Code labels, commands, or older screenshots may still refer to **AI Toolkit**. In this lab, treat those names as referring to the same extension experience.
+
+1. Select the **Foundry Toolkit** icon in the sidebar, and sign in to your Azure account if you're prompted.
+
+    > **Note**: If you're unable to sign in with the Foundry Toolkit extension, you may need to select the Azure extension. Sign in there, then navigate back to the Foundry Toolkit to access your resources.
+
+1. Under **Microsoft Foundry Resources**, choose **Set Default Project** and select the project you created earlier.
+1. Expand the project section. Under **Prompt Agents**, select your `tailwind-knowledge-agent` agent to open the **Agent Builder** window.
+1. In the **Tools** section, add the **Azure AI Search** tool, and then select the connection and knowledge base you created earlier.
+
+    > **Note**: The agent may list more than one tool. The Foundry portal adds a **Web search** tool to new agents by default, so be sure to select the three dots on the **Azure AI Search** tool for your knowledge base rather than another tool.
+1. In the **Require approval before using tools** dropdown, select **Ask for approval for all tools**, and save your changes if you're prompted.
+
+Your agent will now request approval each time it uses Foundry IQ to search the knowledge base, which the client app you complete next will handle.
+
+## Connect to your agent from code
+
+Now you'll complete a Python console client that talks to your agent and handles the approval flow. The starter file is provided in the `Python` folder.
+
+Open the `Python` folder and activate the virtual environment from [Getting started](B0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+1. In **Python/.env**, make sure `AGENT_NAME` is set to `tailwind-knowledge-agent` (the default in `.env.example`). Save the file.
+
+1. Open **knowledge_agent.py** and review the starter code, including:
+    - Import statements and configuration loading
+    - The `send_message_to_agent()` function structure
+    - The `display_conversation_history()` function
+    - The main program loop
+
+1. Find the first **TODO** comment and add the following code to connect to the project, get the OpenAI client, retrieve the agent, and create a new conversation:
+
+    > **Tip**: Be careful to maintain the correct indentation level.
+
+    ```python
+    # Connect to the project and agent
+    credential = DefaultAzureCredential(
+        exclude_environment_credential=True,
+        exclude_managed_identity_credential=True
+    )
+    project_client = AIProjectClient(
+        credential=credential,
+        endpoint=project_endpoint
+    )
+
+    # Get the OpenAI client
+    openai_client = project_client.get_openai_client()
+
+    # Get the agent
+    agent = project_client.agents.get(agent_name=agent_name)
+    print(f"Connected to agent: {agent.name} (id: {agent.id})\n")
+
+    # Create a new conversation
+    conversation = openai_client.conversations.create(items=[])
+    print(f"Created conversation (id: {conversation.id})\n")
+    ```
+
+1. Find the second **TODO** comment inside the `send_message_to_agent()` function and add the following code to send messages and handle responses, including the Foundry IQ approval request:
+
+    ```python
+    # Add user message to the conversation
+    openai_client.conversations.items.create(
+        conversation_id=conversation.id,
+        items=[{"type": "message", "role": "user", "content": user_message}],
+    )
+
+    # Store in conversation history (client-side)
+    conversation_history.append({
+        "role": "user",
+        "content": user_message
+    })
+
+    # Create a response using the agent
+    response = openai_client.responses.create(
+        conversation=conversation.id,
+        extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+        input=""
+    )
+
+    # Check if the response output contains an MCP approval request
+    approval_request = None
+    if hasattr(response, 'output') and response.output:
+        for item in response.output:
+            if hasattr(item, 'type') and item.type == 'mcp_approval_request':
+                approval_request = item
+                break
+
+    # Handle approval request if present
+    if approval_request:
+        print(f"[Approval required for: {approval_request.name}]\n")
+        print(f"Server: {approval_request.server_label}")
+
+        # Parse and display the arguments (optional, for transparency)
+        import json
+        try:
+            args = json.loads(approval_request.arguments)
+            print(f"Arguments: {json.dumps(args, indent=2)}\n")
+        except Exception:
+            print(f"Arguments: {approval_request.arguments}\n")
+
+        # Prompt user for approval
+        approval_input = input("Approve this action? (yes/no): ").strip().lower()
+
+        if approval_input in ['yes', 'y']:
+            print("Approving action...\n")
+
+            # Create approval response item
+            approval_response = {
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request.id,
+                "approve": True
+            }
+        else:
+            print("Action denied.\n")
+
+            # Create denial response item
+            approval_response = {
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request.id,
+                "approve": False
+            }
+
+        # Add the approval response to the conversation
+        openai_client.conversations.items.create(
+            conversation_id=conversation.id,
+            items=[approval_response]
+        )
+
+        # Get the actual response after approval/denial
+        response = openai_client.responses.create(
+            conversation=conversation.id,
+            extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+            input=""
+        )
+    ```
+
+1. After you've added the code, save the file.
+
+1. Review how the code uses the conversations API to manage interactions with your agent, where:
+    - A conversation is created and tracked by its ID
+    - User messages are added to the conversation using `conversations.items.create()`
+    - Responses are generated using `responses.create()` with an agent reference
+    - **Approval handling**: When the agent needs to access Foundry IQ, it returns an `mcp_approval_request` in the response output
+    - The code prompts you to approve or deny the action before proceeding
+    - After approval/denial, an `mcp_approval_response` is added to the conversation and a new response is generated
+
+## Test the integration
+
+Now you'll run your application and test the agent's ability to retrieve information from the knowledge base.
+
+1. In the terminal (in the `Python` folder), sign into Azure:
+
+    ```
+    az login
+    ```
+
+    > **Note**: In most scenarios, just using *az login* will be sufficient. However, if you have subscriptions in multiple tenants, you may need to specify the tenant by using the *--tenant* parameter.
+
+1. When prompted, complete the sign-in process, selecting the subscription containing your Foundry resource if prompted.
+
+1. Run your application:
+
+    ```
+    python knowledge_agent.py
+    ```
+
+1. When the application starts, test the agent with the following queries:
+
+    **Query 1 - Product categories:**
+
+    ```
+    What types of outdoor products does Tailwind Traders offer?
+    ```
+
+    When prompted for approval, type **yes** to allow the agent to search the knowledge base. Observe how the agent retrieves information from multiple documents.
+
+    **Query 2 - Store policy:**
+
+    ```
+    What is the return window for tents and how do gear rentals work?
+    ```
+
+    Approve the request and notice how the agent provides specific details from the returns and rentals policy.
+
+    **Query 3 - Product comparison:**
+
+    ```
+    What's the difference between your daypacks and expedition backpacks?
+    ```
+
+    Approve the request and see how the agent synthesizes information from the backpacks guide.
+
+    **Query 4 - Supplier and restock:**
+
+    ```
+    When should we reorder tents, and who is our tent supplier?
+    ```
+
+    Approve the request and observe the agent answering from the supplier guide.
+
+    **Query 5 - Follow-up question:**
+
+    ```
+    What are our store's core hours?
+    ```
+
+    Notice how the agent maintains conversation context and answers from the store operations doc.
+
+1. Type `history` to view the complete conversation history.
+
+1. Type `quit` when you're done testing.
+
+> ✅ **Checkpoint**: You've created and **grounded** an enterprise-knowledge agent with Foundry
+> IQ, required **approval** before each knowledge lookup, and connected to it from code —
+> handling the approval flow yourself. That's the Core of this lab. Everything below is optional.
+
+### Optional: run the same agent as a web chat app
+
+The same grounded agent can be served through the shared Tailwind Traders web chat window. From the `Python` folder, run:
+
+```
+python knowledge_chat_app.py
+```
+
+A browser opens at `http://localhost:7860` with the **Tailwind Traders Staff Knowledge Assistant**. This variant **auto-approves** the Foundry IQ knowledge tool so the chat stays smooth. Ask it the same questions as above. Close the tab and press **Ctrl+C** to stop it.
+
+> **Fast-forward**: If you'd rather ground an agent in code instead of the portal, run
+> `python setup/bootstrap_agent.py` from the `Python` folder. It creates
+> `tailwind-knowledge-agent`, grounds it on the six knowledge docs with File Search, and writes
+> `AGENT_NAME` to `.env`. The client code you run against it is identical.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 2 — Publish to Microsoft Teams](B2-publish-to-microsoft-teams.md) · [Task 3 — Publish to Microsoft 365 Copilot](B3-publish-to-microsoft-365-copilot.md) · [Task 4 — Work IQ](B4-work-iq-workplace-intelligence.md)

--- a/Instructions/Exercises/B2-publish-to-microsoft-teams.md
+++ b/Instructions/Exercises/B2-publish-to-microsoft-teams.md
@@ -1,0 +1,212 @@
+---
+lab:
+    title: 'Task 2 – Publish your agent to Microsoft Teams'
+    description: 'Publish the Tailwind Traders knowledge agent to Microsoft Teams so staff can chat with it where they already work.'
+    level: 300
+    concepts: 'agent publishing, Microsoft Teams, Azure Bot Service'
+    islab: true
+    status: 'draft'
+---
+
+# Task 2 — Publish your agent to Microsoft Teams
+
+*Part of the **Integrate agents with enterprise knowledge and Microsoft 365** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **Set up (start here):** This task publishes the grounded `tailwind-knowledge-agent` from
+> [Task 1](B1-create-a-foundry-iq-knowledge-agent.md). If you don't have that agent yet, complete
+> Task 1 first (or, for the quickest path, create and ground it in code with
+> `python setup/bootstrap_agent.py` from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365`
+> folder). You also need a **Microsoft 365 account with Teams access**. This task is completed
+> entirely in the portal and Teams — no local code or `.env` file is required.
+
+> **Continuing from a previous task?** If you just finished Task 1 and your
+> `tailwind-knowledge-agent` is grounded and saved in the Foundry portal, you're ready — go
+> straight to **Publish to Microsoft Teams** below.
+
+---
+
+Publishing to **Microsoft Teams** lets Tailwind Traders staff chat with the knowledge assistant
+directly in Teams, without leaving the tools they already use. This task focuses on the
+**deployment and publishing workflow** — you won't write any code.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What happens when I publish to Teams?</summary>
+<div class="concept-body" markdown="1">
+
+When you publish an agent to Teams, the Foundry portal automatically **creates an Azure Bot
+Service**, generates a **Teams app manifest**, packages **app icons and configuration**, and
+provides a **downloadable app package**. You don't build any of that by hand — you fill in a
+short form and the portal wires it up.
+
+</div>
+</details>
+
+## Publish to Microsoft Teams
+
+When you publish to Teams, the Foundry portal automatically:
+
+- Creates an Azure Bot Service
+- Generates a Teams app manifest
+- Packages app icons and configuration
+- Provides a downloadable app package
+
+### Prepare app information
+
+Before publishing, gather this information:
+
+| Field | Value |
+|-------|-------|
+| **App Name** | Tailwind Traders Knowledge Assistant |
+| **Short Description** | AI assistant for Tailwind Traders staff |
+| **Full Description** | Enterprise AI assistant that answers staff questions about products, store operations, returns, rentals, and suppliers |
+| **Developer Name** | Your name or company name |
+| **Website URL** | <https://tailwindtraders.com> (placeholder is fine for lab) |
+| **Privacy Policy URL** | <https://tailwindtraders.com/privacy> |
+| **Terms of Use URL** | <https://tailwindtraders.com/terms> |
+
+### Create app icons
+
+You'll need two icons for the Teams app:
+
+1. **Color icon** (192x192 pixels)
+   - Full color version of your app logo
+   - PNG format
+
+2. **Outline icon** (32x32 pixels)
+   - White outline on transparent background
+   - PNG format
+   - Used in the Teams sidebar
+
+> **Quick option for this lab**: Create a simple colored square with text or initials using PowerPoint, Paint, or an online tool like Canva.
+
+### Publish from the portal
+
+1. In the Foundry portal, open your agent (**Build** → **Agents** → **tailwind-knowledge-agent**)
+
+2. Select the **Publish** button at the top of the page
+
+3. Select **Publish to Teams and Microsoft 365 Copilot**.
+
+4. Select **Continue**
+
+### Configure Teams app details
+
+Fill in the configuration form:
+
+**Basic Information:**
+
+- **App Name**: Tailwind Traders Knowledge Assistant
+- **Short Description**: AI assistant for Tailwind Traders staff
+- **Full Description**: Enterprise AI assistant that answers staff questions about products, store operations, returns, rentals, and suppliers
+
+**Developer Information:**
+
+- **Developer Name**: Your name
+- **Website**: <https://tailwindtraders.com>
+- **Privacy Policy**: <https://tailwindtraders.com/privacy>
+- **Terms of Use**: <https://tailwindtraders.com/terms>
+
+**App Icons:**
+
+- Upload your **color icon** (192x192 px)
+- Upload your **outline icon** (32x32 px)
+
+**App Scope:**
+
+- Select **Personal** for individual chat access
+- Optionally select **Team** for channel access
+
+Select **Prepare Agent**
+
+### Deploy to Teams
+
+After the agent package is prepared (this takes 1-2 minutes), you can deploy it to Teams:
+
+1. When the package is ready, select **Continue the in-product publishing flow**
+
+2. Choose your publish scope:
+   - **Individual scope**: Agent appears under "Your agents" in the Teams agent store. No admin approval required. Best for personal testing.
+   - **Organization (tenant) scope**: Agent appears under "Built by your org" for all users. Requires admin approval.
+
+3. For this lab, select **Individual scope**
+
+4. Select **Submit**
+
+5. Wait for publishing to complete (you'll see a success message)
+
+> **Alternative if direct publishing fails**: If the publish dialog returns a **400** error, and your Microsoft 365 account has permission to publish custom apps, open the **Download & customize** tab instead and follow the instructions.
+
+6. Your agent is now available in Teams! Find it under **Apps** → **Your agents**
+
+### Test your agent in Teams
+
+1. The agent chat should open after installation (or find it under **Apps** → **Your agents**)
+
+2. Send a greeting:
+
+    ```
+    Hello! What can you help me with?
+    ```
+
+3. Test a knowledge query:
+
+    ```
+    What is the return window for a tent?
+    ```
+
+4. Try another question:
+
+    ```
+    What are our store's core hours?
+    ```
+
+5. The agent should respond with information from the Tailwind Traders knowledge base!
+
+> ✅ **Checkpoint**: Your grounded knowledge agent is now available in Microsoft Teams, answering
+> staff questions from the enterprise knowledge base.
+
+### Troubleshooting Teams deployment
+
+**Can't find the agent in Teams (after direct publish):**
+
+- Check the **Apps** → **Your agents** section in Teams
+- Wait 1-2 minutes for the agent to appear after publishing
+- Verify publishing completed successfully in the Foundry portal
+
+**Can't upload the app (manual upload):**
+
+- Ensure the manifest.zip file isn't corrupted (re-download if needed)
+- Check that your Teams admin hasn't disabled custom app uploads
+- Verify the icons are the correct sizes (192x192 and 32x32)
+
+**Agent doesn't respond:**
+
+- Wait 30 seconds after installation for the bot to initialize
+- Check that the Azure Bot Service was created (shown during publishing)
+- Test the agent in the Foundry playground first
+
+**Responses are generic (no knowledge):**
+
+- Verify Foundry IQ (or file search) is enabled on the agent
+- Confirm documents were uploaded and indexed
+- Test knowledge queries in the Foundry playground
+
+---
+
+**Next (optional):** [Task 3 — Publish to Microsoft 365 Copilot](B3-publish-to-microsoft-365-copilot.md) · [Task 4 — Work IQ](B4-work-iq-workplace-intelligence.md)

--- a/Instructions/Exercises/B3-publish-to-microsoft-365-copilot.md
+++ b/Instructions/Exercises/B3-publish-to-microsoft-365-copilot.md
@@ -1,0 +1,183 @@
+---
+lab:
+    title: 'Task 3 – Publish your agent to Microsoft 365 Copilot'
+    description: 'Publish the Tailwind Traders knowledge agent to Microsoft 365 Copilot so staff can reach it inside Copilot.'
+    level: 300
+    concepts: 'agent publishing, Microsoft 365 Copilot, Copilot agents'
+    islab: true
+    status: 'draft'
+---
+
+# Task 3 — Publish your agent to Microsoft 365 Copilot
+
+*Part of the **Integrate agents with enterprise knowledge and Microsoft 365** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **Set up (start here):** This task publishes the grounded `tailwind-knowledge-agent` from
+> [Task 1](B1-create-a-foundry-iq-knowledge-agent.md). If you don't have that agent yet, complete
+> Task 1 first (or create and ground it in code with `python setup/bootstrap_agent.py` from the
+> `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365` folder). This task is completed
+> entirely in the portal and Copilot — no local code or `.env` file is required.
+
+> **Note**: This task requires a **Microsoft 365 Copilot license**. If you don't have one, you can
+> read through the steps to understand the process.
+
+> **Continuing from a previous task?** If you already published to Teams in
+> [Task 2](B2-publish-to-microsoft-teams.md), the same publishing flow makes the agent available
+> in Copilot too — go straight to **Publish to Microsoft 365 Copilot** below.
+
+---
+
+Publishing to **Microsoft 365 Copilot** makes your agent a **Copilot agent** that staff can reach
+directly inside Copilot. This task focuses on the **publishing workflow** — you won't write any code.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is a Microsoft 365 Copilot agent?</summary>
+<div class="concept-body" markdown="1">
+
+When you publish to Copilot, your agent becomes a **Copilot agent** (also called an extension or
+declarative agent). Staff can invoke it with **@mentions** in Copilot, access its knowledge
+alongside Copilot's own capabilities, and switch between Copilot and your agent seamlessly.
+
+</div>
+</details>
+
+## Publish to Microsoft 365 Copilot
+
+When you publish to Copilot, users can:
+
+- Invoke your agent using @mentions in Copilot
+- Access your agent's knowledge alongside Copilot's capabilities
+- Switch between Copilot and your agent seamlessly
+
+### Publish from the portal
+
+1. Return to the Foundry portal (**<https://ai.azure.com>**)
+
+2. Navigate to your agent (**Build** → **Agents** → **tailwind-knowledge-agent**)
+
+3. Select the **Publish** button
+
+4. Select **Publish to Teams and Microsoft 365 Copilot**
+
+5. Select **Continue**
+
+> **Note**: This is the same publishing flow used for Teams. The agent becomes available in both Teams and Copilot through a single publishing process.
+
+### Configure publishing details
+
+If you haven't already published this agent, fill in the configuration (same as the Teams section):
+
+- **Name**: Tailwind Traders Knowledge Assistant
+- **Description**: AI assistant for Tailwind Traders staff
+- **Icons**: Upload your 192x192 and 32x32 icons
+- **Publisher information**: Your name and placeholder URLs
+
+### Choose publish scope
+
+Select your distribution scope:
+
+| Scope | Visibility | Admin Approval | Best For |
+|-------|-----------|----------------|----------|
+| **Shared** | Under "Your agents" in agent store | Not required | Personal testing, small teams |
+| **Organization** | Under "Built by your org" for all users | Required | Organization-wide distribution |
+
+For this lab, select **Shared scope** for immediate access without admin approval.
+
+### Complete publishing
+
+1. Select **Prepare Agent** and wait for packaging (1-2 minutes)
+
+2. Select **Continue the in-product publishing flow**
+
+3. Confirm your scope selection and select **Publish**
+
+4. Wait for publishing to complete
+
+### Access in Microsoft 365 Copilot
+
+Once published with shared scope, your agent is immediately available:
+
+1. Open **Microsoft 365 Copilot** (copilot.microsoft.com or in Microsoft 365 apps)
+
+2. Look for the agent store or **Extensions** panel
+
+3. Find your agent under **Your agents** (for shared scope)
+
+4. Start a conversation:
+
+    ```
+    @Tailwind Traders Knowledge Assistant What is the return window for a tent?
+    ```
+
+5. Or select your agent and ask directly:
+
+    ```
+    When should we reorder tents, and who is our tent supplier?
+    ```
+
+6. Copilot routes the query to your agent and returns information from the Tailwind Traders knowledge base
+
+> **Note**: For **organization scope**, an admin must first approve the app in the [Microsoft 365 admin center](https://admin.cloud.microsoft/?#/agents/all/requested) under **Requests**. Once approved, the agent appears under **Built by your org** for all users.
+
+> ✅ **Checkpoint**: Your grounded knowledge agent is now reachable inside Microsoft 365 Copilot,
+> answering staff questions from the enterprise knowledge base.
+
+## Cleanup
+
+To avoid unnecessary charges, clean up resources when done.
+
+### Delete the agent
+
+1. In the Foundry portal, go to **Build** → **Agents**
+
+2. Find **tailwind-knowledge-agent**
+
+3. Select the **...** menu → **Delete**
+
+4. Confirm deletion
+
+This also removes:
+
+- The Azure Bot Service
+- Associated configurations
+- Published deployments
+
+### Uninstall from Teams
+
+1. Open Microsoft Teams
+
+2. Go to **Apps** → **Manage your apps**
+
+3. Find **Tailwind Traders Knowledge Assistant**
+
+4. Select **...** → **Uninstall**
+
+5. Confirm uninstallation
+
+### Remove Copilot agent
+
+If you published to Copilot:
+
+1. The agent becomes inactive when the underlying agent is deleted
+2. Users will see an error if they try to use it
+3. An admin may need to remove it from the organization catalog
+
+---
+
+**Next (optional):** [Task 4 — Work IQ: bring Microsoft 365 signals into an agent](B4-work-iq-workplace-intelligence.md)

--- a/Instructions/Exercises/B4-work-iq-workplace-intelligence.md
+++ b/Instructions/Exercises/B4-work-iq-workplace-intelligence.md
@@ -1,0 +1,329 @@
+---
+lab:
+    title: 'Task 4 – Work IQ: bring Microsoft 365 signals into an agent'
+    description: 'Build an agent that accesses Microsoft 365 workplace data using Work IQ and the Model Context Protocol for meeting prep, project tracking, and action items.'
+    level: 300
+    concepts: 'Work IQ, Microsoft 365, Model Context Protocol (MCP), function tools'
+    islab: true
+    status: 'draft'
+---
+
+# Task 4 — Work IQ: bring Microsoft 365 signals into an agent
+
+*Part of the **Integrate agents with enterprise knowledge and Microsoft 365** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Foundry project (with a deployed model) and the
+> starter code. If you haven't already, complete [Getting started](B0-getting-started.md) to
+> create your project, clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in
+> `Python/.env`. Then, from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365`
+> folder, verify you're ready:
+
+```
+python setup/check_env.py --task 4
+```
+
+> **Note**: This is an **optional/advanced** task that requires a **Microsoft 365 Copilot
+> license** and **Node.js 18** or later. It's designed for enterprise learners or those with M365
+> Copilot access. Standard M365 accounts without Copilot won't work. You can still read through
+> the steps to understand the concepts.
+
+> **Continuing from a previous task?** If your project, virtual environment, and `.env` are
+> already set from an earlier task, you only need to install Work IQ (below), then go straight to
+> **Explore workplace intelligence scenarios**.
+
+---
+
+Where Tasks 1-3 grounded an agent on *documents*, this task connects an agent to **live Microsoft
+365 signals** — emails, meetings, Teams messages — using **Work IQ**. You'll build a Tailwind
+Traders workplace intelligence agent that can prep for meetings, track projects, and extract
+action items from real M365 data.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is Work IQ?</summary>
+<div class="concept-body" markdown="1">
+
+**Work IQ** is Microsoft's contextual intelligence layer for Microsoft 365, exposed as a **Model
+Context Protocol (MCP)** server. It gives an agent permission-aware access to workplace data —
+emails, calendar, Teams messages, and documents — so the agent can reason over what people are
+actually doing and saying. It complements **Foundry IQ** (curated knowledge) with **live
+workplace signals**.
+
+</div>
+</details>
+
+## Install Work IQ
+
+1. Open your terminal or command prompt.
+
+2. Install Work IQ globally via npm:
+
+   ```
+   npm install -g @microsoft/workiq
+   ```
+
+3. Accept the End User License Agreement:
+
+   ```
+   workiq accept-eula
+   ```
+
+4. Test your Work IQ installation:
+
+   ```
+   workiq ask -q "What meetings do I have today?"
+   ```
+
+5. **If the test succeeds** - You'll see meeting information from your M365 calendar. Continue to the next section.
+
+6. **If you see "Admin consent required":**
+
+   - The command will display a consent URL
+   - Send this URL to your IT administrator with the message: "I need Work IQ access for the Microsoft Learn AI Agents lab"
+   - Wait for admin approval, then retry the test command
+
+7. **If you see "No M365 Copilot license":**
+
+   - Unfortunately, you cannot complete this task without a Copilot license
+   - You can still read through the instructions to understand the concepts
+
+## Prepare the app
+
+The Work IQ app is provided **complete** in the starter code — you run it as-is.
+
+1. Open the `Python` folder and activate the virtual environment from [Getting started](B0-getting-started.md):
+
+    ```
+    .\labenv\Scripts\Activate.ps1
+    ```
+
+1. Confirm your `.env` has `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` set (Work IQ uses the model deployment to run the agent).
+
+1. Review **workiq_lab.py**. It:
+    - Validates your Work IQ installation
+    - Connects to your Microsoft Foundry project
+    - Initializes the Work IQ MCP client (`npx -y @microsoft/workiq mcp`)
+    - Creates a `tailwind-workplace-agent` with the Work IQ tools
+    - Displays an interactive menu with five scenarios
+
+## Explore workplace intelligence scenarios
+
+1. Sign in to Azure, then run the app:
+
+    ```
+    az login
+    ```
+
+    ```
+    python workiq_lab.py
+    ```
+
+The application connects to Work IQ and your Foundry project, then shows a menu of five scenarios.
+
+### Meeting Prep scenario
+
+1. From the main menu, select **1 - Meeting Prep**.
+
+2. When prompted, enter a meeting topic or time, such as:
+   - "my 2pm meeting"
+   - "Spring Catalog Planning session"
+   - "store operations standup"
+
+3. The agent will find your meeting details, search recent emails about the topic, look for previous meetings, summarize key points, and suggest discussion points.
+
+4. Review the output and note how sources are cited (emails, meetings, dates) and how the agent synthesizes information from multiple sources.
+
+### Project Status scenario
+
+1. From the main menu, select **2 - Project Status**.
+
+2. Enter a project name you're working on, such as:
+   - "Spring Catalog Launch"
+   - "Store Refresh"
+   - "Supplier onboarding"
+
+3. The agent searches emails and Teams messages, finds related meetings, identifies recent decisions and blockers, and summarizes next steps and deadlines.
+
+### Action Items scenario
+
+1. From the main menu, select **3 - Action Items**.
+
+2. Choose a time range (or press Enter for "this week"): "today", "last 3 days", "this month".
+
+3. The agent searches meeting notes, task-related emails, and Teams mentions, identifies items with deadlines, and prioritizes by urgency.
+
+### Combined Intelligence scenario
+
+This scenario demonstrates using **both** Work IQ (workplace data) and Foundry IQ (knowledge base) together.
+
+> **Note**: This scenario requires Foundry IQ (Azure AI Search) configured in your project with an indexed knowledge base — for example, the Tailwind Traders knowledge base from [Task 1](B1-create-a-foundry-iq-knowledge-agent.md).
+
+1. From the main menu, select **4 - Combined Intelligence**.
+
+2. Enter a topic that exists in both your workplace discussions and official documentation:
+   - "store return and rental policies"
+   - "supplier lead times"
+   - "guided-trip gear rentals"
+
+3. The agent searches workplace data (Work IQ) **and** the knowledge base (Foundry IQ), compares informal discussions with official documentation, identifies gaps, and provides a comprehensive summary with labeled sources.
+
+**Key insight:**
+
+- **Work IQ** tells you what people are actually doing and saying
+- **Foundry IQ** tells you what's officially documented
+- **Together** they provide complete context for decision-making
+
+### Custom Query scenario
+
+1. From the main menu, select **5 - Custom Query**.
+
+2. Try different types of workplace questions:
+
+    ```
+    Find emails about the spring catalog from my manager
+    ```
+
+    ```
+    What was decided in yesterday's store operations standup?
+    ```
+
+    ```
+    Show me shared documents about supplier lead times
+    ```
+
+3. Experiment with different time ranges, data sources, and follow-up questions to refine results.
+
+### View Work IQ capabilities
+
+From the main menu, select **6 - View Work IQ Capabilities** to review the architecture, data sources, security model, and the Work IQ vs. Foundry IQ comparison. Select **0** to exit — the app deletes the `tailwind-workplace-agent` version on the way out.
+
+## Understanding the code
+
+Let's examine the key patterns used in `workiq_lab.py`.
+
+### Pattern 1: Work IQ MCP client initialization
+
+```python
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Store server parameters for reuse
+self.workiq_server_params = StdioServerParameters(
+    command="npx",
+    args=["-y", "@microsoft/workiq", "mcp"]
+)
+
+# Fetch available tools from Work IQ MCP server
+async def _fetch():
+    async with stdio_client(self.workiq_server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools_result = await session.list_tools()
+            return tools_result.tools
+
+raw_tools = asyncio.run(_fetch())
+```
+
+Rather than maintaining a persistent connection, a new MCP session is opened per operation. `StdioServerParameters` stores the command and arguments used to launch the Work IQ MCP server subprocess each time.
+
+### Pattern 2: Creating the agent with Work IQ tools
+
+```python
+from azure.ai.projects.models import PromptAgentDefinition, FunctionTool
+
+# Convert MCP tools to FunctionTool objects
+workiq_tools = [
+    FunctionTool(
+        name=tool.name,
+        description=tool.description,
+        parameters=tool.inputSchema,
+    )
+    for tool in raw_tools
+]
+
+# Create agent with Work IQ tools
+self.agent = self.project_client.agents.create_version(
+    agent_name="tailwind-workplace-agent",
+    definition=PromptAgentDefinition(
+        model=self.model_deployment,
+        instructions="You are a workplace intelligence assistant for Tailwind Traders staff...",
+        tools=workiq_tools  # Work IQ tools added here
+    )
+)
+```
+
+Each MCP tool is wrapped in a `FunctionTool` and passed to a `PromptAgentDefinition`.
+
+### Pattern 3: Tool call loop
+
+After the initial response, the agent may request one or more Work IQ tool calls. These are executed and fed back to continue the conversation:
+
+```python
+from openai.types.responses.response_input_param import FunctionCallOutput
+
+while True:
+    if response.status == "failed":
+        break
+
+    input_list = []
+    for item in response.output:
+        if item.type == "function_call":
+            kwargs = json.loads(item.arguments)
+            result = self._call_workiq_tool(item.name, kwargs)
+            input_list.append(
+                FunctionCallOutput(
+                    type="function_call_output",
+                    call_id=item.call_id,
+                    output=result.content[0].text,
+                )
+            )
+
+    if input_list:
+        response = self.openai_client.responses.create(
+            input=input_list,
+            previous_response_id=response.id,
+            extra_body={"agent_reference": {"name": self.agent.name, "type": "agent_reference"}}
+        )
+    else:
+        break  # No more tool calls - final response ready
+```
+
+The loop continues until the agent produces a response with no pending function calls, at which point `response.output_text` contains the final answer.
+
+> ✅ **Checkpoint**: You've built an agent that brings **live Microsoft 365 signals** into its
+> reasoning through Work IQ, and seen how it complements the document-grounded agent from Task 1.
+
+## Clean up
+
+The app deletes the `tailwind-workplace-agent` version when you exit. Work IQ uses your M365 license rather than creating Azure resources, so there's nothing else to remove for this task. When you're finished, enter `deactivate` to exit the virtual environment.
+
+## Troubleshooting
+
+**"Work IQ command not found"** — Install Work IQ: `npm install -g @microsoft/workiq`
+
+**"Admin consent required"** — Run `workiq mcp` to get the consent URL and send it to your IT admin, or use a personal M365 account with Copilot.
+
+**"No M365 Copilot license"** — This task requires Copilot. Use an account with an M365 Copilot license, or read through the lab to understand the concepts.
+
+**"MCP server not responding"** — Test Work IQ directly with `workiq ask -q "What meetings do I have?"`. If it fails, reinstall with `npm install -g @microsoft/workiq`.
+
+**"No data returned"** — Ensure your M365 account has emails, meetings, and Teams activity, and try broader queries.
+
+---
+
+**Back to the [lab overview](B-integrate-agents-with-enterprise-knowledge-and-m365.md).**

--- a/Instructions/Exercises/C-build-multi-agent-solutions-with-agent-framework.md
+++ b/Instructions/Exercises/C-build-multi-agent-solutions-with-agent-framework.md
@@ -1,0 +1,156 @@
+---
+lab:
+    title: 'Build multi-agent solutions with the Agent Framework'
+    description: 'Build Tailwind Traders operations agents with the Microsoft Agent Framework: start with a single tool-using agent, then orchestrate several agents in sequence, then connect remote agents across processes with the A2A protocol. A modular lab you can complete end to end or one task at a time.'
+    level: 300
+    concepts: 'Microsoft Agent Framework, tools, multi-agent orchestration, A2A protocol'
+    duration: 30
+    islab: true
+    status: 'draft'
+---
+
+<!--
+PILOT NOTE (remove before publishing):
+This is a pilot of the new lab template (Core + Optional tasks) applied to
+"Lab C" = a consolidation of the current exercises 07, 08, and 09.
+Starter code lives in a single folder — Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/ —
+shared by every task (one virtual environment, one .env). The completed reference code is
+in Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/.
+
+This landing page is the lab overview. Setup lives in C0-getting-started.md and each task is
+its own page (C1–C3) so it can be completed on its own. Optional provisioning scripts live in
+Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/ and infra/.
+-->
+
+# Build multi-agent solutions with the Agent Framework
+
+A single agent is useful. A *team* of agents — each one focused, and able to hand work to the
+others — is how you build real operations. In this lab you'll build up a Tailwind Traders
+multi-agent system with the **Microsoft Agent Framework (MAF)**, starting from one tool-using
+agent and growing to a set of remote agents that call each other over a protocol.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is the Microsoft Agent Framework?</summary>
+<div class="concept-body" markdown="1">
+
+The **Microsoft Agent Framework (MAF)** is a higher-level SDK for building agents on Microsoft
+Foundry. You decorate a plain Python function with `@tool` (the schema is generated for you) and
+call `await agent.run(...)`, which runs the entire tool-calling loop automatically. It also gives
+you building blocks for **multi-agent** solutions — orchestrations that run several agents
+together — so you don't have to wire the plumbing by hand.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-foundry/agents/overview)
+
+</div>
+</details>
+
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that also runs
+guided trips. Across this lab you'll build the automation behind Tailwind Traders operations —
+starting with a single agent that files trip-expense claims, then a pipeline of agents that
+triage customer feedback, and finally a set of specialist trip-planning agents that live in
+separate processes and collaborate over a protocol.
+
+You'll start with the **Core** task that gets you to a working, tool-using agent as quickly as
+possible. From there, a set of **Optional** tasks lets you go deeper into multi-agent patterns.
+
+> **Note**: Some of the technologies used in this exercise are in preview or in active
+> development. You may experience some unexpected behavior, warnings, or errors.
+
+## What you'll learn
+
+By completing the **Core** task of this exercise, you'll be able to:
+
+- **Build an agent with a custom tool** using the Microsoft Agent Framework — decorate a Python
+  function with `@tool`, hand it to an `Agent`, and let `agent.run()` drive the tool-calling loop.
+
+The **Optional** tasks let you additionally:
+
+- **Orchestrate multiple agents** in a sequence, passing work from one specialist agent to the
+  next and collecting every agent's output.
+- **Connect remote agents** that run in separate processes and call each other using the
+  **Agent-to-Agent (A2A)** protocol, coordinated by a routing agent.
+
+## How this lab is organized
+
+This lab is **modular**. Each task is written to be completed **on its own, starting fresh** —
+so you can pick a single task and do just that one. Every task also shares one starter folder,
+one virtual environment, and one `.env`, so if you'd rather work straight through, you can.
+
+1. **Start with [Getting started](C0-getting-started.md)** — create your Microsoft Foundry
+   project (in the portal or with one `azd up` command), get the starter code, and set up
+   your `.env`. Every task begins from here; if you're doing the whole lab in one sitting, you
+   only need to do this once.
+2. **Do any task.** Each task lists the setup it needs so you can start it independently. If
+   you're moving straight from the previous task, a short *"Continuing from a previous task?"*
+   note at the top lets you skip the repeated setup and keep going.
+
+## Lab at a glance
+
+Complete the **Core** task first (about **30 minutes**) — it ends with a working, tool-using
+agent. Then expand any **Optional** tasks that interest you. The full lab, including all
+optional tasks, takes about **1 hour 30 minutes**.
+
+| Section | Task | Difficulty | Time |
+| --- | --- | --- | --- |
+| **Core** | [Task 1 – Build an agent with a tool](C1-create-an-agent-with-a-tool.md) | ★★☆ | ~30 min |
+| *Optional* | [Task 2 – Orchestrate multiple agents in sequence](C2-orchestrate-multiple-agents.md) | ★★☆ | ~30 min |
+| *Optional* | [Task 3 – Connect remote agents with A2A](C3-connect-remote-agents-with-a2a.md) | ★★★ | ~30 min |
+
+**Choosing your path** — pick the tasks that fit the time you have:
+
+- **Core only (~30 min):** do Task 1.
+- **Core + orchestration (~1h):** also do **Task 2**.
+- **Everything (~1h 30m):** add **Task 3** (remote agents with A2A).
+
+## One framework, growing from one agent to many
+
+Every task in this lab is built on the **Microsoft Agent Framework**, so the shape of the code
+stays familiar as the solutions get more ambitious:
+
+- In **Task 1**, you build a **single** agent. You describe a tool with `@tool`, attach it to an
+  `Agent` backed by a `FoundryChatClient`, and call `agent.run(...)` — the framework runs the
+  tool-calling loop for you.
+- In **Task 2**, you keep the same client but create **several** agents and hand them to a
+  `SequentialBuilder` orchestration, which runs them in order and collects each one's output.
+- In **Task 3**, you split the agents across **separate processes** and let a routing agent
+  discover and call them using the **A2A protocol** — the same collaboration idea, now over the
+  network.
+
+Seeing the single-agent mechanics first is what makes the multi-agent patterns meaningful later.
+
+## Summary
+
+Across this lab you:
+
+- Built an **agent with a custom tool** using the Microsoft Agent Framework.
+- (Optionally) **orchestrated several agents** in a sequence to triage work step by step.
+- (Optionally) connected **remote agents** across processes with the **A2A protocol**, routed by
+  a coordinating agent.
+
+Together these show how the Agent Framework scales from a single focused agent to a coordinated
+team of them.
+
+## Clean up
+
+If you're finished, delete the resources you created to avoid unnecessary Azure costs.
+
+1. In the [Azure portal](https://portal.azure.com), navigate to the resource group that contains your Foundry resource.
+1. On the toolbar, select **Delete resource group**, enter the resource group name, and confirm.
+
+> If you provisioned with `azd`, run `azd down` instead to remove everything it created.

--- a/Instructions/Exercises/C0-getting-started.md
+++ b/Instructions/Exercises/C0-getting-started.md
@@ -1,0 +1,126 @@
+---
+lab:
+    title: 'Getting started: set up your environment'
+    description: 'Shared setup for the Build multi-agent solutions with the Agent Framework lab: create a Microsoft Foundry project, get the starter code, and configure your environment. Complete this once before any task.'
+    level: 300
+    concepts: 'environment setup, Microsoft Foundry project'
+    status: 'draft'
+---
+
+# Getting started
+
+This page sets up everything the **Build multi-agent solutions with the Agent Framework** lab
+needs. **Every task begins here** — complete this page first. Each task is written so you can then
+do it on its own; if you're working through the whole lab in one sitting, you only need to do this
+setup once.
+
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that also runs
+guided trips. Across the lab you'll build the automation behind Tailwind Traders operations,
+starting with one agent and growing to a coordinated team of them.
+
+> **Note**: Some of the technologies used in this lab are in preview or in active
+> development. You may experience some unexpected behavior, warnings, or errors.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
+- [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
+- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Git](https://git-scm.com/downloads) installed on your local machine
+- Basic familiarity with Python
+
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+
+## Create a Microsoft Foundry project
+
+You need a Foundry project and a deployed model for every task. You can create these in the
+portal (the default), or provision them with one command using the Azure Developer CLI (`azd`).
+
+### Option A — Create the project in the portal (default)
+
+Microsoft Foundry uses projects to organize models, resources, data, and other assets.
+
+1. In a web browser, open the [Foundry portal](https://ai.azure.com) at `https://ai.azure.com` and sign in using your Azure credentials. Close any tips or quick start panes, and if necessary use the **Foundry** logo at the top left to navigate to the home page.
+
+    > **Important**: For this lab, you're using the **New** Foundry experience.
+
+1. In the top banner, select **Start building**.
+
+1. When prompted, create a **new** project and enter a valid name (for example, `agents-lab-project`).
+
+1. Expand **Advanced options** and specify:
+    - **Microsoft Foundry resource**: *A valid name for your Foundry resource*
+    - **Region**: *Select one available near you*\*
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *Select or create a resource group*
+
+    > \* Some Azure AI resources are constrained by regional model quotas. If you hit a quota limit later, you may need to create another resource in a different region.
+
+1. Select **Create** and wait for your project to be created. When prompted, continue through the welcome dialog.
+
+1. When prompted to deploy a model, deploy a **gpt-4o** model (or another available chat model). Note the **deployment name** — you'll set it as `MODEL_DEPLOYMENT_NAME` in your `.env`.
+
+1. From the project overview, copy the **Project endpoint** — you'll set it as `PROJECT_ENDPOINT`.
+
+### Option B — Provision with azd (optional, one command)
+
+If you'd rather not click through the portal, the lab ships an optional `azd` template that
+creates the Foundry resource, a project, and a model deployment for you.
+
+1. Install the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd).
+
+1. From the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, run:
+
+    ```
+    azd auth login
+    azd up
+    ```
+
+1. Answer the prompts (environment name, region). When it finishes, `azd` writes
+    `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` into `Python/.env` for you.
+
+    > **Note**: When you're done with the lab, run `azd down` to delete everything it created.
+
+## Get the starter code
+
+1. In VS Code, open the Command Palette (**Ctrl+Shift+P**), run **Git: Clone**, and enter:
+
+    ```
+    https://github.com/MicrosoftLearning/mslearn-ai-agents.git
+    ```
+
+1. Open the cloned repo, then **File > Open Folder** and select `mslearn-ai-agents/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python`. This single folder holds the starter code for **every** task in this lab — you use one virtual environment and one `.env` throughout.
+
+1. Right-click **requirements.txt** and choose **Open in Integrated Terminal**. Then create a virtual environment and install packages:
+
+    ```
+    python -m venv labenv
+    .\labenv\Scripts\Activate.ps1
+    pip install -r requirements.txt
+    ```
+
+1. Open the **.env** file and set `PROJECT_ENDPOINT` to your project endpoint and `MODEL_DEPLOYMENT_NAME` to your model deployment name. Save the file. (If you used `azd up`, these are already filled in.)
+
+    > **Tip**: In the Foundry Toolkit VS Code extension, right-click your project deployment and select **Copy Project Endpoint** to get the endpoint URL.
+
+    > The `.env` also ships with `SERVER_URL` and three `*_PORT` values pre-filled — those are only used by **Task 3** (remote agents), and you normally don't need to change them.
+
+## Check you're ready for a task
+
+Each task needs specific values in your `.env`. Before starting a task, run the preflight
+check from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder — it reads
+your `.env` and tells you what (if anything) is missing:
+
+```
+python setup/check_env.py --task 1
+```
+
+Swap `1` for the task number you're about to start. That's it — head to any task:
+
+| Task | Page |
+| --- | --- |
+| Task 1 – Build an agent with a tool | [C1](C1-create-an-agent-with-a-tool.md) |
+| Task 2 – Orchestrate multiple agents in sequence | [C2](C2-orchestrate-multiple-agents.md) |
+| Task 3 – Connect remote agents with A2A | [C3](C3-connect-remote-agents-with-a2a.md) |

--- a/Instructions/Exercises/C1-create-an-agent-with-a-tool.md
+++ b/Instructions/Exercises/C1-create-an-agent-with-a-tool.md
@@ -1,0 +1,198 @@
+---
+lab:
+    title: 'Task 1 – Build an agent with a tool'
+    description: 'Use the Microsoft Agent Framework to build a single agent that calls a custom tool: decorate a Python function with @tool, attach it to an Agent, and let agent.run() drive the tool-calling loop.'
+    level: 300
+    concepts: 'Microsoft Agent Framework, tools, agents'
+    islab: true
+    status: 'draft'
+---
+
+# Task 1 — Build an agent with a tool
+
+*Part of the **Build multi-agent solutions with the Agent Framework** lab. New here? Start with [Getting started](C0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Foundry project and the starter code. If you
+> haven't already, complete [Getting started](C0-getting-started.md) to create your project,
+> clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
+> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+
+```
+python setup/check_env.py --task 1
+```
+
+> **Continuing from a previous task?** If you just finished an earlier task in the same
+> `Python` folder, your project, virtual environment, and `.env` are already set — go
+> straight to **Build the agent with a custom tool** below.
+
+---
+
+Every useful agent can *do* something beyond chatting. With the **Microsoft Agent Framework
+(MAF)**, you give an agent a capability by writing an ordinary Python function, marking it with
+`@tool`, and handing it to the agent — the framework generates the tool's schema and runs the
+whole tool-calling loop for you. In this task you'll build the Tailwind Traders **trip-expense
+agent**: it reads a guide's trip-expense data, itemizes it, and calls a tool to "email" a
+reimbursement claim to the finance desk.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is a tool?</summary>
+<div class="concept-body" markdown="1">
+
+A **tool** is a function you give an agent so it can take action or fetch information beyond the
+model's own knowledge. In the Agent Framework you write a normal Python function and add the
+`@tool` decorator; the framework reads the function signature (including the parameter
+descriptions) to build the schema the model needs. When the model decides a tool is needed,
+`agent.run()` calls your function, feeds the result back to the model, and continues — all
+automatically.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-foundry/agents/overview)
+
+</div>
+</details>
+
+Open the `Python` folder and activate the virtual environment from [Getting started](C0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+### Build the agent with a custom tool
+
+Open **expense_agent.py** and add code at each commented placeholder.
+
+1. Review the code already in the file. It contains:
+    - Some **import** statements.
+    - A `main` function that loads `data.txt` (the trip-expense data), asks you what to do with it, and then calls...
+    - A `process_expenses_data` function where you'll create and run your agent.
+
+    > **Tip**: As you add code, keep the indentation aligned with the comments.
+
+1. At the top of the file, find the comment **Add references** and add the namespaces you'll need:
+
+    ```python
+    # Add references
+    from agent_framework import tool, Agent
+    from agent_framework.foundry import FoundryChatClient
+    from azure.identity import AzureCliCredential
+    from pydantic import Field
+    ```
+
+1. Near the bottom of the file, find the comment **Create a tool function for the email functionality** and add the tool the agent will use to send the claim:
+
+    ```python
+    # Create a tool function for the email functionality
+    @tool(approval_mode="never_require")
+    def submit_claim(
+        to: Annotated[str, Field(description="Who to send the email to")],
+        subject: Annotated[str, Field(description="The subject of the email.")],
+        body: Annotated[str, Field(description="The text body of the email.")],
+    ):
+        """Submit a Tailwind Traders trip-expense claim by sending an email."""
+        print("\nTo:", to)
+        print("Subject:", subject)
+        print(body, "\n")
+    ```
+
+    > **Note**: The function *simulates* sending an email by printing it to the console. In a real application, you'd use an SMTP service or similar to actually send the email. `approval_mode="never_require"` lets the agent call the tool without pausing to ask you for approval each time.
+
+1. Back up in the `process_expenses_data` function, find the comment **Create a foundry chat client** and add the following (keep the indentation level):
+
+    ```python
+    # Create a foundry chat client
+    client = FoundryChatClient(
+        project_endpoint=os.getenv("PROJECT_ENDPOINT"),
+        model=os.getenv("MODEL_DEPLOYMENT_NAME"),
+        credential=AzureCliCredential(),
+    )
+    ```
+
+    The **AzureCliCredential** object lets your code authenticate to Azure using your `az login` session. The **FoundryChatClient** connects to your Foundry project using the endpoint and model deployment name from `.env`.
+
+1. Find the comment **Initialize an agent with the tool and instructions** and add the following:
+
+    ```python
+    # Initialize an agent with the tool and instructions
+    agent = Agent(
+        client=client,
+        name="TripExpenseAgent",
+        instructions="""You are an AI assistant for Tailwind Traders trip-expense claims.
+                    At the user's request, create an expense claim and use the submit_claim tool to send an email to expenses@tailwindtraders.com with the subject 'Trip Expense Claim' and a body that contains the itemized expenses with a total.
+                    Then confirm to the user that you've done so. Don't ask for any more information from the user, just use the data provided to create the email.""",
+        tools=[submit_claim],
+    )
+    ```
+
+    The **Agent** object is initialized with the client, instructions that tell it how to behave, and the `submit_claim` tool it's allowed to call.
+
+1. Review the code that follows the agent (already provided). It creates a **session** to hold the conversation and calls `await agent.run(...)`, which runs the entire tool-calling loop and returns the final response as `response.text`:
+
+    ```python
+    # Create a session and use the agent to process the expenses data
+    try:
+        # A session keeps the conversation history across the agent run
+        session = agent.create_session()
+        # Invoke the agent with the prompt and the trip expenses data
+        response = await agent.run(f"{prompt}: {expenses_data}", session=session)
+        # Display the response
+        print(f"\n# Agent:\n{response.text}")
+    except Exception as e:
+        # Something went wrong
+        print(e)
+    ```
+
+1. Save the file (**Ctrl+S**).
+
+### Run and test
+
+1. In the terminal, sign in and run the app:
+
+    ```
+    az login
+    ```
+
+    ```
+    python expense_agent.py
+    ```
+
+    `az login` lets the `AzureCliCredential` authenticate to your Azure account.
+
+1. When asked what to do with the expenses data, enter:
+
+    ```
+    Submit an expense claim
+    ```
+
+1. Review the output. The agent should compose an itemized expense-claim email — printed by the `submit_claim` tool — and then confirm it's done. You'll see output similar to:
+
+    ```
+    To: expenses@tailwindtraders.com
+    Subject: Trip Expense Claim
+    ...itemized expenses with a total...
+
+    # Agent:
+    I've submitted your trip-expense claim to expenses@tailwindtraders.com.
+    ```
+
+    > **Tip**: If the app fails because the rate limit is exceeded, wait a few seconds and try again. If there is insufficient quota available in your subscription, the model may not be able to respond.
+
+> ✅ **Checkpoint**: You've built a single agent with a custom tool using the Microsoft Agent
+> Framework — the model decided when to call your tool, and `agent.run()` handled the loop.
+> That's the Core of this lab. The optional tasks below grow this into a multi-agent solution.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 2 — Orchestrate multiple agents in sequence](C2-orchestrate-multiple-agents.md) · [Task 3 — Connect remote agents with A2A](C3-connect-remote-agents-with-a2a.md)

--- a/Instructions/Exercises/C2-orchestrate-multiple-agents.md
+++ b/Instructions/Exercises/C2-orchestrate-multiple-agents.md
@@ -1,0 +1,212 @@
+---
+lab:
+    title: 'Task 2 – Orchestrate multiple agents in sequence'
+    description: 'Use the Microsoft Agent Framework to orchestrate several agents in a sequence: a summarizer, a classifier, and an action agent triage a piece of customer feedback, each building on the last.'
+    level: 300
+    concepts: 'Microsoft Agent Framework, multi-agent orchestration, sequential workflow'
+    islab: true
+    status: 'draft'
+---
+
+# Task 2 — Orchestrate multiple agents in sequence
+
+*Part of the **Build multi-agent solutions with the Agent Framework** lab. New here? Start with [Getting started](C0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Foundry project and the starter code. If you
+> haven't already, complete [Getting started](C0-getting-started.md) to create your project,
+> clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
+> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+
+```
+python setup/check_env.py --task 2
+```
+
+> **Continuing from a previous task?** If you just finished an earlier task in the same
+> `Python` folder, your project, virtual environment, and `.env` are already set — go
+> straight to **Create the agents** below.
+
+---
+
+Some jobs are best done by a **team** of specialists, each handling one step and passing its
+result to the next. The Microsoft Agent Framework's **sequential orchestration** does exactly
+that: it runs a list of agents in order and collects each one's output. In this task you'll build
+a Tailwind Traders **feedback triage** pipeline — a *summarizer* condenses a customer comment, a
+*classifier* labels it, and an *action* agent recommends the next step.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is sequential orchestration?</summary>
+<div class="concept-body" markdown="1">
+
+**Sequential orchestration** runs several agents one after another, feeding the running
+conversation from each agent into the next. It's a good fit when a task breaks cleanly into
+ordered stages — summarize, then classify, then decide — and each stage benefits from the output
+of the one before it. In the Agent Framework you build one with `SequentialBuilder`, listing the
+participant agents in the order they should run.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-foundry/agents/overview)
+
+</div>
+</details>
+
+Open the `Python` folder and activate the virtual environment from [Getting started](C0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+### Create the agents
+
+Open **feedback_agents.py** and add code at each commented placeholder.
+
+1. Review the code already in the file. In the `main` function, take a moment to read the three
+    sets of agent **instructions** (summarizer, classifier, action) — these define what each agent
+    does.
+
+    > **Tip**: As you add code, keep the indentation aligned with the comments.
+
+1. At the top of the file, find the comment **Add references** and add the namespaces you'll need:
+
+    ```python
+    # Add references
+    from agent_framework import Message
+    from agent_framework.foundry import FoundryChatClient
+    from agent_framework.orchestrations import SequentialBuilder
+    from azure.identity import AzureCliCredential
+    ```
+
+1. Find the comment **Create the chat client** and add the following (keep the indentation level):
+
+    ```python
+    # Create the chat client
+    credential = AzureCliCredential()
+    chat_client = FoundryChatClient(
+        credential=credential,
+        project_endpoint=os.getenv("PROJECT_ENDPOINT"),
+        model=os.getenv("MODEL_DEPLOYMENT_NAME"),
+    )
+    ```
+
+    The **AzureCliCredential** lets your code authenticate to Azure using your `az login` session, and the **FoundryChatClient** connects to your Foundry project. All three agents share this one client.
+
+1. Find the comment **Create agents** and add the following to create the three agents from the shared client:
+
+    ```python
+    # Create agents
+    summarizer_agent = chat_client.as_agent(
+        name="summarizer",
+        instructions=summarizer_instructions,
+    )
+
+    classifier_agent = chat_client.as_agent(
+        name="classifier",
+        instructions=classifier_instructions,
+    )
+
+    action_agent = chat_client.as_agent(
+        name="action",
+        instructions=action_instructions,
+    )
+    ```
+
+1. Find the comment **Initialize the current feedback** and add a sample piece of customer feedback for the pipeline to triage:
+
+    ```python
+    # Initialize the current feedback
+    feedback="""
+    I use your trail-finder app before every hike, and it works well overall.
+    But when I'm checking the map at night on the trail, the bright screen is really harsh on my eyes.
+    If you added a dark mode option, it would make it much more comfortable to use in low light.
+    """
+    ```
+
+### Create a sequential orchestration
+
+1. Find the comment **Build sequential orchestration** and add the following to define the pipeline:
+
+    ```python
+    # Build sequential orchestration
+    workflow = SequentialBuilder(
+        participants=[summarizer_agent, classifier_agent, action_agent],
+        output_from="all",
+    ).build()
+    ```
+
+    The agents process the feedback in the order they're listed. `output_from="all"` ensures the outputs from *every* agent are collected, not just the last one.
+
+1. Find the comment **Run and collect outputs** and add the following:
+
+    ```python
+    # Run and collect outputs
+    result = await workflow.run(f"Customer feedback: {feedback}")
+    outputs = result.get_outputs()
+    ```
+
+    This runs the orchestration and collects the output from each participating agent.
+
+1. Find the comment **Display outputs** and add the following:
+
+    ```python
+    # Display outputs
+    i = 1
+    for response in outputs:
+        for msg in cast(list[Message], response.messages):
+            name = msg.author_name or ("assistant" if msg.role == "assistant" else "user")
+            print(f"{'-' * 60}\n{i:02d} [{name}]\n{msg.text}")
+            i += 1
+    ```
+
+    This formats and prints each message collected from the orchestration, labeled with the agent that produced it.
+
+1. Save the file (**Ctrl+S**).
+
+### Run and test
+
+1. In the terminal, sign in and run the app:
+
+    ```
+    az login
+    ```
+
+    ```
+    python feedback_agents.py
+    ```
+
+1. Review the output. Each agent contributes one step, and you should see output similar to:
+
+    ```
+    Customer requests a dark mode option for comfortable nighttime trail use.
+    Feature request
+    Log as an enhancement request to add a dark mode for nighttime trail use.
+    ------------------------------------------------------------
+    01 [summarizer]
+    Customer requests a dark mode option for comfortable nighttime trail use.
+    ------------------------------------------------------------
+    02 [classifier]
+    Feature request
+    ------------------------------------------------------------
+    03 [action]
+    Log as an enhancement request to add a dark mode for nighttime trail use.
+    ```
+
+    > **Tip**: If the app fails because the rate limit is exceeded, wait a few seconds and try again. Try editing the `feedback` string to a complaint or a compliment and run again to see the classification and recommended action change.
+
+> ✅ **Checkpoint**: You've orchestrated three agents in a sequence with the Microsoft Agent
+> Framework, passing work from one specialist to the next and collecting every agent's output.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 3 — Connect remote agents with A2A](C3-connect-remote-agents-with-a2a.md)

--- a/Instructions/Exercises/C3-connect-remote-agents-with-a2a.md
+++ b/Instructions/Exercises/C3-connect-remote-agents-with-a2a.md
@@ -1,0 +1,372 @@
+---
+lab:
+    title: 'Task 3 – Connect remote agents with A2A'
+    description: 'Use the Agent-to-Agent (A2A) protocol to connect agents that run in separate processes: a routing agent discovers and delegates to a trip-title agent and a trip-itinerary agent, which collaborate to plan Tailwind Traders guided trips.'
+    level: 300
+    concepts: 'A2A protocol, remote agents, multi-agent orchestration'
+    islab: true
+    status: 'draft'
+---
+
+# Task 3 — Connect remote agents with A2A
+
+*Part of the **Build multi-agent solutions with the Agent Framework** lab. New here? Start with [Getting started](C0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Foundry project and the starter code. If you
+> haven't already, complete [Getting started](C0-getting-started.md) to create your project,
+> clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
+> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+
+```
+python setup/check_env.py --task 3
+```
+
+> **Continuing from a previous task?** If you just finished an earlier task in the same
+> `Python` folder, your project, virtual environment, and `.env` are already set — go
+> straight to **Create a discoverable agent** below.
+
+---
+
+So far your agents have lived in a single process. Real systems are often split across services —
+each agent runs on its own, and they collaborate over the network. The **Agent-to-Agent (A2A)
+protocol** is a standard way for agents to advertise what they can do and send each other work.
+In this task you'll build a Tailwind Traders trip-planning system from three remote agents: a
+**trip-title agent** suggests a headline, a **trip-itinerary agent** drafts an outline, and a
+**routing agent** discovers both and delegates each request to the right one.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is the A2A protocol?</summary>
+<div class="concept-body" markdown="1">
+
+The **Agent-to-Agent (A2A) protocol** lets agents in separate processes discover and call one
+another. Each agent publishes an **agent card** — a small document describing its name, skills,
+and endpoint — so other agents can find it at runtime. One agent (here, the routing agent) reads
+those cards, decides who should handle a request, and sends a message over HTTP; the remote agent
+does the work and returns a response.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-foundry/agents/overview)
+
+</div>
+</details>
+
+Open the `Python` folder and activate the virtual environment from [Getting started](C0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+The starter code for this task is organized into one folder per agent, plus a client and a
+launcher:
+
+```output
+Python
+├── outline_agent/       # remote agent: drafts a trip itinerary outline (provided complete)
+│   ├── agent.py
+│   ├── agent_executor.py
+│   └── server.py
+├── routing_agent/       # orchestrator that discovers and delegates to the other agents
+│   ├── agent.py
+│   └── server.py
+├── title_agent/         # remote agent: suggests a guided-trip title
+│   ├── agent.py
+│   ├── agent_executor.py
+│   └── server.py
+├── client.py            # sends your prompt to the routing agent
+└── run_all.py           # launches all three agent servers
+```
+
+Each agent folder contains the Foundry agent code and a server to host it. The **routing agent**
+discovers and communicates with the **trip-title** and **trip-itinerary** agents. The **client**
+lets you submit prompts to the routing agent. `run_all.py` launches all the servers.
+
+> The `outline_agent` (trip-itinerary agent) is provided **complete** as a reference — you'll
+> build the equivalent code in the `title_agent`, then wire up the `routing_agent`.
+
+### Create a discoverable agent
+
+In this task you complete the trip-title agent that suggests headlines for Tailwind Traders
+guided trips. You also define the agent's skills and card, which the A2A protocol uses to make
+the agent discoverable.
+
+> **Tip**: As you add code, keep the indentation aligned with the comments.
+
+1. Open **title_agent/agent.py**.
+
+1. Find the comment **Create the agents client** and add the code to connect to your Foundry project:
+
+    ```python
+    # Create the agents client
+    self.client = AgentsClient(
+        endpoint=os.environ['PROJECT_ENDPOINT'],
+        credential=DefaultAzureCredential(
+            exclude_environment_credential=True,
+            exclude_managed_identity_credential=True
+        )
+    )
+    ```
+
+1. Find the comment **Create the title agent** and add the code to create the agent:
+
+    ```python
+    # Create the title agent
+    self.agent = self.client.create_agent(
+        model=os.environ['MODEL_DEPLOYMENT_NAME'],
+        name='trip-title-agent',
+        instructions="""
+        You are a helpful trip marketing assistant for Tailwind Traders.
+        Given a region or activity the customer wants to explore, suggest a single clear and catchy guided-trip title.
+        """,
+    )
+    ```
+
+1. Find the comment **Create a thread for the chat session** and add:
+
+    ```python
+    # Create a thread for the chat session
+    thread = self.client.threads.create()
+    ```
+
+1. Find the comment **Send user message** and add:
+
+    ```python
+    # Send user message
+    self.client.messages.create(thread_id=thread.id, role=MessageRole.USER, content=user_message)
+    ```
+
+1. Find the comment **Create and run the agent** and add:
+
+    ```python
+    # Create and run the agent
+    run = self.client.runs.create_and_process(thread_id=thread.id, agent_id=self.agent.id)
+    ```
+
+    The rest of the file processes and returns the agent's response.
+
+1. Save the file (**Ctrl+S**). Now share the agent's skills and card with the A2A protocol.
+
+1. Open **title_agent/server.py**.
+
+1. Find the comment **Define agent skills** and add:
+
+    ```python
+    # Define agent skills
+    skills = [
+        AgentSkill(
+            id='generate_trip_title',
+            name='Generate Trip Title',
+            description='Generates a guided-trip title based on a region or activity',
+            tags=['title'],
+            examples=[
+                'Can you give me a title for a hiking trip in Patagonia?',
+            ],
+        ),
+    ]
+    ```
+
+1. Find the comment **Create agent card** and add the metadata that makes the agent discoverable:
+
+    ```python
+    # Create agent card
+    agent_card = AgentCard(
+        name='Tailwind Traders Trip Title Agent',
+        description='An intelligent trip-title generator agent powered by Foundry. '
+        'I can help you generate catchy titles for Tailwind Traders guided trips.',
+        url=f'http://{host}:{port}/',
+        version='1.0.0',
+        default_input_modes=['text'],
+        default_output_modes=['text'],
+        capabilities=AgentCapabilities(),
+        skills=skills,
+    )
+    ```
+
+1. Find the comment **Create agent executor** and add:
+
+    ```python
+    # Create agent executor
+    agent_executor = create_foundry_agent_executor(agent_card)
+    ```
+
+1. Find the comment **Create request handler** and add:
+
+    ```python
+    # Create request handler
+    request_handler = DefaultRequestHandler(
+        agent_executor=agent_executor, task_store=InMemoryTaskStore()
+    )
+    ```
+
+1. Find the comment **Create A2A application** and add:
+
+    ```python
+    # Create A2A application
+    a2a_app = A2AStarletteApplication(
+        agent_card=agent_card, http_handler=request_handler
+    )
+    ```
+
+    This creates an A2A server that shares the trip-title agent's information and handles incoming requests using the agent executor.
+
+1. Save the file (**Ctrl+S**).
+
+### Enable messages between the agents
+
+In this task you use the A2A protocol to let the routing agent send messages to the other agents,
+and let the trip-title agent receive them by completing its agent executor.
+
+1. Open **routing_agent/agent.py**.
+
+    The routing agent orchestrates the system: when a user message arrives, it starts a thread,
+    uses `create_and_process` to decide which remote agent should handle the request, and routes
+    the message to that agent over HTTP with the `send_message` function. The `send_message`
+    method is async and must be awaited for the run to complete.
+
+1. Find the comment **Retrieve the remote agent's A2A client using the agent name** and add:
+
+    ```python
+    # Retrieve the remote agent's A2A client using the agent name 
+    client = self.remote_agent_connections[agent_name]
+    ```
+
+1. Find the comment **Construct the payload to send to the remote agent** and add:
+
+    ```python
+    # Construct the payload to send to the remote agent
+    payload: dict[str, Any] = {
+        'message': {
+            'role': 'user',
+            'parts': [{'kind': 'text', 'text': task}],
+            'messageId': message_id,
+        },
+    }
+    ```
+
+1. Find the comment **Wrap the payload in a SendMessageRequest object** and add:
+
+    ```python
+    # Wrap the payload in a SendMessageRequest object
+    message_request = SendMessageRequest(id=message_id, params=MessageSendParams.model_validate(payload))
+    ```
+
+1. Find the comment **Send the message to the remote agent client and await the response** and add:
+
+    ```python
+    # Send the message to the remote agent client and await the response
+    send_response: SendMessageResponse = await client.send_message(message_request=message_request)
+    ```
+
+1. Save the file (**Ctrl+S**). The routing agent can now discover and message the remote agents.
+    Next, complete the trip-title agent's executor so it can handle those incoming messages.
+
+1. Open **title_agent/agent_executor.py**.
+
+    The `AgentExecutor` class must implement `execute` and `cancel`. The `cancel` method is
+    provided. The `execute` method uses a `TaskUpdater` object to manage events and signal when
+    the task is complete — add the execution logic below.
+
+1. In the `execute` method, find the comment **Process the request** and add:
+
+    ```python
+    # Process the request
+    await self._process_request(context.message.parts, context.context_id, updater)
+    ```
+
+1. In the `_process_request` method, find the comment **Get the title agent** and add:
+
+    ```python
+    # Get the title agent
+    agent = await self._get_or_create_agent()
+    ```
+
+1. Find the comment **Update the task status** and add:
+
+    ```python
+    # Update the task status
+    await task_updater.update_status(
+        TaskState.working,
+        message=new_agent_text_message('Title Agent is processing your request...', context_id=context_id),
+    )
+    ```
+
+1. Find the comment **Run the agent conversation** and add:
+
+    ```python
+    # Run the agent conversation
+    responses = await agent.run_conversation(user_message)
+    ```
+
+1. Find the comment **Update the task with the responses** and add:
+
+    ```python
+    # Update the task with the responses
+    for response in responses:
+        await task_updater.update_status(
+            TaskState.working,
+            message=new_agent_text_message(response, context_id=context_id),
+        )
+    ```
+
+1. Find the comment **Mark the task as complete** and add:
+
+    ```python
+    # Mark the task as complete
+    final_message = responses[-1] if responses else 'Task completed.'
+    await task_updater.complete(
+        message=new_agent_text_message(final_message, context_id=context_id)
+    )
+    ```
+
+    The trip-title agent is now wrapped with an executor that the A2A protocol uses to handle messages.
+
+1. Save the file (**Ctrl+S**).
+
+### Run and test
+
+1. In the terminal, sign in and start all three agent servers:
+
+    ```
+    az login
+    ```
+
+    ```
+    python run_all.py
+    ```
+
+    The servers start using your authenticated Azure session. Wait until each server reports it's ready.
+
+1. In a **second** terminal (with the virtual environment activated), run the client:
+
+    ```
+    python client.py
+    ```
+
+1. When prompted, enter a prompt such as:
+
+    ```
+    Create a title and outline for a guided hiking trip in Patagonia.
+    ```
+
+    After a few moments, the routing agent delegates to the trip-title and trip-itinerary agents, and you should see a suggested title and an itinerary outline in the response.
+
+    > **Tip**: If a server fails to start because a port is already in use, stop any earlier run (Ctrl+C in the `run_all.py` terminal) and try again, or change the `*_PORT` values in `.env`.
+
+1. When you're finished, press **Ctrl+C** in the `run_all.py` terminal to stop every server, then enter `deactivate` in each terminal to exit the virtual environment.
+
+> ✅ **Checkpoint**: You've connected agents running in separate processes with the A2A protocol —
+> publishing agent cards, routing requests to the right remote agent, and returning their results.
+
+---
+
+**Next:** You've completed the optional tasks. Head back to the [lab overview](C-build-multi-agent-solutions-with-agent-framework.md) for a summary and clean-up steps.

--- a/Instructions/Exercises/D-design-agent-workflows-in-foundry.md
+++ b/Instructions/Exercises/D-design-agent-workflows-in-foundry.md
@@ -1,0 +1,149 @@
+---
+lab:
+    title: 'Design agent workflows in Microsoft Foundry'
+    description: 'Design a Tailwind Traders customer-support workflow in the Microsoft Foundry visual workflow designer: classify each ticket with an AI agent and route it to the right place. A modular lab you can complete end to end or one task at a time.'
+    level: 300
+    concepts: 'agent workflows, ticket classification, conditional routing'
+    duration: 20
+    islab: true
+    status: 'draft'
+---
+
+<!--
+PILOT NOTE (remove before publishing):
+This is a pilot of the new lab template (Core + Optional tasks) applied to
+"Lab D" = a standalone consolidation of the current exercise 06 (Build a workflow in
+Microsoft Foundry), reskinned to the Tailwind Traders scenario.
+
+This lab is built mostly in the Foundry portal's visual workflow designer, so there is
+very little code. The copy/paste assets for the portal steps live in
+Labfiles/D-design-agent-workflows-in-foundry/assets/, and the optional client app
+(starter + complete solution) lives in Labfiles/D-design-agent-workflows-in-foundry/.
+
+This landing page is the lab overview. Setup lives in D0-getting-started.md and each task is
+its own page (D1-D4) so it can be completed on its own.
+-->
+
+# Design agent workflows in Microsoft Foundry
+
+Some jobs are bigger than a single agent turn. When work needs to happen **in a sequence** —
+loop over a batch, ask an agent to make a decision, then branch on that decision — you need a
+**workflow**. In this lab you'll design one in the Microsoft Foundry **visual workflow
+designer**, no orchestration code required.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is a workflow?</summary>
+<div class="concept-body" markdown="1">
+
+A **workflow** is a UI-defined sequence of actions that can include AI agents. Instead of
+writing an orchestration loop in code, you drag and connect **nodes** — set a variable, loop
+over a list, invoke an agent, branch with if/else — in the Foundry visual designer. Agents make
+the *decisions*; the workflow controls the *flow* around them.
+
+</div>
+</details>
+
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that also runs
+guided trips. The support inbox is overflowing, so you'll design a workflow that **triages
+customer support tickets**: it reads each ticket, uses an AI agent to classify it as
+**Billing**, **Gear**, or **General** with a confidence score, and then routes it — escalating
+billing issues to a human while handling the rest automatically.
+
+You'll start with the **Core** task that gets a working classify-and-route workflow running as
+quickly as possible. From there, a set of **Optional** tasks lets you make the workflow smarter
+and connect it to your own code.
+
+> **Note**: The workflow designer in Microsoft Foundry is currently in preview. You may
+> experience some unexpected behavior, warnings, or errors. If you encounter an issue that
+> blocks your progress, you may need to start over with a new project and workflow.
+
+## What you'll learn
+
+By completing the **Core** task of this exercise, you'll be able to:
+
+- **Design a sequential workflow** in the Foundry visual designer using variables, a for-each
+  loop, and conditional (if/else) routing.
+- **Invoke an AI agent from a workflow** to classify each support ticket into a category with a
+  confidence score, using a structured JSON response.
+
+The **Optional** tasks let you additionally:
+
+- Add **conditional logic for low-confidence classifications** so uncertain tickets ask for
+  more detail instead of being routed blindly.
+- **Generate a recommended response** for non-billing tickets with a second AI agent.
+- **Call your workflow from a client application** using the Azure AI Projects SDK — as a
+  console script or a browser chat window.
+
+## How this lab is organized
+
+This lab is **modular**. Each task is written to be completed **on its own** — so you can pick a
+single task and do just that one. The optional tasks each extend the same workflow, so if you'd
+rather work straight through, you can.
+
+1. **Start with [Getting started](D0-getting-started.md)** — create your Microsoft Foundry
+   project. Every task begins from here; you only need to do this once.
+2. **Do the Core task**, then any Optional tasks. Each task lists the setup it needs so you can
+   start it independently. If you're moving straight from the previous task, a short
+   *"Continuing from a previous task?"* note lets you skip the repeated setup and keep going.
+
+## Lab at a glance
+
+Complete the **Core** task first (about **20 minutes**) — it ends with a working
+classify-and-route workflow. Then expand any **Optional** tasks that interest you. The full
+lab, including all optional tasks, takes about **55 minutes**.
+
+| Section | Task | Difficulty | Time |
+| --- | --- | --- | --- |
+| **Core** | [Task 1 – Classify and route a support ticket](D1-classify-and-route-a-ticket.md) | ★★☆ | ~20 min |
+| *Optional* | [Task 2 – Handle low-confidence tickets](D2-handle-low-confidence-tickets.md) | ★☆☆ | ~10 min |
+| *Optional* | [Task 3 – Generate recommended responses](D3-generate-recommended-responses.md) | ★★☆ | ~10 min |
+| *Optional* | [Task 4 – Call your workflow from a client app](D4-call-your-workflow-from-a-client-app.md) | ★★☆ | ~15 min |
+
+**Choosing your path** — pick the tasks that fit the time you have:
+
+- **Core only (~20 min):** do Task 1.
+- **Core + smarter workflow (~40 min):** also do **Task 2** and **Task 3** (they build on the
+  workflow from Task 1, so do Task 1 first).
+- **Everything (~55 min):** add **Task 4** to drive the finished workflow from your own code.
+
+> **One workflow, growing capabilities**: Tasks 2–3 keep editing the **same**
+> `Tailwind-Traders-Support-Triage` workflow you build in Task 1 — each adds one node or branch.
+> Task 4 then invokes that finished workflow from code, so build it first.
+
+## Summary
+
+Across this lab you:
+
+- Designed a **sequential workflow** that loops over a batch of Tailwind Traders support tickets.
+- Used an **AI agent to classify** each ticket and **conditional logic to route** it — escalating
+  billing issues while handling gear and general questions automatically.
+- (Optionally) added **low-confidence handling**, **agent-drafted responses**, and a **client
+  app** that runs the whole workflow from your own code.
+
+Together these show how workflows let agents make decisions while you stay in control of the
+flow — loops, branches, and hand-offs — without writing orchestration code.
+
+## Clean up
+
+If you're finished, delete the resources you created to avoid unnecessary Azure costs.
+
+1. In the [Azure portal](https://portal.azure.com), navigate to the resource group that contains your Foundry resource.
+1. On the toolbar, select **Delete resource group**, enter the resource group name, and confirm.
+
+> Agents created inside the workflow are removed when you delete the resource group.

--- a/Instructions/Exercises/D0-getting-started.md
+++ b/Instructions/Exercises/D0-getting-started.md
@@ -1,0 +1,81 @@
+---
+lab:
+    title: 'Getting started: set up your environment'
+    description: 'Shared setup for the Design agent workflows in Microsoft Foundry lab: create a Microsoft Foundry project. Complete this once before any task.'
+    level: 300
+    concepts: 'environment setup, Microsoft Foundry project'
+    status: 'draft'
+---
+
+# Getting started
+
+This page sets up everything the **Design agent workflows in Microsoft Foundry** lab needs.
+**Every task begins here** — complete this page first. Each task is written so you can then do
+it on its own; if you're working through the whole lab in one sitting, you only need to do this
+setup once.
+
+**Your scenario:** you work at **Tailwind Traders**, an outdoor-gear retailer that also runs
+guided trips. Across the lab you'll design a workflow that triages customer support tickets —
+classifying each one and routing it to the right place.
+
+> **Note**: The workflow designer in Microsoft Foundry is currently in preview. You may
+> experience some unexpected behavior, warnings, or errors. If you encounter an issue that
+> blocks your progress, you may need to start over with a new project and workflow.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
+- [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine (only needed for the optional client-app task)
+- [Python 3.13](https://www.python.org/downloads/) or later installed (only needed for the optional client-app task)
+- [Git](https://git-scm.com/downloads) installed on your local machine (only needed for the optional client-app task)
+
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+
+## Create a Microsoft Foundry project
+
+Microsoft Foundry uses projects to organize models, resources, data, and other assets. You need
+a project for this lab — you'll create the triage workflow inside it.
+
+1. In a web browser, open the [Foundry portal](https://ai.azure.com) at `https://ai.azure.com` and sign in using your Azure credentials.
+
+1. Ensure the **New Foundry** toggle is set to *On*.
+
+    ![Screenshot of the New Foundry toggle.](../Media/ai-foundry-toggle.png)
+
+1. You may be prompted to create a new project before continuing to the New Foundry experience. Select **Create a new project**.
+
+    ![Screenshot of the prompt to create a new project.](../Media/ai-foundry-new-project.png)
+
+    If you're not prompted, select the projects drop-down menu on the upper left, and then select **Create new project**.
+
+1. Enter a name for your Foundry project (for example, `tailwind-support-project`) and select **Create**.
+
+    Wait a few moments for the project to be created. The new Foundry portal home page should appear with your project selected.
+
+1. Close the **Welcome to the new Microsoft Foundry** dialog if it appears.
+
+    The dialog may prompt you to create an agent, which is not necessary at this time. Agents are created inside the workflow in a later step.
+
+Keep this browser tab open — you'll use it in Task 1.
+
+## Check you're ready
+
+That's the only required setup for the **Core** and optional workflow tasks (Tasks 1–3), which
+are all completed in the portal. When you're ready, head to any task:
+
+| Task | Page | Extra setup needed |
+| --- | --- | --- |
+| Task 1 – Classify and route a support ticket | [D1](D1-classify-and-route-a-ticket.md) | None (portal only) |
+| Task 2 – Handle low-confidence tickets | [D2](D2-handle-low-confidence-tickets.md) | The workflow from Task 1 |
+| Task 3 – Generate recommended responses | [D3](D3-generate-recommended-responses.md) | The workflow from Task 1 |
+| Task 4 – Call your workflow from a client app | [D4](D4-call-your-workflow-from-a-client-app.md) | VS Code, Python, and the starter code (see the task) |
+
+> **Only doing Task 4?** The optional client-app task additionally needs VS Code, Python, and
+> the starter code from `Labfiles/D-design-agent-workflows-in-foundry`. That task page walks
+> you through cloning the repo and creating a virtual environment.
+
+---
+
+**Next:** [Task 1 — Classify and route a support ticket](D1-classify-and-route-a-ticket.md)

--- a/Instructions/Exercises/D1-classify-and-route-a-ticket.md
+++ b/Instructions/Exercises/D1-classify-and-route-a-ticket.md
@@ -1,0 +1,262 @@
+---
+lab:
+    title: 'Task 1 – Classify and route a support ticket'
+    description: 'Design a sequential workflow in the Microsoft Foundry visual designer that loops over Tailwind Traders support tickets, classifies each with an AI agent, and routes it by category.'
+    level: 300
+    concepts: 'agent workflows, structured outputs, conditional routing'
+    islab: true
+    status: 'draft'
+---
+
+# Task 1 — Classify and route a support ticket
+
+*Part of the **Design agent workflows in Microsoft Foundry** lab. New here? Start with [Getting started](D0-getting-started.md).*
+
+> **What you need:** a **Microsoft Foundry project**. Don't have one yet? Complete
+> [Getting started](D0-getting-started.md) first. This task is completed entirely in the
+> portal — no local code or `.env` file is required.
+
+---
+
+You'll design a **sequential workflow** that triages Tailwind Traders support tickets. It loops
+over a batch of tickets, asks an AI agent to classify each one, and then routes it: billing
+issues are escalated to a human, while everything else stays on the automated path.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why a structured (JSON) response?</summary>
+<div class="concept-body" markdown="1">
+
+An agent normally replies with free-form text — great for people, awkward for a workflow that
+needs to *branch* on the answer. By giving the triage agent a **JSON Schema response format**,
+you force it to return a predictable object (`category`, `confidence`, `customer_issue`). The
+workflow can then read `Local.TriageOutputJson.category` and route on it reliably.
+
+</div>
+</details>
+
+## Create a customer support triage workflow
+
+In this section you'll create a workflow that triages support requests for **Tailwind
+Traders**. The workflow uses an AI agent to classify each ticket and conditional logic to route
+it.
+
+1. On the Foundry portal home page, select **Build** from the toolbar menu.
+
+1. On the left-hand menu, select **Agents**, then select the **Workflows** tab.
+
+1. In the upper right corner, select **Create** > **Blank workflow** to create a new blank workflow.
+
+    The type of workflow you'll create in this exercise is a sequential workflow. However, starting with a blank workflow simplifies the process of adding the necessary nodes.
+
+1. Select **Save** in the visualizer to save your new workflow. In the dialog box, enter the name *Tailwind-Traders-Support-Triage*, and then select **Save**.
+
+## Create a ticket array variable
+
+1. In the workflow visualizer, select the **+** (plus) icon to add a new node.
+
+1. In the workflow actions menu, under **Data transformation**, select **Set variable** to add a node that initializes an array of support tickets.
+
+1. In the **Set variable** node editor, enter a name for a new variable, such as *SupportTickets*.
+
+    ![Screenshot of creating a new variable in the Set variable node.](../Media/node-new-variable.png)
+
+    The new variable should appear as `Local.SupportTickets`.
+
+1. In the **To value** field, enter the following array of sample Tailwind Traders support tickets:
+
+    ```output
+   [
+    "The GPS on my TrailMate hiking watch keeps losing signal even after I did a full factory reset.",
+    "Is there a way to see all of my past orders and download them as receipts?",
+    "I was charged twice for the same tent order last Friday and my card statement shows two payments. Can someone fix this?"]
+    ```
+
+    These three tickets deliberately cover one of each category you'll route on: **Gear**, **General**, and **Billing**.
+
+1. Select **Done** to save the node.
+
+## Add a for-each loop to process tickets
+
+1. Select the **+** (plus) icon below the **Set variable** node and create a **For each** node to process each support ticket in the array.
+
+1. In the **For each** node editor, set the **Select the items to loop for each** field to the variable you created earlier: `Local.SupportTickets`.
+
+1. In the **Loop Value Variable** field, create a new variable named `CurrentTicket`.
+
+1. Select **Done** to save the node.
+
+## Invoke an agent to classify the ticket
+
+1. Select the **+** (plus) icon within the **For each** node to add a new node that classifies the current support ticket.
+
+1. In the workflow actions menu, under **Invoke**, select **Agent** to add an agent node.
+
+1. In the **Agent** node editor, under **Select an agent**, select **Create new agent**.
+
+1. Enter an agent name such as *Triage-Agent* and select **Create**.
+
+### Configure the agent settings
+
+1. In the editor, under **Details**, select the **Parameters** button near the model name.
+
+    ![Screenshot of the Parameters button in the agent editor.](../Media/agent-parameters.png)
+
+1. In the **Parameters** pane, next to **Text format**, select **JSON Schema**.
+
+1. In the **Add response format** pane, enter the following definition and select **Save**:
+
+    ```json
+    {
+    "name": "category_response",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "customer_issue": {
+                "type": "string"
+            },
+            "category": {
+                "type": "string"
+            },
+            "confidence": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "customer_issue",
+            "category",
+            "confidence"
+        ]
+    },
+    "strict": true
+    }
+    ```
+
+1. In the Agent Details pane, set the **Instructions** field to the following prompt:
+
+    ```output
+    Classify the customer's support message into exactly ONE category from the list below. Provide a confidence score from 0 to 1.
+
+    Billing
+    - Charges, refunds, duplicate payments
+    - Missing or incorrect refunds on an order
+    - Being charged the wrong price for an order or a gear rental
+
+    Gear
+    - Faulty, damaged, or defective equipment
+    - Product setup, pairing, or usage problems
+    - Unexpected behavior from gear or gadgets
+
+    General
+    - How-to questions
+    - Product, trip, or stock availability
+    - Order history, receipts, returns, or website navigation
+
+    Important rules
+    - Questions about viewing, downloading, or exporting orders or receipts are General, not Billing
+    - Billing ONLY applies when money was charged, refunded, or paid incorrectly
+    ```
+
+1. Select **Node settings** to configure the input and output of the agent.
+
+1. Set the **Input message** field to the `Local.CurrentTicket` variable.
+
+1. Under **Save agent output message as**, create a new variable named `TriageOutputText`.
+
+1. Under **Save the output json_object as**, create a new variable named `TriageOutputJson`.
+
+1. Select **Done** to save the node.
+
+## Route the ticket based on category
+
+In this section you'll add conditional logic to route each ticket based on its classified
+category. Billing tickets are escalated to a human; other tickets stay on the automated path.
+
+1. Select the **+** (plus) icon below the **Invoke agent** node to add a new node that routes the ticket.
+
+1. In the workflow actions menu, under **Flow**, select **If/Else** to add a conditional logic node.
+
+1. In the **If/Else** node editor, select the **Add a path** button to create the if-branch condition, then select the pencil icon to edit the condition.
+
+1. Set the **If Condition** to the following expression to check if the ticket category is "Billing":
+
+    ```output
+    Local.TriageOutputJson.category = "Billing"
+    ```
+
+1. Select **Done** to save the node.
+
+### Escalate billing tickets
+
+1. Select the **+** (plus) icon under the **If** branch of the **If/Else** node to add a new node.
+
+1. In the workflow actions menu, under **Basics**, select **Deliver a message** to add a send message activity.
+
+1. In the **Deliver a message** node editor, set the **Message to send** field to the following response:
+
+    ```output
+   Escalate billing issue to the Tailwind Traders orders team.
+    ```
+
+1. Select **Done** to save the node.
+
+### Handle non-billing tickets automatically
+
+1. Select the **+** (plus) icon under the **Else** branch of the **If/Else** node to add a new node.
+
+1. In the workflow actions menu, under **Basics**, select **Deliver a message** to add a send message activity.
+
+1. In the **Deliver a message** node editor, set the **Message to send** field to the following response:
+
+    ```output
+   Handling automatically: "{Local.CurrentTicket}"
+    ```
+
+    > In [Task 3](D3-generate-recommended-responses.md) you'll replace this placeholder message with a second AI agent that drafts a real, category-appropriate reply.
+
+1. Select **Done** to save the node.
+
+## Preview the workflow
+
+1. Select the **Save** button to save all changes to your workflow.
+
+1. Select the **Preview** button to start the workflow.
+
+1. In the chat window that appears, enter some text to trigger the workflow, such as `Start processing support tickets.`
+
+1. Observe the workflow as it processes each support ticket in sequence. Review the messages generated by the workflow in the chat window.
+
+    You should see the billing ticket (the duplicate tent charge) flagged for escalation, while the gear and general tickets are handled on the automated path. For example:
+
+    ```output
+    Current Ticket:
+    I was charged twice for the same tent order last Friday and my card statement shows two payments. Can someone fix this?
+
+
+    Copilot said:
+    Escalate billing issue to the Tailwind Traders orders team.
+    ```
+
+> ✅ **Checkpoint**: Your workflow loops over a batch of tickets, classifies each one with the
+> Triage-Agent, and routes it by category — escalating billing issues while handling the rest
+> automatically. You've built a working classify-and-route workflow entirely in the portal.
+
+---
+
+**Next (optional):** [Task 2 — Handle low-confidence tickets](D2-handle-low-confidence-tickets.md)

--- a/Instructions/Exercises/D2-handle-low-confidence-tickets.md
+++ b/Instructions/Exercises/D2-handle-low-confidence-tickets.md
@@ -1,0 +1,116 @@
+---
+lab:
+    title: 'Task 2 – Handle low-confidence tickets'
+    description: 'Add conditional logic to the Tailwind Traders triage workflow so tickets the agent is unsure about ask for more detail instead of being routed blindly.'
+    level: 300
+    concepts: 'confidence scores, conditional logic, if/else branching'
+    islab: true
+    status: 'draft'
+---
+
+# Task 2 — Handle low-confidence tickets
+
+*Part of the **Design agent workflows in Microsoft Foundry** lab. New here? Start with [Getting started](D0-getting-started.md).*
+
+> **What you need:** the **Tailwind-Traders-Support-Triage** workflow from
+> [Task 1](D1-classify-and-route-a-ticket.md), open in the Foundry visual designer. Haven't
+> built it yet? Do [Task 1](D1-classify-and-route-a-ticket.md) first — it takes about 20
+> minutes and this task adds one branch to it. This task is completed entirely in the portal.
+>
+> > **Continuing from a previous task?** If you just finished Task 1 in the same workflow, it's
+> > already open and saved — go straight to **Add a confidence gate** below.
+
+---
+
+The Triage-Agent returns a **confidence score** alongside each category. A low score means the
+agent is guessing — routing that ticket automatically risks sending it the wrong way. In this
+task you'll add a **confidence gate**: only well-classified tickets continue to routing;
+uncertain ones are sent back for more detail.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why gate on confidence?</summary>
+<div class="concept-body" markdown="1">
+
+A classifier is only as useful as it is *certain*. Acting on a low-confidence guess can escalate
+the wrong ticket or auto-reply with irrelevant help. A confidence threshold turns "I think this
+is Billing" into a safe default: **when unsure, ask a human or the customer for more** instead of
+committing. `0.6` is a reasonable starting threshold — raise it to be more cautious.
+
+</div>
+</details>
+
+## Add a confidence gate
+
+You'll insert a new **If/Else** node between the Triage-Agent node and the category routing you
+built in Task 1. Its condition checks the confidence score; the routing you already built moves
+under the high-confidence (**If**) branch.
+
+1. In the visualizer, select the **+** (plus) icon **directly below the Invoke agent node** (and above the category-routing **If/Else** you added in Task 1) to add a new node.
+
+1. In the workflow actions menu, under **Flow**, select **If/Else** to add a conditional logic node.
+
+1. In the **If/Else** node editor, select the **Add a path** button to create the if-branch condition, then select the pencil icon to edit the condition.
+
+1. Set the **Condition** field to the following expression to check whether the confidence score is above 0.6:
+
+    ```output
+   Local.TriageOutputJson.confidence > 0.6
+    ```
+
+1. Select **Done** to save the node.
+
+## Move the category routing under the If branch
+
+The high-confidence path should do the routing you already built. Place the category-routing
+**If/Else** (and its **Escalate** / **Handle automatically** branches from Task 1) **under the
+If branch** of your new confidence node.
+
+- If the designer lets you drag the existing category **If/Else** node into the **If** branch, do that.
+- If not, it's quick to rebuild: under the **If** branch, add an **If/Else** node with the condition `Local.TriageOutputJson.category = "Billing"`, then re-add the two **Deliver a message** nodes from [Task 1](D1-classify-and-route-a-ticket.md#route-the-ticket-based-on-category) (escalate on the **If** branch; handle automatically on the **Else** branch).
+
+> The goal is this shape: **Agent → If confidence > 0.6 → (If) route by category / (Else) ask for more detail.**
+
+## Recommend additional info for low-confidence tickets
+
+1. In the visualizer, under the **Else** branch of your new confidence **If/Else** node, select the **+** (plus) icon to add a new node.
+
+1. In the workflow actions menu, under **Basics**, select **Deliver a message** to add a send message activity.
+
+1. In the **Deliver a message** node editor, set the **Message to send** field to the following response:
+
+    ```output
+   The support ticket classification has low confidence. Requesting more details about the issue: "{Local.CurrentTicket}"
+    ```
+
+1. Select **Done** to save the node.
+
+## Preview the workflow
+
+1. Select the **Save** button to save all changes to your workflow.
+
+1. Select the **Preview** button, then enter `Start processing support tickets.` to trigger the workflow.
+
+1. Watch how each ticket now passes through the confidence gate first. Tickets the agent is confident about are routed by category as before; any low-confidence ticket instead receives the "requesting more details" message.
+
+> ✅ **Checkpoint**: Your workflow now protects against uncertain classifications — only
+> confidently classified tickets are routed, and the rest are sent back for more detail.
+
+---
+
+**Next (optional):** [Task 3 — Generate recommended responses](D3-generate-recommended-responses.md)

--- a/Instructions/Exercises/D2-handle-low-confidence-tickets.md
+++ b/Instructions/Exercises/D2-handle-low-confidence-tickets.md
@@ -16,9 +16,9 @@ lab:
 > [Task 1](D1-classify-and-route-a-ticket.md), open in the Foundry visual designer. Haven't
 > built it yet? Do [Task 1](D1-classify-and-route-a-ticket.md) first — it takes about 20
 > minutes and this task adds one branch to it. This task is completed entirely in the portal.
->
-> > **Continuing from a previous task?** If you just finished Task 1 in the same workflow, it's
-> > already open and saved — go straight to **Add a confidence gate** below.
+
+> **Continuing from a previous task?** If you just finished Task 1 in the same workflow, it's
+> already open and saved — go straight to **Add a confidence gate** below.
 
 ---
 

--- a/Instructions/Exercises/D3-generate-recommended-responses.md
+++ b/Instructions/Exercises/D3-generate-recommended-responses.md
@@ -1,0 +1,135 @@
+---
+lab:
+    title: 'Task 3 – Generate recommended responses'
+    description: 'Add a second AI agent to the Tailwind Traders triage workflow that drafts a category-appropriate support reply for non-billing tickets.'
+    level: 300
+    concepts: 'agent workflows, multi-agent handoff, response generation'
+    islab: true
+    status: 'draft'
+---
+
+# Task 3 — Generate recommended responses
+
+*Part of the **Design agent workflows in Microsoft Foundry** lab. New here? Start with [Getting started](D0-getting-started.md).*
+
+> **What you need:** the **Tailwind-Traders-Support-Triage** workflow from
+> [Task 1](D1-classify-and-route-a-ticket.md) (optionally with the confidence gate from
+> [Task 2](D2-handle-low-confidence-tickets.md)), open in the Foundry visual designer. Haven't
+> built it yet? Do [Task 1](D1-classify-and-route-a-ticket.md) first. This task is completed
+> entirely in the portal.
+>
+> > **Continuing from a previous task?** If you just finished Task 1 or Task 2 in the same
+> > workflow, it's already open and saved — go straight to **Add a resolution agent** below.
+
+---
+
+So far, non-billing tickets just get a placeholder "handling automatically" message. In this
+task you'll replace that with a **second AI agent** — a **Resolution-Agent** — that reads the
+ticket and drafts a real, category-appropriate support reply. This is a simple **agent
+hand-off**: the Triage-Agent decides *what kind* of ticket it is; the Resolution-Agent decides
+*how to respond*.
+
+<style>
+/* "Ask Anton" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#6b4ba1; background:#6b4ba112;
+  border:1px solid #6b4ba133; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Anton: "; font-weight:700;
+  padding-left:1.5em;
+  background:url("../Media/anton-avatar.png") left center / 1.25em 1.25em no-repeat; }
+details.concept > summary:hover { background:#6b4ba1; color:#fff; border-color:#6b4ba1; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #6b4ba133; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#6b4ba108; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why use a second agent?</summary>
+<div class="concept-body" markdown="1">
+
+You *could* ask one agent to both classify and reply, but splitting the work keeps each agent
+focused and easy to tune. The Triage-Agent is constrained to emit clean JSON for routing; the
+Resolution-Agent is free to write natural, on-brand prose. Passing the triage output into the
+resolution step is a **hand-off** — the same pattern that scales up to full multi-agent systems.
+
+</div>
+</details>
+
+## Add a resolution agent
+
+You'll replace the **Handle non-billing tickets automatically** message from Task 1 with an
+agent node on the same **Else** branch (the non-billing path).
+
+1. In the visualizer, find the **Deliver a message** node on the **Else** branch of the category-routing **If/Else** node (the one that sends `Handling automatically: "{Local.CurrentTicket}"`). Delete it.
+
+    > If you'd rather keep it, you can instead add the agent node **below** that message — but replacing it keeps the branch clean.
+
+1. On that same **Else** branch, select the **+** (plus) icon to add a new node.
+
+1. In the workflow actions menu, under **Invoke**, select **Agent** to add an agent node.
+
+1. In the **Agent** node editor, select **Create new agent**.
+
+1. Enter an agent name such as *Resolution-Agent* and select **Create**.
+
+1. In the agent editor, set the **Instructions** field to the following prompt:
+
+    ```output
+    You are a customer support resolution assistant for Tailwind Traders, an outdoor-gear retailer that also runs guided trips.
+
+    Your task is to draft a clear, professional, and friendly support response based on the issue category and customer message.
+
+    Guidelines:
+    If the issue category is Gear:
+    Suggest 1-2 common troubleshooting steps at a high level.
+
+    Avoid asking for serial numbers, order numbers, or sensitive data.
+
+    Do not imply fault by the customer.
+    If the issue category is General:
+    Provide a concise, helpful explanation or guidance.
+    Keep the response under 5 sentences.
+
+    Tone:
+    Professional, calm, and supportive
+    Clear and concise
+    No emojis
+
+    Output:
+    Return only the drafted response text.
+    Do not include internal reasoning or analysis.
+    ```
+
+1. Select **Node settings** to configure the input and output of the agent.
+
+1. Set the **Input message** field to the `Local.TriageOutputText` variable.
+
+1. Under **Save agent output message as**, create a new variable named `ResolutionOutputText`.
+
+1. Select **Done** to save the node.
+
+## Preview the workflow
+
+1. Select the **Save** button to save all changes to your workflow.
+
+1. Select the **Preview** button, then enter `Start processing support tickets.` to trigger the workflow.
+
+1. Watch the workflow run. Billing tickets are still escalated, but non-billing tickets (the gear and general questions) now receive a drafted response from the Resolution-Agent. For example:
+
+    ```output
+    Current Ticket:
+    The GPS on my TrailMate hiking watch keeps losing signal even after I did a full factory reset.
+
+
+    Copilot said:
+    Thanks for reaching out about your TrailMate watch losing GPS signal. Try taking the watch outdoors with a clear view of the sky and giving it a minute to reacquire satellites, and make sure it's running the latest firmware from the Tailwind Traders companion app. If it still can't hold a signal after that, reply here and we'll arrange a closer look.
+    ```
+
+> ✅ **Checkpoint**: Your workflow now hands non-billing tickets to a second agent that drafts a
+> category-appropriate reply — a Triage-Agent to *classify* and a Resolution-Agent to *respond*.
+
+---
+
+**Next (optional):** [Task 4 — Call your workflow from a client app](D4-call-your-workflow-from-a-client-app.md)

--- a/Instructions/Exercises/D3-generate-recommended-responses.md
+++ b/Instructions/Exercises/D3-generate-recommended-responses.md
@@ -17,9 +17,9 @@ lab:
 > [Task 2](D2-handle-low-confidence-tickets.md)), open in the Foundry visual designer. Haven't
 > built it yet? Do [Task 1](D1-classify-and-route-a-ticket.md) first. This task is completed
 > entirely in the portal.
->
-> > **Continuing from a previous task?** If you just finished Task 1 or Task 2 in the same
-> > workflow, it's already open and saved — go straight to **Add a resolution agent** below.
+
+> **Continuing from a previous task?** If you just finished Task 1 or Task 2 in the same
+> workflow, it's already open and saved — go straight to **Add a resolution agent** below.
 
 ---
 

--- a/Instructions/Exercises/D4-call-your-workflow-from-a-client-app.md
+++ b/Instructions/Exercises/D4-call-your-workflow-from-a-client-app.md
@@ -1,0 +1,196 @@
+---
+lab:
+    title: 'Task 4 – Call your workflow from a client app'
+    description: 'Invoke your saved Tailwind Traders triage workflow from your own code with the Azure AI Projects SDK — as a console script or a browser chat window.'
+    level: 300
+    concepts: 'Azure AI Projects SDK, Responses API, workflow invocation'
+    islab: true
+    status: 'draft'
+---
+
+# Task 4 — Call your workflow from a client app
+
+*Part of the **Design agent workflows in Microsoft Foundry** lab. New here? Start with [Getting started](D0-getting-started.md).*
+
+> **Set up (start here):** This task needs the **Tailwind-Traders-Support-Triage** workflow
+> from [Task 1](D1-classify-and-route-a-ticket.md) (Tasks 2 and 3 optional but recommended),
+> **plus** VS Code, Python, and the starter code. If you haven't built the workflow yet, do
+> [Task 1](D1-classify-and-route-a-ticket.md) first.
+>
+> > **Continuing from a previous task?** Your workflow is already built and saved in the
+> > portal. You still need to get the starter code and set `PROJECT_ENDPOINT` (below), since the
+> > earlier tasks were portal-only.
+
+---
+
+**Goal**: Now that your workflow runs in the portal, invoke it from **your own code** using the
+Azure AI Projects SDK — so you can integrate triage into an application or automate it.
+
+**Concept reinforced**: driving a saved workflow programmatically — you create a conversation,
+reference the workflow **by name**, stream its events, and print the result.
+
+## Get the starter code
+
+1. In VS Code, open the Command Palette (**Ctrl+Shift+P**), run **Git: Clone**, and enter:
+
+    ```
+    https://github.com/MicrosoftLearning/mslearn-ai-agents.git
+    ```
+
+1. Open the cloned repo, then **File > Open Folder** and select `mslearn-ai-agents/Labfiles/D-design-agent-workflows-in-foundry/Python`.
+
+1. Right-click **requirements.txt** and choose **Open in Integrated Terminal**. Then create a virtual environment and install packages:
+
+    ```
+    python -m venv labenv
+    .\labenv\Scripts\Activate.ps1
+    pip install -r requirements.txt
+    ```
+
+## Configure the application
+
+1. In the browser, return to the workflow visualizer in the Foundry portal.
+
+1. Select **Code** in the upper right corner of the visualizer. Then select **.env variables** to view the environment variables required to connect to your Foundry project from code.
+
+1. Copy the value of the **AZURE_EXISTING_AIPROJECT_ENDPOINT** variable — this is the endpoint URL for your Foundry project.
+
+1. In VS Code, copy **.env.example** to **.env**, then open **.env** and set `PROJECT_ENDPOINT` to the endpoint you just copied. Save the file (**Ctrl+S**).
+
+## Invoke the workflow from code
+
+Open **workflow.py**. It already contains a `print_workflow_output` helper that formats the
+results; you'll fill in the connection and invocation using the comments in the file.
+
+> **Try it first**: Before revealing the solution, predict — how does the client tell the
+> Responses API to run a *workflow* rather than a single agent? (Hint: look at how Task 1's
+> agent node referenced an agent by name.)
+
+<details markdown="1">
+<summary>Show a solution</summary>
+
+Work through the comments in **workflow.py**:
+
+1. Find the comment **Add references** and add the imports:
+
+    ```python
+    # Add references
+    from azure.identity import DefaultAzureCredential
+    from azure.ai.projects import AIProjectClient
+    ```
+
+1. Find the comment **Connect to the AI Project client** and add:
+
+    ```python
+    # Connect to the AI Project client
+    with (
+        DefaultAzureCredential() as credential,
+        AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
+        project_client.get_openai_client() as openai_client,
+    ):
+    ```
+
+    > **Tip**: When adding the subsequent code, keep the right level of indentation.
+
+1. Find the comment **Specify the workflow** and add (use the exact name you saved in Task 1):
+
+    ```python
+        # Specify the workflow
+        workflow = {
+            "name": "Tailwind-Traders-Support-Triage"
+        }
+    ```
+
+1. Find the comment **Create a conversation and run the workflow** and add:
+
+    ```python
+        # Create a conversation and run the workflow
+        conversation = openai_client.conversations.create()
+        print(f"Created conversation (id: {conversation.id})")
+
+        stream = openai_client.responses.create(
+            conversation=conversation.id,
+            extra_body={"agent_reference": {"name": workflow["name"], "type": "agent_reference"}},
+            input="Start",
+            stream=True,
+        )
+    ```
+
+1. Find the comment **Process events from the workflow run** and add:
+
+    ```python
+        # Process events from the workflow run
+        for event in stream:
+            if (event.type == "response.completed"):
+                print("\nResponse completed:")
+                response = openai_client.responses.retrieve(event.response.id)
+                print_workflow_output(response.output_text)
+    ```
+
+1. Find the comment **Clean up resources** and add:
+
+    ```python
+        # Clean up resources
+        openai_client.conversations.delete(conversation_id=conversation.id)
+        print("\nConversation deleted")
+    ```
+
+1. Save the file (**Ctrl+S**).
+
+</details>
+
+## Test the client application
+
+1. In the integrated terminal, sign in and run the app:
+
+    ```
+    az login
+    ```
+
+    ```
+   python workflow.py
+    ```
+
+1. Wait a moment for the workflow to process the tickets. You should see console output for each ticket — its category, confidence, and the drafted response or escalation. For example:
+
+    ```output
+    ================================================================================
+    Ticket 1: Gear (93% confidence)
+    --------------------------------------------------------------------------------
+    Issue: The GPS on my TrailMate hiking watch keeps losing signal even after I did a full factory reset.
+
+    Response:
+    Thanks for reaching out about your TrailMate watch losing GPS signal. Try taking the watch outdoors with a clear view of the sky...
+    ================================================================================
+    ```
+
+1. When you're finished, enter `deactivate` in the terminal to exit the virtual environment.
+
+## Optional: run it as a web chat app
+
+The lab also ships a **web chat** version, `workflow_ui.py` (in the `Solution/Python` folder),
+that runs the same invocation behind the shared Gradio chat shell (`tailwind_ui.py`) — so your
+workflow feels like a real app. You provide a `respond()` function; the shell turns it into a
+browser chat window. You don't edit `tailwind_ui.py`.
+
+To try it, copy `workflow_ui.py` next to your `workflow.py`, then run:
+
+```
+python workflow_ui.py
+```
+
+Your browser opens a chat window at `http://localhost:7860`. Type any message (for example,
+`Start processing support tickets`) and the classified, routed tickets render inline. Close the
+tab and press **Ctrl+C** in the terminal to stop the app.
+
+> The complete, ready-to-run versions of both files are in
+> `Labfiles/D-design-agent-workflows-in-foundry/Solution/Python`.
+
+**Stretch**: after each response, print the number of tickets escalated versus auto-resolved.
+
+> ✅ **Checkpoint**: You've driven your saved Foundry workflow from your own code — creating a
+> conversation, referencing the workflow by name, and printing (or chatting) its results.
+
+---
+
+**Back to the overview:** [Design agent workflows in Microsoft Foundry](D-design-agent-workflows-in-foundry.md)

--- a/Instructions/Exercises/D4-call-your-workflow-from-a-client-app.md
+++ b/Instructions/Exercises/D4-call-your-workflow-from-a-client-app.md
@@ -16,10 +16,10 @@ lab:
 > from [Task 1](D1-classify-and-route-a-ticket.md) (Tasks 2 and 3 optional but recommended),
 > **plus** VS Code, Python, and the starter code. If you haven't built the workflow yet, do
 > [Task 1](D1-classify-and-route-a-ticket.md) first.
->
-> > **Continuing from a previous task?** Your workflow is already built and saved in the
-> > portal. You still need to get the starter code and set `PROJECT_ENDPOINT` (below), since the
-> > earlier tasks were portal-only.
+
+> **Continuing from a previous task?** Your workflow is already built and saved in the
+> portal. You still need to get the starter code and set `PROJECT_ENDPOINT` (below), since the
+> earlier tasks were portal-only.
 
 ---
 
@@ -56,6 +56,14 @@ reference the workflow **by name**, stream its events, and print the result.
 1. Copy the value of the **AZURE_EXISTING_AIPROJECT_ENDPOINT** variable — this is the endpoint URL for your Foundry project.
 
 1. In VS Code, copy **.env.example** to **.env**, then open **.env** and set `PROJECT_ENDPOINT` to the endpoint you just copied. Save the file (**Ctrl+S**).
+
+1. Confirm your environment is ready. From the same **Python** folder terminal, run:
+
+    ```
+    python ..\setup\check_env.py --task 4
+    ```
+
+    You should see `[OK ] PROJECT_ENDPOINT`. If it reports the value missing, revisit the step above.
 
 ## Invoke the workflow from code
 

--- a/Labfiles/07-agent-framework/python/requirements.txt
+++ b/Labfiles/07-agent-framework/python/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv
 azure-identity==1.25.3
-agent-framework==1.12.1
+agent-framework==1.9.0

--- a/Labfiles/07-agent-framework/python/requirements.txt
+++ b/Labfiles/07-agent-framework/python/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv
 azure-identity==1.25.3
-agent-framework==1.9.0
+agent-framework==1.12.1

--- a/Labfiles/08-agent-orchestration/Python/requirements.txt
+++ b/Labfiles/08-agent-orchestration/Python/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv
 azure-identity
-agent-framework==1.12.1
+agent-framework==1.9.0

--- a/Labfiles/08-agent-orchestration/Python/requirements.txt
+++ b/Labfiles/08-agent-orchestration/Python/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv
 azure-identity
-agent-framework==1.9.0
+agent-framework==1.12.1

--- a/Labfiles/A-build-and-extend-ai-agents/Python/requirements.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/requirements.txt
@@ -6,4 +6,4 @@ mcp
 fastmcp
 uvicorn
 gradio==6.20.0
-agent-framework==1.9.0
+agent-framework==1.12.1

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/requirements.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/requirements.txt
@@ -6,4 +6,4 @@ mcp
 fastmcp
 uvicorn
 gradio==6.20.0
-agent-framework==1.9.0
+agent-framework==1.12.1

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/.env.example
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/.env.example
@@ -1,0 +1,13 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# In VS Code, Foundry Toolkit > right-click your active project > Copy Project Endpoint,
+# or copy it from the Microsoft Foundry portal project overview page.
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (for example, gpt-4o) — used by Task 4 (Work IQ)
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here
+
+# The enterprise-knowledge agent you create in Task 1 — used by the code clients
+AGENT_NAME=tailwind-knowledge-agent

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-backpacks-guide.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-backpacks-guide.md
@@ -1,0 +1,183 @@
+# Tailwind Traders - Backpacks & Hiking Gear Guide 2026
+
+## Your Complete Backpack Selection Guide
+
+Welcome to the Tailwind Traders backpack collection. Whether a customer is planning a day hike or a month-long expedition, we have the perfect pack to carry their gear comfortably and efficiently. Store staff can use this guide to match customers to the right pack size and features.
+
+---
+
+## Understanding Backpack Sizing
+
+### How to Measure Torso Length
+1. Locate the C7 vertebra (the bony bump at the base of the neck when the head tilts forward).
+2. Place hands on the hip bones at the iliac crest.
+3. Measure the distance between these two points.
+
+**Size Chart:**
+- **X-Small:** 15-16 inches (38-41 cm)
+- **Small:** 16-17 inches (41-43 cm)
+- **Medium:** 17-19 inches (43-48 cm)
+- **Large:** 19-21 inches (48-53 cm)
+- **X-Large:** 21+ inches (53+ cm)
+
+---
+
+## Daypacks (20-35 Liters)
+
+### SummitTrail 25L Daypack
+**SKU:** PACK-ST-25
+**Price:** $89.99
+**Sizes:** One Size (fits most)
+
+Perfect for day hikes, urban exploring, and daily commutes.
+
+- **Capacity:** 25 liters
+- **Weight:** 1.3 lbs (590g)
+- **Materials:** 210D ripstop nylon body, water-resistant coating
+- **Features:** Breathable mesh back panel, hydration bladder compatible (3L), two side bottle pockets, trekking pole attachment
+- **Available Colors:** Forest Green, Slate Blue, Charcoal Grey, Sunset Orange
+
+**Best For:** Day hiking, biking, travel
+
+**Warranty:** 3-year limited warranty
+
+---
+
+### Explorer Pro 32L
+**SKU:** PACK-EP-32
+**Price:** $129.99
+**Sizes:** S/M, M/L
+
+A versatile technical daypack for serious hikers who need more capacity and features.
+
+- **Capacity:** 32 liters
+- **Weight:** 2.1 lbs (950g)
+- **Materials:** 210D ripstop nylon with DWR finish, YKK zippers
+- **Features:** AirFlow suspended mesh back panel, padded hip belt with pockets, dedicated hydration sleeve, ice axe loop
+- **Available Colors:** Alpine Blue, Summit Black, Trail Red
+
+**Best For:** Technical day hikes, scrambling, winter hiking
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Weekend Backpacks (40-50 Liters)
+
+### TrailMaster 45L
+**SKU:** PACK-TM-45
+**Price:** $189.99
+**Sizes:** S, M, L, XL
+
+The ideal pack for 1-3 night trips, offering excellent value and comfort.
+
+- **Capacity:** 45 liters (2,745 cubic inches)
+- **Weight:** 3.8 lbs (1.72 kg)
+- **Load Range:** 25-40 lbs (11-18 kg)
+- **Features:** Adjustable torso length, removable top lid, sleeping bag compartment, integrated rain cover, hydration compatible
+- **Available Colors:** Forest Green, Navy Blue, Grey/Black
+
+**Best For:** Weekend backpacking, overnight trips, hut-to-hut hiking
+
+**Warranty:** 5-year limited warranty
+
+---
+
+### Alpine Trekker 50L
+**SKU:** PACK-AT-50
+**Price:** $249.99
+**Sizes:** S, M, L, XL
+
+Premium weekend pack with enhanced comfort and technical features.
+
+- **Capacity:** 50 liters + 10L extendable collar = 60L max
+- **Weight:** 4.2 lbs (1.9 kg)
+- **Features:** FreeFloat adjustable suspension, 3D-molded foam back panel, built-in rain cover, QuickAdjust torso system
+- **Available Colors:** Summit Black, Mountain Grey, Alpine Blue, Terra Red
+
+**Best For:** Weekend backpacking, alpine trekking, shoulder-season trips
+
+**Warranty:** 10-year limited warranty
+
+---
+
+## Expedition Backpacks (60-75 Liters)
+
+### Expedition Pro 65L
+**SKU:** PACK-XP-65
+**Price:** $349.99
+**Sizes:** S, M, L, XL
+
+Our flagship expedition pack designed for extended trips and heavy loads. **Available in all sizes including XL.**
+
+- **Capacity:** 65 liters + 15L extendable collar = 80L max
+- **Weight:** 5.2 lbs (2.36 kg)
+- **Load Range:** 35-65 lbs (16-29 kg)
+- **Frame:** Internal aluminum stays (removable and adjustable)
+- **Features:** ExoFrame external aluminum perimeter frame, dual-access main compartment, integrated rain cover, crampon patch, helmet attachment straps
+- **Available Colors:** Expedition Black, Mountain Blue, Alpine Grey
+
+**Best For:** Week-long trips, mountaineering, international trekking
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+### Summit Master 75L
+**SKU:** PACK-SM-75
+**Price:** $429.99
+**Sizes:** M, L, XL
+
+Our largest and most capable pack for extended expeditions and high-altitude mountaineering. **Available in XL.**
+
+- **Capacity:** 75 liters + 15L collar extension = 90L max
+- **Weight:** 6.1 lbs (2.77 kg)
+- **Load Range:** 40-80 lbs (18-36 kg)
+- **Frame:** Dual aluminum stay system with HDPE framesheet
+- **Features:** Roll-top closure plus lid, triple compartment design, full-length side zip access, ski/snowboard carrying system
+- **Available Colors:** Expedition Black, Ice Blue
+
+**Best For:** Extended expeditions, high-altitude mountaineering, guided treks
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+## Backpack Accessories
+
+### Rain Cover Collection
+**SKU:** ACC-RC-SERIES
+**Price Range:** $19.99 - $34.99
+
+Custom-fit rain covers available for all Tailwind Traders backpack sizes (Small through X-Large). High-visibility colors with reflective accents.
+
+### Hydration Bladder - 3L
+**SKU:** ACC-HYD-3L
+**Price:** $39.99
+
+BPA-free, taste-free 3-liter hydration bladder with wide opening, insulated tube, and magnetic tube clip. Lifetime warranty against leaks.
+
+---
+
+## Fitting a Backpack
+
+1. **Adjust torso length** so the hip belt sits on the iliac crest.
+2. **Hip belt:** load about 20 lbs and tighten until 80% of the weight is on the hips.
+3. **Shoulder straps:** snug but not tight; anchors 1-2 inches below the shoulder tops.
+4. **Load lifters:** adjust to a 45-degree angle to pull weight off the shoulders.
+5. **Sternum strap:** position 2-3 inches below the collarbone.
+
+> **Pro Tip:** Offer customers an in-store professional fitting. Trained staff help find the perfect pack and ensure optimal fit.
+
+---
+
+## Contact Information
+
+**Tailwind Traders**
+Customer Service: 1-800-TAILWIND
+Email: backpacks@tailwindtraders.com
+Website: www.tailwindtraders.com/backpacks
+
+*All specifications are approximate. Colors may vary from images shown.*
+
+**Last Updated:** January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-camping-accessories.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-camping-accessories.md
@@ -1,0 +1,199 @@
+# Tailwind Traders - Camping Accessories & Equipment 2026
+
+## Essential Gear for Every Adventure
+
+Complete a customer's outdoor setup with the Tailwind Traders collection of camping accessories. From sleeping comfort to cooking essentials, we have everything needed for a successful camping experience. Store staff can use this document to answer accessory questions and build add-on recommendations.
+
+---
+
+## Sleeping Systems
+
+### Sleeping Bags
+
+#### Alpine Down -15F
+**SKU:** SLP-AD-15
+**Price:** $299.99
+**Temperature Rating:** -15F / -26C (Comfort)
+
+Premium 800-fill power down sleeping bag for cold weather camping.
+- **Fill:** 800-fill power RDS-certified goose down
+- **Weight:** 3.2 lbs (1.45 kg)
+- **Features:** Mummy shape, insulated draft tube, compression stuff sack included
+
+**Best For:** Winter camping, high-altitude mountaineering
+
+**Warranty:** 5-year limited warranty
+
+#### TrailRest 20F
+**SKU:** SLP-TR-20
+**Price:** $129.99
+**Temperature Rating:** 20F / -7C (Comfort)
+
+Affordable synthetic bag for three-season camping.
+- **Fill:** TailwindTherm synthetic insulation
+- **Weight:** 4.1 lbs (1.86 kg)
+- **Features:** Semi-rectangular shape, two-way zipper, machine washable
+
+**Best For:** Spring through fall camping, car camping, scout trips
+
+**Warranty:** 3-year limited warranty
+
+#### Summer Lite 40F
+**SKU:** SLP-SL-40
+**Price:** $79.99
+**Temperature Rating:** 40F / 4C (Comfort)
+
+Lightweight bag for warm weather camping and backpacking.
+- **Weight:** 2.3 lbs (1.04 kg)
+- **Features:** Rectangular shape, zips together with another bag, lightweight compression sack
+
+**Best For:** Summer camping, festivals, emergency kit
+
+**Warranty:** 2-year limited warranty
+
+### Sleeping Pads
+
+#### Alpine Air Pro
+**SKU:** PAD-AAP
+**Price:** $179.99
+
+Premium inflatable sleeping pad with superior insulation.
+- **R-Value:** 5.4 (four-season use)
+- **Weight:** 1.7 lbs (771g)
+- **Features:** Vertical sidewalls, Cyclone pump sack, self-sealing flat valve, repair kit included
+- **Sizes:** Regular $179.99, Large $199.99, X-Large $219.99
+
+**Best For:** Backpacking, cold weather camping, side sleepers
+
+**Warranty:** Lifetime warranty against defects
+
+---
+
+## Cooking Equipment
+
+### Trail Chef Stove System
+**SKU:** COOK-TCS
+**Price:** $149.99
+
+Integrated canister stove system for fast boiling.
+- **Boil Time:** 2.5 minutes (16 oz water)
+- **Weight:** 14.2 oz (403g) including pot
+- **Fuel:** Isobutane-propane mix (canister sold separately)
+- **Features:** Heat exchanger, built-in igniter, insulated cozy, strainer lid
+
+**Best For:** Solo backpacking, fast cooking
+
+**Warranty:** 3-year limited warranty
+
+### BaseCamp Cookset
+**SKU:** COOK-BCS
+**Price:** $79.99
+
+Complete family cooking system in hard-anodized aluminum. Includes a 3L pot, a 2L pot, a 9-inch frying pan, four bowls, four sporks, and a storage bag. Nests together for compact storage.
+
+**Best For:** Family camping, group trips
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Lighting
+
+### HeadLamp Pro 500
+**SKU:** LGT-HLP-500
+**Price:** $49.99
+
+High-performance rechargeable headlamp.
+- **Max Output:** 500 lumens
+- **Run Time:** 2 hours (high), 24 hours (low)
+- **Water Rating:** IPX6 (weather resistant)
+- **Features:** USB rechargeable, red light mode, tilting head, lockout mode
+
+**Best For:** Night hiking, camping, trail running
+
+**Warranty:** 2-year limited warranty
+
+### Lantern LED 600
+**SKU:** LGT-LED-600
+**Price:** $39.99
+
+Collapsible LED lantern for camp lighting.
+- **Max Output:** 600 lumens
+- **Run Time:** 6 hours (high), 40 hours (low)
+- **Features:** Collapses for storage, hanging hook, SOS flash mode, water-resistant (IPX4)
+
+**Best For:** Campsite lighting, emergency kit
+
+**Warranty:** 3-year limited warranty
+
+---
+
+## Hydration
+
+### Water Filter Pro
+**SKU:** HYD-WFP
+**Price:** $79.99
+
+Lightweight gravity water filter system.
+- **Flow Rate:** 2L in 3 minutes
+- **Filter Life:** 1,500 liters
+- **Removes:** 99.99% bacteria, 99.9% protozoa
+- **Features:** Gravity-fed, quick-connect system, backflush syringe included
+
+**Best For:** Group camping, base camp, emergencies
+
+**Warranty:** Limited lifetime warranty
+
+### Water Bottle Insulated 32oz
+**SKU:** HYD-WB-32
+**Price:** $34.99
+
+Double-wall insulated stainless steel bottle. Keeps cold 24 hours, hot 12 hours. Leak-proof wide-mouth lid, BPA-free.
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Navigation & Safety
+
+### GPS Navigator Pro
+**SKU:** NAV-GPS-PRO
+**Price:** $399.99
+
+Rugged handheld GPS with preloaded topographic maps, 3-inch color touchscreen, 20-hour battery, and IPX7 submersible rating. SOS alert capability requires a subscription.
+
+**Best For:** Backcountry navigation, orienteering
+
+**Warranty:** 2-year limited warranty
+
+### First Aid Kit - Trail
+**SKU:** SAF-FAK-TRL
+**Price:** $49.99
+
+Comprehensive first aid kit for outdoor adventures. Treats 1-4 people for 1-4 days. Includes bandages, gauze, medical tape, antiseptic wipes, blister treatment, emergency blanket, and a first aid guide in a water-resistant bag.
+
+**Best For:** Hiking, camping, backcountry travel
+
+---
+
+## Recommended Accessories for a Weekend Hiking Trip
+
+When a customer books a weekend guided trip, staff should recommend this starter bundle:
+- HeadLamp Pro 500 (LGT-HLP-500)
+- Water Filter Pro (HYD-WFP)
+- TrailRest 20F sleeping bag (SLP-TR-20)
+- Alpine Air Pro sleeping pad (PAD-AAP)
+- First Aid Kit - Trail (SAF-FAK-TRL)
+
+---
+
+## Contact & Support
+
+**Tailwind Traders**
+Customer Service: 1-800-TAILWIND
+Email: gear@tailwindtraders.com
+Website: www.tailwindtraders.com
+
+*All specifications are approximate. Products and prices subject to change without notice.*
+
+**Last Updated:** January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-returns-and-rentals-policy.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-returns-and-rentals-policy.md
@@ -1,0 +1,69 @@
+# Tailwind Traders - Returns and Rentals Policy
+
+Effective: January 2026
+Owner: Retail Operations Team
+
+This policy tells store staff how to handle product returns, exchanges, and gear rentals for guided trips. The internal knowledge assistant is grounded on this document.
+
+========================================
+RETURNS AND EXCHANGES
+========================================
+
+Standard Return Window:
+- Unused items with a receipt: 90 days for a full refund to the original payment method
+- Unused items without a receipt: store credit at the current selling price
+- Tents, sleeping bags, and backpacks: 90-day window; must be clean, dry, and free of damage
+
+Worn or Used Gear:
+- Items showing normal use may be returned within 30 days for store credit at staff discretion
+- Items returned dirty or wet are subject to a $25 cleaning fee before credit is issued
+
+Defective Items:
+- Manufacturing defects are covered by the product warranty (see each product catalog)
+- Defective items can be exchanged at any time within the warranty period
+- Log defective returns in the inventory portal so they can be sent back to the supplier
+
+Non-Returnable Items:
+- Fuel canisters and other consumables
+- Used first aid kits
+- Final-sale clearance items (marked on the receipt)
+
+========================================
+GEAR RENTALS FOR GUIDED TRIPS
+========================================
+
+Tailwind Traders rents tents, sleeping bags, sleeping pads, and stoves for guided trips.
+
+Rental Tiers:
+- Standard gear: $20 per day
+- Premium gear: $35 per day
+- Group/family tents: $45 per day
+
+Service Level Multipliers:
+- Standard service: 1.0x
+- Priority service (pre-staged and pre-checked before the trip): 1.25x
+
+Deposits:
+- A refundable deposit equal to 50% of the item's retail price is collected at pickup
+- The deposit is returned when gear is checked back in clean and undamaged
+- Cleaning fee: $15 per item returned dirty; damage is charged at repair or replacement cost
+
+Example Calculation:
+- 5 days of premium gear at priority service = 5 x $35 x 1.25 = $218.75 rental fee (plus deposit)
+
+Booking Rules:
+- Confirm trip availability at the guided-trips desk before reserving rental gear
+- Reserve rental gear at least 48 hours before the trip start date
+- Recommend the weekend gear bundle from the Camping Accessories catalog
+
+========================================
+CONTACT INFORMATION
+========================================
+
+- Returns questions: returns@tailwindtraders.com or (555) 200-4570
+- Rentals and guided trips: trips@tailwindtraders.com or (555) 200-4571
+
+If the assistant cannot find an answer here, advise the customer that a staff member will follow up.
+
+Policy Version: 1.0
+Last Updated: January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-store-operations.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-store-operations.md
@@ -1,0 +1,91 @@
+# Tailwind Traders - Store Operations Handbook
+
+Effective: January 2026
+Owner: Retail Operations Team
+
+This handbook gives Tailwind Traders store staff the operational policies they need day to day: store hours, staff accounts and systems security, and how to handle customer data. The internal knowledge assistant is grounded on this document so staff can get quick, accurate answers.
+
+========================================
+STORE HOURS AND STAFF AVAILABILITY
+========================================
+
+Store Hours:
+- Monday-Saturday: 9:00 AM - 8:00 PM (local store time)
+- Sunday: 10:00 AM - 6:00 PM
+- Guided-trip desk: opens 30 minutes before the store and closes 30 minutes after
+
+Core Hours for Staff:
+All store staff must be available and on the floor during core hours:
+- Monday-Friday: 10:00 AM - 4:00 PM (local time)
+- Respond to internal Teams messages within 30 minutes during core hours
+- Trade or swap shifts through the staff scheduling app at least 48 hours in advance
+
+========================================
+STAFF ACCOUNTS AND SYSTEMS SECURITY
+========================================
+
+Every staff member has a Tailwind Traders account used for the point-of-sale (POS) system, the inventory portal, and Microsoft 365 (email, Teams, SharePoint).
+
+Password Requirements:
+- Minimum 12 characters
+- Must include uppercase, lowercase, numbers, and special characters
+- Change every 90 days
+- Cannot reuse the last 5 passwords
+- No dictionary words or common patterns
+
+Multi-Factor Authentication (MFA):
+MFA is required for the POS system, the inventory portal, VPN access, and all Microsoft 365 apps.
+
+Supported MFA methods:
+- Microsoft Authenticator app (recommended)
+- SMS text message (backup)
+- Security key (for manager and admin accounts)
+- Phone call (alternative)
+
+Register at least two authentication methods and keep backup codes in a safe location.
+
+Register Handling:
+- Lock the POS screen (Windows+L) whenever stepping away from the register
+- Never share a POS login with another staff member
+- Report a lost badge or suspected account compromise to the store manager immediately
+
+========================================
+CUSTOMER DATA HANDLING
+========================================
+
+Data Classification:
+- PUBLIC: marketing materials, catalog content, store hours
+- INTERNAL: staffing schedules, standard operating procedures, restock reports
+- CONFIDENTIAL: customer orders, payment details, personal contact information
+- RESTRICTED: supplier pricing agreements, unreleased product plans
+
+Rules for Confidential and Restricted data:
+- Access on a need-to-know basis only
+- Never email customer payment details
+- Share documents through SharePoint or OneDrive links only, never personal cloud services
+- Set expiration dates on shared links and review shares quarterly
+
+========================================
+GUIDED TRIPS DESK
+========================================
+
+Tailwind Traders runs guided trips in several regions (for example: Pacific Northwest, Rockies, Patagonia).
+Staff at the trips desk:
+- Confirm trip availability and capacity before taking a booking
+- Recommend the weekend gear bundle from the Camping Accessories catalog
+- Collect the rental agreement and deposit (see the Returns and Rentals Policy)
+
+========================================
+ESCALATION AND SUPPORT
+========================================
+
+- Product and inventory questions: use the internal knowledge assistant, then the inventory portal
+- POS or account issues: IT Helpdesk at ithelp@tailwindtraders.com or (555) 200-4580
+- HR and scheduling: staffops@tailwindtraders.com or (555) 200-4567
+- Security incidents (lost device, phishing, account compromise): security@tailwindtraders.com, 24/7 hotline (555) 200-4599
+
+If the assistant cannot find an answer in the store documentation, tell the customer you will follow up and contact the relevant team above.
+
+Handbook Version: 1.0
+Last Updated: January 2026
+Next Review: January 2027

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-supplier-guide.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-supplier-guide.md
@@ -1,0 +1,76 @@
+# Tailwind Traders - Supplier and Restock Guide
+
+Effective: January 2026
+Owner: Supply Chain Team
+
+This guide gives store staff the supplier, restock, and supplier-returns information they need to keep shelves stocked and to send defective product back correctly. The internal knowledge assistant is grounded on this document.
+
+========================================
+KEY SUPPLIERS
+========================================
+
+Tents:
+- Supplier: Summit Shelter Co.
+- Lead time: 3 weeks
+- Minimum order: 10 units per model
+- Contact: orders@summitshelter.example
+
+Backpacks:
+- Supplier: Ridgeline Packs Ltd.
+- Lead time: 2 weeks
+- Minimum order: 12 units per model
+- Contact: wholesale@ridgelinepacks.example
+
+Sleeping systems and accessories:
+- Supplier: BasecampGear Distribution
+- Lead time: 10 business days
+- Minimum order: no minimum for accessories; 6 units per sleeping bag model
+- Contact: b2b@basecampgear.example
+
+========================================
+RESTOCK RULES
+========================================
+
+Reorder Thresholds:
+- Recommend a restock when on-hand inventory for an item falls below 10 units AND weekly sales are above 15 units
+- Recommend clearance when on-hand inventory is above 20 units AND weekly sales are below 5 units
+- Flagship items (Windward Explorer 2P, Expedition Pro 65L) should never fall below 5 units on hand
+
+Ordering Process:
+1. Check current on-hand levels in the inventory portal
+2. Compare against the reorder thresholds above
+3. Raise a purchase order to the relevant supplier, respecting the minimum order quantity
+4. Record the expected delivery date and follow up if it is late
+
+Seasonal Notes:
+- Order winter and four-season tents by early autumn; Summit Shelter Co. lead times double in Q4
+- Increase daypack stock ahead of the spring and summer guided-trip season
+
+========================================
+RETURNS TO SUPPLIER
+========================================
+
+Defective Product:
+- Log every defective item in the inventory portal with the SKU, batch, and a short description
+- Batch defective returns weekly and ship them back under the supplier's RMA (Return Merchandise Authorization) process
+- Request an RMA number from the supplier before shipping; never ship without one
+
+Warranty Claims:
+- Customer warranty returns are first credited to the customer (see the Returns and Rentals Policy)
+- The store then recovers the cost from the supplier under the warranty terms in the product catalog
+
+Damaged-in-Transit:
+- Photograph damaged shipments before unpacking further
+- Report to the supplier within 48 hours of delivery to qualify for replacement
+
+========================================
+CONTACT INFORMATION
+========================================
+
+- Supply chain team: supplychain@tailwindtraders.com or (555) 200-4590
+- Inventory portal support: ithelp@tailwindtraders.com or (555) 200-4580
+
+If the assistant cannot find supplier or restock details here, advise staff to contact the supply chain team.
+
+Guide Version: 1.0
+Last Updated: January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-tents-catalog.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/data/tailwind-tents-catalog.md
@@ -1,0 +1,180 @@
+# Tailwind Traders - Tents Catalog 2026
+
+## Welcome to Tailwind Traders Tents
+
+Tailwind Traders is proud to present our comprehensive line of high-quality tents designed for every outdoor adventure. Whether your customer is a weekend camper, a serious backpacker, or a family looking for a comfortable outdoor experience, we have the perfect tent for them. Store staff can use this catalog to answer product questions, compare models, and make recommendations.
+
+---
+
+## 2-Person Backpacking Tents
+
+### Windward Explorer 2P
+**SKU:** TENT-WEX-2P
+**Price:** $329.99
+
+Our flagship ultralight backpacking tent, perfect for serious hikers and mountaineers who need reliable shelter without the extra weight.
+
+**Features:**
+- **Weight:** 3.2 lbs (1.45 kg) including stakes and guylines
+- **Floor Area:** 28 sq ft (2.6 sq m)
+- **Peak Height:** 42 inches (107 cm)
+- **Waterproof Rating:** 3000mm rain fly, 5000mm floor
+- **Materials:** 20D ripstop nylon fly with silicone coating; DAC aluminum poles
+- **Ventilation:** Dual vestibules with mesh panels for superior airflow
+- **Setup:** Freestanding design with color-coded clips for easy 5-minute setup
+
+**Best For:** Alpine climbing, long-distance backpacking, bike touring
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+### TrailMaster Lite 2P
+**SKU:** TENT-TML-2P
+**Price:** $219.99
+
+An excellent value option for recreational backpackers, combining comfort and durability at an accessible price point.
+
+**Features:**
+- **Weight:** 4.8 lbs (2.18 kg)
+- **Floor Area:** 32 sq ft (3.0 sq m)
+- **Peak Height:** 44 inches (112 cm)
+- **Waterproof Rating:** 2000mm rain fly, 3000mm floor
+- **Materials:** 75D polyester taffeta fly and floor; fiberglass poles
+- **Setup:** Simple two-pole design, 10-minute setup
+
+**Best For:** Weekend camping, beginner backpackers, casual hikers
+
+**Warranty:** 3-year limited warranty
+
+---
+
+## 4-Person Family Tents
+
+### SummitDome 4P
+**SKU:** TENT-SD-4P
+**Price:** $279.99
+
+Our most popular family tent, offering spacious comfort and ease of setup for car camping and family adventures.
+
+**Features:**
+- **Weight:** 12.5 lbs (5.67 kg)
+- **Floor Area:** 64 sq ft (5.9 sq m)
+- **Center Height:** 68 inches (173 cm)
+- **Waterproof Rating:** 1500mm rain fly, 2000mm floor
+- **Room Divider:** Removable center divider creates two separate sleeping areas
+- **Setup:** Simple dome design, 15-minute setup with color-coded poles
+
+**Best For:** Family camping, car camping, festivals
+
+**Warranty:** 2-year limited warranty
+
+---
+
+### MegaSpace 4P Cabin
+**SKU:** TENT-MS-4P
+**Price:** $399.99
+
+A cabin tent offering stand-up room and home-like comfort for families who want maximum living space at the campsite.
+
+**Features:**
+- **Weight:** 18.2 lbs (8.26 kg)
+- **Floor Area:** 80 sq ft (7.4 sq m)
+- **Center Height:** 78 inches (198 cm) - full stand-up height
+- **Waterproof Rating:** 2000mm rain fly, 3000mm floor
+- **Room Configuration:** Divides into 2 rooms with the included privacy panel
+- **Setup:** Hub-style pole system, 20-minute setup
+
+**Best For:** Extended family camping trips, base camp, glamping
+
+**Warranty:** 3-year limited warranty
+
+---
+
+## 6-Person Group Tents
+
+### BaseCamp Pro 6P
+**SKU:** TENT-BCP-6P
+**Price:** $549.99
+
+Our premium large-capacity tent designed for groups, families, or extended camping trips where comfort and durability are paramount.
+
+**Features:**
+- **Weight:** 24.8 lbs (11.25 kg)
+- **Floor Area:** 120 sq ft (11.1 sq m)
+- **Center Height:** 84 inches (213 cm)
+- **Waterproof Rating:** 3000mm rain fly, 5000mm floor
+- **Room Configuration:** 3-room design with 2 removable dividers
+- **Weather Protection:** Extended rain fly, taped seams, storm flaps over all zippers
+
+**Best For:** Large families, scout groups, long-term camping
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Specialty Tents
+
+### FourSeason Alpine 2P
+**SKU:** TENT-4SA-2P
+**Price:** $599.99
+
+Our most technical tent, engineered for mountaineering and winter camping in extreme conditions.
+
+**Features:**
+- **Weight:** 6.8 lbs (3.08 kg)
+- **Waterproof Rating:** 5000mm rain fly, 10000mm floor
+- **4-Season Construction:** Minimal mesh for warmth retention, full-coverage fly
+- **Weather Protection:** Engineered for extreme wind loads and snow accumulation
+
+**Best For:** Mountaineering, winter camping, alpine expeditions
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+### UltraLite Solo 1P
+**SKU:** TENT-ULS-1P
+**Price:** $249.99
+
+The ultimate minimalist shelter for solo adventurers who count every ounce.
+
+**Features:**
+- **Weight:** 1.9 lbs (0.86 kg) including stakes
+- **Floor Area:** 17 sq ft (1.6 sq m)
+- **Waterproof Rating:** 3000mm rain fly, 5000mm floor
+- **Setup:** Trekking pole compatible (pole not included), 3-minute setup
+
+**Best For:** Ultralight backpacking, thru-hiking, fast-packing
+
+**Warranty:** 2-year limited warranty
+
+---
+
+## Rental Fleet
+
+All family and group tents above are available through the Tailwind Traders **gear rental** program.
+See the *Returns and Rentals Policy* document for daily rates, deposits, and cleaning fees.
+
+---
+
+## Care and Maintenance
+
+1. **Always dry your tent completely** before storing to prevent mold and mildew.
+2. **Store loosely** - never keep your tent compressed for extended periods.
+3. **Clean with mild soap** and water only - harsh detergents damage coatings.
+4. **Reseal seams** annually with seam sealer for maximum waterproofing.
+5. **Repair small tears** immediately with repair tape to prevent further damage.
+
+---
+
+## Contact Information
+
+**Tailwind Traders**
+Customer Service: 1-800-TAILWIND
+Email: support@tailwindtraders.com
+Website: www.tailwindtraders.com
+
+*Prices and specifications subject to change. All weights are approximate.*
+
+**Last Updated:** January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/knowledge_agent.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/knowledge_agent.py
@@ -1,0 +1,127 @@
+import os
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+# Load environment variables
+load_dotenv()
+project_endpoint = os.getenv("PROJECT_ENDPOINT")
+agent_name = os.getenv("AGENT_NAME")
+
+# Validate configuration
+if not project_endpoint or not agent_name:
+    raise ValueError("PROJECT_ENDPOINT and AGENT_NAME must be set in .env file")
+
+print(f"Connecting to project: {project_endpoint}")
+print(f"Using agent: {agent_name}\n")
+
+# TODO: Connect to the project and create a conversation
+# Add your code here to:
+# 1. Create DefaultAzureCredential
+# 2. Create AIProjectClient with endpoint
+# 3. Get the OpenAI client
+# 4. Get the agent by name
+# 5. Create a new conversation
+
+
+# Conversation history for context (client-side tracking)
+conversation_history = []
+
+
+def send_message_to_agent(user_message):
+    """
+    Send a message to the agent and handle the response using the conversations API.
+    """
+    try:
+        print("\nAgent: ", end="", flush=True)
+
+        # TODO: Add user message to conversation and get response
+        # Add your code here to:
+        # 1. Add the user message to the conversation using conversations.items.create()
+        # 2. Create a response using responses.create() with agent reference
+        # 3. Handle any MCP approval request for the Foundry IQ knowledge tool
+        # 4. Extract and display the response text
+        # Your code will go here
+
+
+
+        # Extract the response text
+        if response and response.output_text:
+            response_text = response.output_text
+
+            print(f"{response_text}\n")
+
+            # Check for citations if available
+            if hasattr(response, 'citations') and response.citations:
+                print("\nSources:")
+                for citation in response.citations:
+                    print(f"  - {citation.content if hasattr(citation, 'content') else 'Knowledge Base'}")
+
+            # Store in conversation history (client-side)
+            conversation_history.append({
+                "role": "assistant",
+                "content": response_text
+            })
+
+            return response_text
+        else:
+            print("No response received.\n")
+            return None
+    except Exception as e:
+        print(f"\n\nError: {str(e)}\n")
+        return None
+
+
+def display_conversation_history():
+    """
+    Display the full conversation history.
+    """
+    print("\n" + "=" * 60)
+    print("CONVERSATION HISTORY")
+    print("=" * 60 + "\n")
+
+    for turn in conversation_history:
+        role = turn["role"].upper()
+        content = turn["content"]
+        print(f"{role}: {content}\n")
+
+    print("=" * 60 + "\n")
+
+
+def main():
+    """
+    Main interaction loop.
+    """
+    print("Tailwind Traders Knowledge Assistant")
+    print("Ask questions about our products, store policies, returns, rentals, and suppliers.")
+    print("Type 'history' to see conversation history, or 'quit' to exit.\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+
+            if not user_input:
+                continue
+
+            if user_input.lower() == 'quit':
+                print("\nEnding conversation...")
+                break
+
+            if user_input.lower() == 'history':
+                display_conversation_history()
+                continue
+
+            # Send message and get response
+            send_message_to_agent(user_input)
+
+        except KeyboardInterrupt:
+            print("\n\nInterrupted by user.")
+            break
+        except Exception as e:
+            print(f"\nUnexpected error: {str(e)}\n")
+
+    print("\nConversation ended.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/knowledge_chat_app.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/knowledge_chat_app.py
@@ -1,0 +1,91 @@
+"""
+Tailwind Traders Staff Knowledge Assistant - web chat variant (provided complete).
+
+This is an optional, friendlier version of knowledge_agent.py. Instead of a console
+loop, it serves the same Foundry IQ enterprise-knowledge agent through the shared
+Tailwind Traders web chat window (tailwind_ui.py).
+
+To keep the browser experience smooth, this variant AUTO-APPROVES the Foundry IQ
+knowledge tool when the agent asks for approval. The console client
+(knowledge_agent.py) shows the interactive yes/no approval flow instead.
+"""
+
+import os
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+from tailwind_ui import run_chat_app
+
+# Load environment variables
+load_dotenv()
+project_endpoint = os.getenv("PROJECT_ENDPOINT")
+agent_name = os.getenv("AGENT_NAME")
+
+if not project_endpoint or not agent_name:
+    raise ValueError("PROJECT_ENDPOINT and AGENT_NAME must be set in .env file")
+
+# Connect to the project and agent
+credential = DefaultAzureCredential(
+    exclude_environment_credential=True,
+    exclude_managed_identity_credential=True
+)
+project_client = AIProjectClient(
+    credential=credential,
+    endpoint=project_endpoint
+)
+openai_client = project_client.get_openai_client()
+agent = project_client.agents.get(agent_name=agent_name)
+
+# One shared conversation for the browser session
+conversation = openai_client.conversations.create(items=[])
+
+
+def respond(user_message):
+    """Route a chat message to the Foundry IQ agent and return the reply text."""
+    # Add the user's message to the conversation
+    openai_client.conversations.items.create(
+        conversation_id=conversation.id,
+        items=[{"type": "message", "role": "user", "content": user_message}],
+    )
+
+    # Ask the agent to respond
+    response = openai_client.responses.create(
+        conversation=conversation.id,
+        extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+        input=""
+    )
+
+    # Auto-approve any Foundry IQ knowledge-tool approval request
+    approval_request = None
+    if getattr(response, "output", None):
+        for item in response.output:
+            if getattr(item, "type", None) == "mcp_approval_request":
+                approval_request = item
+                break
+
+    if approval_request:
+        openai_client.conversations.items.create(
+            conversation_id=conversation.id,
+            items=[{
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request.id,
+                "approve": True,
+            }],
+        )
+        response = openai_client.responses.create(
+            conversation=conversation.id,
+            extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+            input=""
+        )
+
+    return response.output_text or "No response received."
+
+
+if __name__ == "__main__":
+    run_chat_app(
+        respond,
+        title="Tailwind Traders Staff Knowledge Assistant",
+        subtitle="Grounded on store policies, product catalog, returns, rentals, and supplier docs.",
+        placeholder="Ask about products, returns, rentals, or suppliers...",
+    )

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/requirements.txt
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/requirements.txt
@@ -1,0 +1,6 @@
+python-dotenv
+azure-identity
+azure-ai-projects==2.3.0
+openai
+mcp
+gradio==6.20.0

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/tailwind_ui.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/tailwind_ui.py
@@ -1,0 +1,68 @@
+"""
+Tailwind Traders – shared chat UI shell (provided).
+
+You don't need to edit this file. It gives every task in the lab the same simple
+web chat window so your agent feels like a real app instead of a console script.
+
+Each task provides a `respond` function that takes the user's message and returns
+either a plain string, or an `AgentReply` carrying text plus any image files to
+show inline (for example, a chart produced by the code interpreter). The function
+may be synchronous or asynchronous (Task 5 uses an async one for the MCP session).
+"""
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Callable
+
+import gradio as gr
+
+
+@dataclass
+class AgentReply:
+    """A single reply from the agent."""
+    text: str = ""
+    images: list = field(default_factory=list)  # local image file paths to display inline
+
+
+def run_chat_app(
+    respond: Callable,
+    title: str = "Tailwind Traders Assistant",
+    subtitle: str = "",
+    placeholder: str = "Ask the assistant...",
+    server_port: int = 7860,
+):
+    """Launch a browser chat window that routes each message to `respond`."""
+
+    async def handle(user_message, history):
+        history = (history or []) + [{"role": "user", "content": user_message}]
+
+        # Call the task's respond function (await it if it's async)
+        result = respond(user_message)
+        if inspect.isawaitable(result):
+            result = await result
+
+        if isinstance(result, str):
+            result = AgentReply(text=result)
+
+        if result and result.text:
+            history.append({"role": "assistant", "content": result.text})
+        for image_path in (result.images if result else []):
+            history.append({"role": "assistant", "content": {"path": image_path}})
+
+        return history, ""
+
+    with gr.Blocks(title=title) as demo:
+        gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
+        if subtitle:
+            gr.Markdown(subtitle)
+        chatbot = gr.Chatbot(height=460, show_label=False)
+        with gr.Row():
+            textbox = gr.Textbox(
+                placeholder=placeholder, show_label=False, scale=8, autofocus=True
+            )
+            send = gr.Button("Send", variant="primary", scale=1)
+
+        for trigger in (textbox.submit, send.click):
+            trigger(handle, [textbox, chatbot], [chatbot, textbox])
+
+    demo.launch(server_port=server_port, inbrowser=True, css="footer {visibility: hidden}", theme=gr.themes.Soft())

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/workiq_lab.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/workiq_lab.py
@@ -1,0 +1,541 @@
+"""
+Tailwind Traders - Work IQ Integration (Workplace Intelligence Agent)
+
+This application demonstrates how to build agents that access Microsoft 365
+workplace data using Work IQ (a Model Context Protocol server for M365 Copilot).
+
+Scenarios covered:
+1. Meeting Prep - Get context for upcoming meetings
+2. Project Status - Track project updates from M365 data
+3. Action Items - Extract tasks from emails and meetings
+4. Combined Intelligence - Use both Work IQ + Foundry IQ
+5. Custom Query - Ask your own workplace questions
+
+Run this single file to explore all Work IQ capabilities.
+"""
+
+import os
+import time
+import json
+import asyncio
+from dotenv import load_dotenv
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import PromptAgentDefinition, Tool, FunctionTool
+from azure.identity import DefaultAzureCredential
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from openai.types.responses.response_input_param import FunctionCallOutput, ResponseInputParam
+
+# Load environment variables
+load_dotenv()
+
+class WorkIQLab:
+    def __init__(self):
+        """Initialize the lab with Microsoft Foundry connection."""
+        self.project_endpoint = os.getenv("PROJECT_ENDPOINT")
+        self.model_deployment = os.getenv("MODEL_DEPLOYMENT_NAME", "gpt-5")
+
+        if not self.project_endpoint:
+            print("[ERROR] PROJECT_ENDPOINT not set in .env file")
+            print("Please configure .env with your Microsoft Foundry project endpoint")
+            exit(1)
+
+        print("Connecting to Microsoft Foundry project...")
+        self.credential = DefaultAzureCredential()
+        self.project_client = None
+        self.openai_client = None
+        self.workiq_client = None
+        self.agent = None
+        self.workiq_server_params = None
+
+    def validate_workiq_setup(self):
+        """Check if Work IQ is installed and accessible."""
+        import subprocess
+
+        print("\n" + "=" * 70)
+        print("VALIDATING WORK IQ SETUP")
+        print("=" * 70)
+
+        try:
+            # Check if workiq command is available
+            result = subprocess.run(
+                ["workiq", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                shell=True
+            )
+
+            if result.returncode == 0:
+                print("[OK] Work IQ is installed")
+                print(f"   Version: {result.stdout.strip()}\n")
+                return True
+            else:
+                print("[ERROR] Work IQ not found or not working properly")
+                print("\nTo install Work IQ:")
+                print("   npm install -g @microsoft/workiq")
+                print("   workiq accept-eula\n")
+                return False
+
+        except FileNotFoundError:
+            print("[ERROR] Work IQ command not found")
+            print("\nTo install Work IQ:")
+            print("   npm install -g @microsoft/workiq")
+            print("   workiq accept-eula\n")
+            return False
+        except Exception as e:
+            print(f"[WARN] Could not validate Work IQ setup: {e}")
+            print("   Continuing anyway - you may encounter errors\n")
+            return True
+
+    def connect(self):
+        """Establish connection to Microsoft Foundry and Work IQ."""
+        try:
+            # Validate Work IQ first
+            if not self.validate_workiq_setup():
+                print("[WARN] Work IQ validation failed, but continuing...")
+                print("   Make sure Work IQ is installed and configured.\n")
+
+            # Create project client
+            self.project_client = AIProjectClient(
+                credential=self.credential,
+                endpoint=self.project_endpoint
+            )
+
+            # Get OpenAI-compatible client for Responses API
+            self.openai_client = self.project_client.get_openai_client()
+
+            # Initialize Work IQ MCP client
+            print("Connecting to Work IQ MCP server...")
+            self.workiq_server_params = StdioServerParameters(
+                command="npx",
+                args=["-y", "@microsoft/workiq", "mcp"]
+            )
+
+            # Get available tools from Work IQ
+            print("[OK] Connected to Microsoft Foundry and Work IQ MCP\n")
+
+            # Create a single agent with Work IQ tools
+            self._create_workplace_agent()
+
+            return True
+
+        except Exception as e:
+            print(f"[ERROR] Connection failed: {e}")
+            print("\nTroubleshooting:")
+            print("  1. Ensure Work IQ is installed: npm install -g @microsoft/workiq")
+            print("  2. Accept EULA: workiq accept-eula")
+            print("  3. Ensure you have M365 Copilot license and admin consent")
+            print("  4. Test with: workiq ask -q 'What meetings do I have today?'")
+            return False
+
+    def _get_workiq_tools(self):
+        """Fetch tools from Work IQ MCP server."""
+        async def _fetch():
+            async with stdio_client(self.workiq_server_params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    tools_result = await session.list_tools()
+                    return tools_result.tools
+        return asyncio.run(_fetch())
+
+    def _call_workiq_tool(self, tool_name, kwargs):
+        """Execute a Work IQ tool via MCP and return result."""
+        async def _execute():
+            async with stdio_client(self.workiq_server_params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool_name, kwargs)
+                    return result
+        return asyncio.run(_execute())
+
+    def _create_workplace_agent(self):
+        """Create the workplace intelligence agent with Work IQ tools."""
+        try:
+            print("Creating workplace intelligence agent...")
+
+            # Get Work IQ tools
+            raw_tools = self._get_workiq_tools()
+            workiq_tools = [
+                FunctionTool(
+                    name=tool.name,
+                    description=tool.description,
+                    parameters=tool.inputSchema,
+                )
+                for tool in raw_tools
+            ]
+
+            # Create agent using Responses API pattern
+            self.agent = self.project_client.agents.create_version(
+                agent_name="tailwind-workplace-agent",
+                definition=PromptAgentDefinition(
+                    model=self.model_deployment,
+                    instructions="""You are a workplace intelligence assistant for Tailwind Traders staff, with access to Microsoft 365 data through Work IQ.
+
+Your capabilities:
+- Search emails, meetings, calendar, Teams messages, and documents
+- Provide context for meetings and projects
+- Extract action items and tasks
+- Summarize communications and decisions
+
+Guidelines:
+- Always cite sources with timestamps when available
+- Respect user privacy and data sensitivity
+- Provide concise, actionable information
+- If you can't find information, explain what you searched and suggest alternatives""",
+                    tools=workiq_tools
+                )
+            )
+
+            # Store raw tools map for lookup during tool execution
+            self.raw_tools_map = {tool.name: tool for tool in raw_tools}
+
+            print(f"[OK] Created agent: {self.agent.name} (version {self.agent.version})\n")
+
+        except Exception as e:
+            print(f"[ERROR] Failed to create agent: {e}")
+            raise
+
+    def _execute_query(self, query, scenario_name="Query"):
+        """Execute a query against the workplace agent."""
+        try:
+            print(f"\n{'=' * 70}")
+            print(f">> {scenario_name}")
+            print(f"{'=' * 70}")
+            print(f"\nQuery: {query}\n")
+            print("Processing with Work IQ tools...")
+
+            # Create conversation
+            conversation = self.openai_client.conversations.create(
+                items=[{"type": "message", "role": "user", "content": query}]
+            )
+
+            # Create response with agent
+            response = self.openai_client.responses.create(
+                conversation=conversation.id,
+                extra_body={"agent_reference": {"name": self.agent.name, "type": "agent_reference"}}
+            )
+
+            # Tool call loop
+            while True:
+                # Check for failures
+                if response.status == "failed":
+                    print(f"[ERROR] Response failed: {response.error}")
+                    return
+
+                input_list: ResponseInputParam = []
+
+                # Process function calls
+                for item in response.output:
+                    if item.type == "function_call":
+                        function_name = item.name
+                        kwargs = json.loads(item.arguments)
+
+                        print(f"   [tool] Calling Work IQ tool: {function_name}")
+
+                        # Call the tool via MCP
+                        result = self._call_workiq_tool(function_name, kwargs)
+
+                        input_list.append(
+                            FunctionCallOutput(
+                                type="function_call_output",
+                                call_id=item.call_id,
+                                output=result.content[0].text,
+                            )
+                        )
+
+                # If there were tool calls, send results back and continue loop
+                if input_list:
+                    response = self.openai_client.responses.create(
+                        input=input_list,
+                        previous_response_id=response.id,
+                        extra_body={
+                            "agent_reference": {"name": self.agent.name, "type": "agent_reference"}
+                        }
+                    )
+                else:
+                    # No tool calls - we have the final response
+                    break
+
+            # Extract and display final response
+            print("\nResponse:")
+            print("-" * 70)
+
+            if response.output_text:
+                print(response.output_text)
+            else:
+                print("No response received from agent.")
+
+            print("-" * 70)
+
+        except Exception as e:
+            print(f"\n[ERROR] Error executing query: {e}")
+            print("\nPossible issues:")
+            print("  - Work IQ MCP server not responding")
+            print("  - No M365 Copilot license or admin consent")
+            print("  - Agent doesn't have access to requested data")
+
+    def show_menu(self):
+        """Display the main menu."""
+        print("\n" + "=" * 70)
+        print("        TAILWIND TRADERS: WORK IQ - WORKPLACE INTELLIGENCE")
+        print("=" * 70)
+        print("\nChoose a scenario:\n")
+        print("  1. Meeting Prep")
+        print("     Get context for your next meeting")
+        print()
+        print("  2. Project Status")
+        print("     Check latest updates on a project")
+        print()
+        print("  3. Action Items")
+        print("     Find your open tasks and action items")
+        print()
+        print("  4. Combined Intelligence")
+        print("     Search both workplace data AND knowledge base")
+        print()
+        print("  5. Custom Query")
+        print("     Ask your own workplace question")
+        print()
+        print("  6. View Work IQ Capabilities")
+        print()
+        print("  0. Exit")
+        print("\n" + "=" * 70)
+
+    def scenario_1_meeting_prep(self):
+        """Scenario 1: Meeting preparation with context."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 1: MEETING PREP")
+        print("=" * 70)
+        print("\nThis scenario helps you prepare for meetings by gathering")
+        print("context from emails, previous meetings, and shared documents.\n")
+
+        # Get meeting topic from user
+        meeting_topic = input("Enter meeting topic or time (e.g., '2pm meeting', 'Spring Catalog Planning'): ").strip()
+
+        if not meeting_topic:
+            meeting_topic = "my next meeting"
+
+        query = f"""Help me prepare for {meeting_topic}. Please:
+1. Find the meeting details (time, attendees, agenda)
+2. Search for recent emails about this topic
+3. Look for previous meetings on this topic
+4. Summarize key points and decisions I should know
+5. Suggest discussion points or questions
+
+Provide a concise prep summary with sources."""
+
+        self._execute_query(query, "Meeting Prep")
+
+    def scenario_2_project_status(self):
+        """Scenario 2: Project status tracking."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 2: PROJECT STATUS")
+        print("=" * 70)
+        print("\nThis scenario tracks project updates by searching across")
+        print("emails, Teams chats, meetings, and shared documents.\n")
+
+        # Get project name from user
+        project_name = input("Enter project name (e.g., 'Spring Catalog Launch', 'Store Refresh'): ").strip()
+
+        if not project_name:
+            project_name = "current projects"
+
+        query = f"""Give me a status update on {project_name}. Please:
+1. Search recent emails and Teams messages about this project
+2. Find related meetings and their outcomes
+3. Identify recent decisions and changes
+4. List any blockers or issues mentioned
+5. Summarize next steps and deadlines
+
+Provide a concise status report with sources and dates."""
+
+        self._execute_query(query, "Project Status")
+
+    def scenario_3_action_items(self):
+        """Scenario 3: Action item extraction."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 3: ACTION ITEMS")
+        print("=" * 70)
+        print("\nThis scenario extracts your open tasks and action items")
+        print("from meetings, emails, and Teams messages.\n")
+
+        # Optional: time filter
+        time_filter = input("Time range (e.g., 'this week', 'last 3 days', or press Enter for 'recent'): ").strip()
+
+        if not time_filter:
+            time_filter = "the past week"
+
+        query = f"""Find my open action items and tasks from {time_filter}. Please:
+1. Search meeting notes for assigned action items
+2. Look for task-related emails sent to me
+3. Check Teams messages where I was mentioned or assigned tasks
+4. Identify items with deadlines or due dates
+5. Categorize by urgency if possible
+
+Provide a prioritized list with sources, deadlines, and who assigned each item."""
+
+        self._execute_query(query, "Action Items")
+
+    def scenario_4_combined_intelligence(self):
+        """Scenario 4: Work IQ + Foundry IQ combined."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 4: COMBINED INTELLIGENCE")
+        print("=" * 70)
+        print("\nThis scenario demonstrates using BOTH Work IQ (workplace signals)")
+        print("and Foundry IQ (knowledge base) together for comprehensive context.\n")
+        print("[NOTE] This requires Foundry IQ search to be configured in your project.\n")
+
+        topic = input("Enter topic to research (workplace + knowledge base): ").strip()
+
+        if not topic:
+            topic = "our store return and rental policies"
+
+        query = f"""Research {topic} using both workplace data and knowledge base. Please:
+
+FROM WORKPLACE DATA (Work IQ):
+1. Search recent emails and messages about this topic
+2. Find relevant meetings and discussions
+3. Identify who has been involved and what was decided
+
+FROM KNOWLEDGE BASE (Foundry IQ):
+4. Search official documentation
+5. Find policies, guidelines, or procedures
+
+SYNTHESIS:
+6. Compare workplace discussions with official documentation
+7. Identify any gaps or inconsistencies
+8. Provide a comprehensive summary with sources from both
+
+Label each piece of information with its source (workplace or knowledge base)."""
+
+        self._execute_query(query, "Combined Intelligence")
+
+    def scenario_5_custom_query(self):
+        """Scenario 5: User-defined custom query."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 5: CUSTOM QUERY")
+        print("=" * 70)
+        print("\nAsk any workplace question! Examples:")
+        print("  - What did my manager say about the spring catalog?")
+        print("  - Find emails about the Q4 inventory count")
+        print("  - What did the store operations team discuss yesterday?")
+        print("  - Show me shared documents about supplier lead times")
+        print("  - Summarize this week's team standups\n")
+
+        custom_query = input("Your workplace question: ").strip()
+
+        if not custom_query:
+            print("\n[WARN] No query entered. Returning to menu.")
+            return
+
+        self._execute_query(custom_query, "Custom Query")
+
+    def show_capabilities(self):
+        """Display Work IQ capabilities and architecture."""
+        print("\n" + "=" * 70)
+        print("WORK IQ CAPABILITIES")
+        print("=" * 70)
+        print("\nWhat is Work IQ?")
+        print("-" * 70)
+        print("Work IQ is Microsoft's contextual intelligence layer for Microsoft 365.")
+        print("It provides AI agents with access to workplace data through the")
+        print("Model Context Protocol (MCP).\n")
+
+        print("Data Sources:")
+        print("  - Emails (Outlook)")
+        print("  - Calendar and meetings")
+        print("  - Teams messages and chats")
+        print("  - OneDrive and SharePoint documents")
+        print("  - People and organizational data")
+        print("  - Notifications and signals\n")
+
+        print("Security & Privacy:")
+        print("  - Respects existing M365 permissions")
+        print("  - Uses Microsoft Entra ID authentication")
+        print("  - Requires M365 Copilot license")
+        print("  - Requires admin consent for organizational use")
+        print("  - All data access is logged and auditable\n")
+
+        print("Work IQ vs Foundry IQ:")
+        print("  Work IQ:    Workplace signals (who said what, when)")
+        print("  Foundry IQ: Knowledge base (curated documents, data)")
+        print("  Together:   Complete context for decision-making\n")
+
+        print("MCP Architecture:")
+        print("  1. Work IQ runs as MCP server (npx @microsoft/workiq mcp)")
+        print("  2. Agent connects via StdioMCPClient")
+        print("  3. Agent calls Work IQ tools to query M365")
+        print("  4. Work IQ returns data with proper permissions")
+        print("  5. Agent synthesizes and presents results\n")
+
+        print("Use Cases:")
+        print("  - Meeting preparation and context")
+        print("  - Project status tracking")
+        print("  - Action item extraction")
+        print("  - Document discovery and search")
+        print("  - Communication summarization")
+        print("  - Team activity monitoring")
+        print("  - Decision history and rationale\n")
+
+        print("=" * 70)
+        input("\nPress Enter to return to menu...")
+
+    def cleanup(self):
+        """Clean up resources."""
+        try:
+            if self.agent:
+                print("\nCleaning up resources...")
+                self.project_client.agents.delete_version(
+                    agent_name=self.agent.name,
+                    version=self.agent.version
+                )
+                print("[OK] Agent deleted")
+        except Exception as e:
+            print(f"[WARN] Cleanup warning: {e}")
+
+    def run(self):
+        """Main application loop."""
+        print("\n" + "=" * 70)
+        print("   TAILWIND TRADERS: WORK IQ - WORKPLACE INTELLIGENCE FOR AI AGENTS")
+        print("=" * 70)
+        print("\nThis lab demonstrates how to build AI agents that access")
+        print("Microsoft 365 workplace data using Work IQ.\n")
+
+        # Connect to services
+        if not self.connect():
+            print("\n[ERROR] Failed to connect. Please check your configuration.")
+            return
+
+        # Main menu loop
+        while True:
+            self.show_menu()
+            choice = input("\nSelect option (0-6): ").strip()
+
+            if choice == "1":
+                self.scenario_1_meeting_prep()
+            elif choice == "2":
+                self.scenario_2_project_status()
+            elif choice == "3":
+                self.scenario_3_action_items()
+            elif choice == "4":
+                self.scenario_4_combined_intelligence()
+            elif choice == "5":
+                self.scenario_5_custom_query()
+            elif choice == "6":
+                self.show_capabilities()
+            elif choice == "0":
+                print("\nExiting lab...")
+                break
+            else:
+                print("\n[WARN] Invalid option. Please choose 0-6.")
+
+            input("\nPress Enter to continue...")
+
+        # Cleanup
+        self.cleanup()
+        print("\n[OK] Lab complete! Thank you for exploring Work IQ.\n")
+
+
+if __name__ == "__main__":
+    lab = WorkIQLab()
+    lab.run()

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/.env.example
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/.env.example
@@ -1,0 +1,13 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# In VS Code, Foundry Toolkit > right-click your active project > Copy Project Endpoint,
+# or copy it from the Microsoft Foundry portal project overview page.
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (for example, gpt-4o) — used by Task 4 (Work IQ)
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here
+
+# The enterprise-knowledge agent you create in Task 1 — used by the code clients
+AGENT_NAME=tailwind-knowledge-agent

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-backpacks-guide.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-backpacks-guide.md
@@ -1,0 +1,183 @@
+# Tailwind Traders - Backpacks & Hiking Gear Guide 2026
+
+## Your Complete Backpack Selection Guide
+
+Welcome to the Tailwind Traders backpack collection. Whether a customer is planning a day hike or a month-long expedition, we have the perfect pack to carry their gear comfortably and efficiently. Store staff can use this guide to match customers to the right pack size and features.
+
+---
+
+## Understanding Backpack Sizing
+
+### How to Measure Torso Length
+1. Locate the C7 vertebra (the bony bump at the base of the neck when the head tilts forward).
+2. Place hands on the hip bones at the iliac crest.
+3. Measure the distance between these two points.
+
+**Size Chart:**
+- **X-Small:** 15-16 inches (38-41 cm)
+- **Small:** 16-17 inches (41-43 cm)
+- **Medium:** 17-19 inches (43-48 cm)
+- **Large:** 19-21 inches (48-53 cm)
+- **X-Large:** 21+ inches (53+ cm)
+
+---
+
+## Daypacks (20-35 Liters)
+
+### SummitTrail 25L Daypack
+**SKU:** PACK-ST-25
+**Price:** $89.99
+**Sizes:** One Size (fits most)
+
+Perfect for day hikes, urban exploring, and daily commutes.
+
+- **Capacity:** 25 liters
+- **Weight:** 1.3 lbs (590g)
+- **Materials:** 210D ripstop nylon body, water-resistant coating
+- **Features:** Breathable mesh back panel, hydration bladder compatible (3L), two side bottle pockets, trekking pole attachment
+- **Available Colors:** Forest Green, Slate Blue, Charcoal Grey, Sunset Orange
+
+**Best For:** Day hiking, biking, travel
+
+**Warranty:** 3-year limited warranty
+
+---
+
+### Explorer Pro 32L
+**SKU:** PACK-EP-32
+**Price:** $129.99
+**Sizes:** S/M, M/L
+
+A versatile technical daypack for serious hikers who need more capacity and features.
+
+- **Capacity:** 32 liters
+- **Weight:** 2.1 lbs (950g)
+- **Materials:** 210D ripstop nylon with DWR finish, YKK zippers
+- **Features:** AirFlow suspended mesh back panel, padded hip belt with pockets, dedicated hydration sleeve, ice axe loop
+- **Available Colors:** Alpine Blue, Summit Black, Trail Red
+
+**Best For:** Technical day hikes, scrambling, winter hiking
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Weekend Backpacks (40-50 Liters)
+
+### TrailMaster 45L
+**SKU:** PACK-TM-45
+**Price:** $189.99
+**Sizes:** S, M, L, XL
+
+The ideal pack for 1-3 night trips, offering excellent value and comfort.
+
+- **Capacity:** 45 liters (2,745 cubic inches)
+- **Weight:** 3.8 lbs (1.72 kg)
+- **Load Range:** 25-40 lbs (11-18 kg)
+- **Features:** Adjustable torso length, removable top lid, sleeping bag compartment, integrated rain cover, hydration compatible
+- **Available Colors:** Forest Green, Navy Blue, Grey/Black
+
+**Best For:** Weekend backpacking, overnight trips, hut-to-hut hiking
+
+**Warranty:** 5-year limited warranty
+
+---
+
+### Alpine Trekker 50L
+**SKU:** PACK-AT-50
+**Price:** $249.99
+**Sizes:** S, M, L, XL
+
+Premium weekend pack with enhanced comfort and technical features.
+
+- **Capacity:** 50 liters + 10L extendable collar = 60L max
+- **Weight:** 4.2 lbs (1.9 kg)
+- **Features:** FreeFloat adjustable suspension, 3D-molded foam back panel, built-in rain cover, QuickAdjust torso system
+- **Available Colors:** Summit Black, Mountain Grey, Alpine Blue, Terra Red
+
+**Best For:** Weekend backpacking, alpine trekking, shoulder-season trips
+
+**Warranty:** 10-year limited warranty
+
+---
+
+## Expedition Backpacks (60-75 Liters)
+
+### Expedition Pro 65L
+**SKU:** PACK-XP-65
+**Price:** $349.99
+**Sizes:** S, M, L, XL
+
+Our flagship expedition pack designed for extended trips and heavy loads. **Available in all sizes including XL.**
+
+- **Capacity:** 65 liters + 15L extendable collar = 80L max
+- **Weight:** 5.2 lbs (2.36 kg)
+- **Load Range:** 35-65 lbs (16-29 kg)
+- **Frame:** Internal aluminum stays (removable and adjustable)
+- **Features:** ExoFrame external aluminum perimeter frame, dual-access main compartment, integrated rain cover, crampon patch, helmet attachment straps
+- **Available Colors:** Expedition Black, Mountain Blue, Alpine Grey
+
+**Best For:** Week-long trips, mountaineering, international trekking
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+### Summit Master 75L
+**SKU:** PACK-SM-75
+**Price:** $429.99
+**Sizes:** M, L, XL
+
+Our largest and most capable pack for extended expeditions and high-altitude mountaineering. **Available in XL.**
+
+- **Capacity:** 75 liters + 15L collar extension = 90L max
+- **Weight:** 6.1 lbs (2.77 kg)
+- **Load Range:** 40-80 lbs (18-36 kg)
+- **Frame:** Dual aluminum stay system with HDPE framesheet
+- **Features:** Roll-top closure plus lid, triple compartment design, full-length side zip access, ski/snowboard carrying system
+- **Available Colors:** Expedition Black, Ice Blue
+
+**Best For:** Extended expeditions, high-altitude mountaineering, guided treks
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+## Backpack Accessories
+
+### Rain Cover Collection
+**SKU:** ACC-RC-SERIES
+**Price Range:** $19.99 - $34.99
+
+Custom-fit rain covers available for all Tailwind Traders backpack sizes (Small through X-Large). High-visibility colors with reflective accents.
+
+### Hydration Bladder - 3L
+**SKU:** ACC-HYD-3L
+**Price:** $39.99
+
+BPA-free, taste-free 3-liter hydration bladder with wide opening, insulated tube, and magnetic tube clip. Lifetime warranty against leaks.
+
+---
+
+## Fitting a Backpack
+
+1. **Adjust torso length** so the hip belt sits on the iliac crest.
+2. **Hip belt:** load about 20 lbs and tighten until 80% of the weight is on the hips.
+3. **Shoulder straps:** snug but not tight; anchors 1-2 inches below the shoulder tops.
+4. **Load lifters:** adjust to a 45-degree angle to pull weight off the shoulders.
+5. **Sternum strap:** position 2-3 inches below the collarbone.
+
+> **Pro Tip:** Offer customers an in-store professional fitting. Trained staff help find the perfect pack and ensure optimal fit.
+
+---
+
+## Contact Information
+
+**Tailwind Traders**
+Customer Service: 1-800-TAILWIND
+Email: backpacks@tailwindtraders.com
+Website: www.tailwindtraders.com/backpacks
+
+*All specifications are approximate. Colors may vary from images shown.*
+
+**Last Updated:** January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-camping-accessories.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-camping-accessories.md
@@ -1,0 +1,199 @@
+# Tailwind Traders - Camping Accessories & Equipment 2026
+
+## Essential Gear for Every Adventure
+
+Complete a customer's outdoor setup with the Tailwind Traders collection of camping accessories. From sleeping comfort to cooking essentials, we have everything needed for a successful camping experience. Store staff can use this document to answer accessory questions and build add-on recommendations.
+
+---
+
+## Sleeping Systems
+
+### Sleeping Bags
+
+#### Alpine Down -15F
+**SKU:** SLP-AD-15
+**Price:** $299.99
+**Temperature Rating:** -15F / -26C (Comfort)
+
+Premium 800-fill power down sleeping bag for cold weather camping.
+- **Fill:** 800-fill power RDS-certified goose down
+- **Weight:** 3.2 lbs (1.45 kg)
+- **Features:** Mummy shape, insulated draft tube, compression stuff sack included
+
+**Best For:** Winter camping, high-altitude mountaineering
+
+**Warranty:** 5-year limited warranty
+
+#### TrailRest 20F
+**SKU:** SLP-TR-20
+**Price:** $129.99
+**Temperature Rating:** 20F / -7C (Comfort)
+
+Affordable synthetic bag for three-season camping.
+- **Fill:** TailwindTherm synthetic insulation
+- **Weight:** 4.1 lbs (1.86 kg)
+- **Features:** Semi-rectangular shape, two-way zipper, machine washable
+
+**Best For:** Spring through fall camping, car camping, scout trips
+
+**Warranty:** 3-year limited warranty
+
+#### Summer Lite 40F
+**SKU:** SLP-SL-40
+**Price:** $79.99
+**Temperature Rating:** 40F / 4C (Comfort)
+
+Lightweight bag for warm weather camping and backpacking.
+- **Weight:** 2.3 lbs (1.04 kg)
+- **Features:** Rectangular shape, zips together with another bag, lightweight compression sack
+
+**Best For:** Summer camping, festivals, emergency kit
+
+**Warranty:** 2-year limited warranty
+
+### Sleeping Pads
+
+#### Alpine Air Pro
+**SKU:** PAD-AAP
+**Price:** $179.99
+
+Premium inflatable sleeping pad with superior insulation.
+- **R-Value:** 5.4 (four-season use)
+- **Weight:** 1.7 lbs (771g)
+- **Features:** Vertical sidewalls, Cyclone pump sack, self-sealing flat valve, repair kit included
+- **Sizes:** Regular $179.99, Large $199.99, X-Large $219.99
+
+**Best For:** Backpacking, cold weather camping, side sleepers
+
+**Warranty:** Lifetime warranty against defects
+
+---
+
+## Cooking Equipment
+
+### Trail Chef Stove System
+**SKU:** COOK-TCS
+**Price:** $149.99
+
+Integrated canister stove system for fast boiling.
+- **Boil Time:** 2.5 minutes (16 oz water)
+- **Weight:** 14.2 oz (403g) including pot
+- **Fuel:** Isobutane-propane mix (canister sold separately)
+- **Features:** Heat exchanger, built-in igniter, insulated cozy, strainer lid
+
+**Best For:** Solo backpacking, fast cooking
+
+**Warranty:** 3-year limited warranty
+
+### BaseCamp Cookset
+**SKU:** COOK-BCS
+**Price:** $79.99
+
+Complete family cooking system in hard-anodized aluminum. Includes a 3L pot, a 2L pot, a 9-inch frying pan, four bowls, four sporks, and a storage bag. Nests together for compact storage.
+
+**Best For:** Family camping, group trips
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Lighting
+
+### HeadLamp Pro 500
+**SKU:** LGT-HLP-500
+**Price:** $49.99
+
+High-performance rechargeable headlamp.
+- **Max Output:** 500 lumens
+- **Run Time:** 2 hours (high), 24 hours (low)
+- **Water Rating:** IPX6 (weather resistant)
+- **Features:** USB rechargeable, red light mode, tilting head, lockout mode
+
+**Best For:** Night hiking, camping, trail running
+
+**Warranty:** 2-year limited warranty
+
+### Lantern LED 600
+**SKU:** LGT-LED-600
+**Price:** $39.99
+
+Collapsible LED lantern for camp lighting.
+- **Max Output:** 600 lumens
+- **Run Time:** 6 hours (high), 40 hours (low)
+- **Features:** Collapses for storage, hanging hook, SOS flash mode, water-resistant (IPX4)
+
+**Best For:** Campsite lighting, emergency kit
+
+**Warranty:** 3-year limited warranty
+
+---
+
+## Hydration
+
+### Water Filter Pro
+**SKU:** HYD-WFP
+**Price:** $79.99
+
+Lightweight gravity water filter system.
+- **Flow Rate:** 2L in 3 minutes
+- **Filter Life:** 1,500 liters
+- **Removes:** 99.99% bacteria, 99.9% protozoa
+- **Features:** Gravity-fed, quick-connect system, backflush syringe included
+
+**Best For:** Group camping, base camp, emergencies
+
+**Warranty:** Limited lifetime warranty
+
+### Water Bottle Insulated 32oz
+**SKU:** HYD-WB-32
+**Price:** $34.99
+
+Double-wall insulated stainless steel bottle. Keeps cold 24 hours, hot 12 hours. Leak-proof wide-mouth lid, BPA-free.
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Navigation & Safety
+
+### GPS Navigator Pro
+**SKU:** NAV-GPS-PRO
+**Price:** $399.99
+
+Rugged handheld GPS with preloaded topographic maps, 3-inch color touchscreen, 20-hour battery, and IPX7 submersible rating. SOS alert capability requires a subscription.
+
+**Best For:** Backcountry navigation, orienteering
+
+**Warranty:** 2-year limited warranty
+
+### First Aid Kit - Trail
+**SKU:** SAF-FAK-TRL
+**Price:** $49.99
+
+Comprehensive first aid kit for outdoor adventures. Treats 1-4 people for 1-4 days. Includes bandages, gauze, medical tape, antiseptic wipes, blister treatment, emergency blanket, and a first aid guide in a water-resistant bag.
+
+**Best For:** Hiking, camping, backcountry travel
+
+---
+
+## Recommended Accessories for a Weekend Hiking Trip
+
+When a customer books a weekend guided trip, staff should recommend this starter bundle:
+- HeadLamp Pro 500 (LGT-HLP-500)
+- Water Filter Pro (HYD-WFP)
+- TrailRest 20F sleeping bag (SLP-TR-20)
+- Alpine Air Pro sleeping pad (PAD-AAP)
+- First Aid Kit - Trail (SAF-FAK-TRL)
+
+---
+
+## Contact & Support
+
+**Tailwind Traders**
+Customer Service: 1-800-TAILWIND
+Email: gear@tailwindtraders.com
+Website: www.tailwindtraders.com
+
+*All specifications are approximate. Products and prices subject to change without notice.*
+
+**Last Updated:** January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-returns-and-rentals-policy.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-returns-and-rentals-policy.md
@@ -1,0 +1,69 @@
+# Tailwind Traders - Returns and Rentals Policy
+
+Effective: January 2026
+Owner: Retail Operations Team
+
+This policy tells store staff how to handle product returns, exchanges, and gear rentals for guided trips. The internal knowledge assistant is grounded on this document.
+
+========================================
+RETURNS AND EXCHANGES
+========================================
+
+Standard Return Window:
+- Unused items with a receipt: 90 days for a full refund to the original payment method
+- Unused items without a receipt: store credit at the current selling price
+- Tents, sleeping bags, and backpacks: 90-day window; must be clean, dry, and free of damage
+
+Worn or Used Gear:
+- Items showing normal use may be returned within 30 days for store credit at staff discretion
+- Items returned dirty or wet are subject to a $25 cleaning fee before credit is issued
+
+Defective Items:
+- Manufacturing defects are covered by the product warranty (see each product catalog)
+- Defective items can be exchanged at any time within the warranty period
+- Log defective returns in the inventory portal so they can be sent back to the supplier
+
+Non-Returnable Items:
+- Fuel canisters and other consumables
+- Used first aid kits
+- Final-sale clearance items (marked on the receipt)
+
+========================================
+GEAR RENTALS FOR GUIDED TRIPS
+========================================
+
+Tailwind Traders rents tents, sleeping bags, sleeping pads, and stoves for guided trips.
+
+Rental Tiers:
+- Standard gear: $20 per day
+- Premium gear: $35 per day
+- Group/family tents: $45 per day
+
+Service Level Multipliers:
+- Standard service: 1.0x
+- Priority service (pre-staged and pre-checked before the trip): 1.25x
+
+Deposits:
+- A refundable deposit equal to 50% of the item's retail price is collected at pickup
+- The deposit is returned when gear is checked back in clean and undamaged
+- Cleaning fee: $15 per item returned dirty; damage is charged at repair or replacement cost
+
+Example Calculation:
+- 5 days of premium gear at priority service = 5 x $35 x 1.25 = $218.75 rental fee (plus deposit)
+
+Booking Rules:
+- Confirm trip availability at the guided-trips desk before reserving rental gear
+- Reserve rental gear at least 48 hours before the trip start date
+- Recommend the weekend gear bundle from the Camping Accessories catalog
+
+========================================
+CONTACT INFORMATION
+========================================
+
+- Returns questions: returns@tailwindtraders.com or (555) 200-4570
+- Rentals and guided trips: trips@tailwindtraders.com or (555) 200-4571
+
+If the assistant cannot find an answer here, advise the customer that a staff member will follow up.
+
+Policy Version: 1.0
+Last Updated: January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-store-operations.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-store-operations.md
@@ -1,0 +1,91 @@
+# Tailwind Traders - Store Operations Handbook
+
+Effective: January 2026
+Owner: Retail Operations Team
+
+This handbook gives Tailwind Traders store staff the operational policies they need day to day: store hours, staff accounts and systems security, and how to handle customer data. The internal knowledge assistant is grounded on this document so staff can get quick, accurate answers.
+
+========================================
+STORE HOURS AND STAFF AVAILABILITY
+========================================
+
+Store Hours:
+- Monday-Saturday: 9:00 AM - 8:00 PM (local store time)
+- Sunday: 10:00 AM - 6:00 PM
+- Guided-trip desk: opens 30 minutes before the store and closes 30 minutes after
+
+Core Hours for Staff:
+All store staff must be available and on the floor during core hours:
+- Monday-Friday: 10:00 AM - 4:00 PM (local time)
+- Respond to internal Teams messages within 30 minutes during core hours
+- Trade or swap shifts through the staff scheduling app at least 48 hours in advance
+
+========================================
+STAFF ACCOUNTS AND SYSTEMS SECURITY
+========================================
+
+Every staff member has a Tailwind Traders account used for the point-of-sale (POS) system, the inventory portal, and Microsoft 365 (email, Teams, SharePoint).
+
+Password Requirements:
+- Minimum 12 characters
+- Must include uppercase, lowercase, numbers, and special characters
+- Change every 90 days
+- Cannot reuse the last 5 passwords
+- No dictionary words or common patterns
+
+Multi-Factor Authentication (MFA):
+MFA is required for the POS system, the inventory portal, VPN access, and all Microsoft 365 apps.
+
+Supported MFA methods:
+- Microsoft Authenticator app (recommended)
+- SMS text message (backup)
+- Security key (for manager and admin accounts)
+- Phone call (alternative)
+
+Register at least two authentication methods and keep backup codes in a safe location.
+
+Register Handling:
+- Lock the POS screen (Windows+L) whenever stepping away from the register
+- Never share a POS login with another staff member
+- Report a lost badge or suspected account compromise to the store manager immediately
+
+========================================
+CUSTOMER DATA HANDLING
+========================================
+
+Data Classification:
+- PUBLIC: marketing materials, catalog content, store hours
+- INTERNAL: staffing schedules, standard operating procedures, restock reports
+- CONFIDENTIAL: customer orders, payment details, personal contact information
+- RESTRICTED: supplier pricing agreements, unreleased product plans
+
+Rules for Confidential and Restricted data:
+- Access on a need-to-know basis only
+- Never email customer payment details
+- Share documents through SharePoint or OneDrive links only, never personal cloud services
+- Set expiration dates on shared links and review shares quarterly
+
+========================================
+GUIDED TRIPS DESK
+========================================
+
+Tailwind Traders runs guided trips in several regions (for example: Pacific Northwest, Rockies, Patagonia).
+Staff at the trips desk:
+- Confirm trip availability and capacity before taking a booking
+- Recommend the weekend gear bundle from the Camping Accessories catalog
+- Collect the rental agreement and deposit (see the Returns and Rentals Policy)
+
+========================================
+ESCALATION AND SUPPORT
+========================================
+
+- Product and inventory questions: use the internal knowledge assistant, then the inventory portal
+- POS or account issues: IT Helpdesk at ithelp@tailwindtraders.com or (555) 200-4580
+- HR and scheduling: staffops@tailwindtraders.com or (555) 200-4567
+- Security incidents (lost device, phishing, account compromise): security@tailwindtraders.com, 24/7 hotline (555) 200-4599
+
+If the assistant cannot find an answer in the store documentation, tell the customer you will follow up and contact the relevant team above.
+
+Handbook Version: 1.0
+Last Updated: January 2026
+Next Review: January 2027

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-supplier-guide.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-supplier-guide.md
@@ -1,0 +1,76 @@
+# Tailwind Traders - Supplier and Restock Guide
+
+Effective: January 2026
+Owner: Supply Chain Team
+
+This guide gives store staff the supplier, restock, and supplier-returns information they need to keep shelves stocked and to send defective product back correctly. The internal knowledge assistant is grounded on this document.
+
+========================================
+KEY SUPPLIERS
+========================================
+
+Tents:
+- Supplier: Summit Shelter Co.
+- Lead time: 3 weeks
+- Minimum order: 10 units per model
+- Contact: orders@summitshelter.example
+
+Backpacks:
+- Supplier: Ridgeline Packs Ltd.
+- Lead time: 2 weeks
+- Minimum order: 12 units per model
+- Contact: wholesale@ridgelinepacks.example
+
+Sleeping systems and accessories:
+- Supplier: BasecampGear Distribution
+- Lead time: 10 business days
+- Minimum order: no minimum for accessories; 6 units per sleeping bag model
+- Contact: b2b@basecampgear.example
+
+========================================
+RESTOCK RULES
+========================================
+
+Reorder Thresholds:
+- Recommend a restock when on-hand inventory for an item falls below 10 units AND weekly sales are above 15 units
+- Recommend clearance when on-hand inventory is above 20 units AND weekly sales are below 5 units
+- Flagship items (Windward Explorer 2P, Expedition Pro 65L) should never fall below 5 units on hand
+
+Ordering Process:
+1. Check current on-hand levels in the inventory portal
+2. Compare against the reorder thresholds above
+3. Raise a purchase order to the relevant supplier, respecting the minimum order quantity
+4. Record the expected delivery date and follow up if it is late
+
+Seasonal Notes:
+- Order winter and four-season tents by early autumn; Summit Shelter Co. lead times double in Q4
+- Increase daypack stock ahead of the spring and summer guided-trip season
+
+========================================
+RETURNS TO SUPPLIER
+========================================
+
+Defective Product:
+- Log every defective item in the inventory portal with the SKU, batch, and a short description
+- Batch defective returns weekly and ship them back under the supplier's RMA (Return Merchandise Authorization) process
+- Request an RMA number from the supplier before shipping; never ship without one
+
+Warranty Claims:
+- Customer warranty returns are first credited to the customer (see the Returns and Rentals Policy)
+- The store then recovers the cost from the supplier under the warranty terms in the product catalog
+
+Damaged-in-Transit:
+- Photograph damaged shipments before unpacking further
+- Report to the supplier within 48 hours of delivery to qualify for replacement
+
+========================================
+CONTACT INFORMATION
+========================================
+
+- Supply chain team: supplychain@tailwindtraders.com or (555) 200-4590
+- Inventory portal support: ithelp@tailwindtraders.com or (555) 200-4580
+
+If the assistant cannot find supplier or restock details here, advise staff to contact the supply chain team.
+
+Guide Version: 1.0
+Last Updated: January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-tents-catalog.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/data/tailwind-tents-catalog.md
@@ -1,0 +1,180 @@
+# Tailwind Traders - Tents Catalog 2026
+
+## Welcome to Tailwind Traders Tents
+
+Tailwind Traders is proud to present our comprehensive line of high-quality tents designed for every outdoor adventure. Whether your customer is a weekend camper, a serious backpacker, or a family looking for a comfortable outdoor experience, we have the perfect tent for them. Store staff can use this catalog to answer product questions, compare models, and make recommendations.
+
+---
+
+## 2-Person Backpacking Tents
+
+### Windward Explorer 2P
+**SKU:** TENT-WEX-2P
+**Price:** $329.99
+
+Our flagship ultralight backpacking tent, perfect for serious hikers and mountaineers who need reliable shelter without the extra weight.
+
+**Features:**
+- **Weight:** 3.2 lbs (1.45 kg) including stakes and guylines
+- **Floor Area:** 28 sq ft (2.6 sq m)
+- **Peak Height:** 42 inches (107 cm)
+- **Waterproof Rating:** 3000mm rain fly, 5000mm floor
+- **Materials:** 20D ripstop nylon fly with silicone coating; DAC aluminum poles
+- **Ventilation:** Dual vestibules with mesh panels for superior airflow
+- **Setup:** Freestanding design with color-coded clips for easy 5-minute setup
+
+**Best For:** Alpine climbing, long-distance backpacking, bike touring
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+### TrailMaster Lite 2P
+**SKU:** TENT-TML-2P
+**Price:** $219.99
+
+An excellent value option for recreational backpackers, combining comfort and durability at an accessible price point.
+
+**Features:**
+- **Weight:** 4.8 lbs (2.18 kg)
+- **Floor Area:** 32 sq ft (3.0 sq m)
+- **Peak Height:** 44 inches (112 cm)
+- **Waterproof Rating:** 2000mm rain fly, 3000mm floor
+- **Materials:** 75D polyester taffeta fly and floor; fiberglass poles
+- **Setup:** Simple two-pole design, 10-minute setup
+
+**Best For:** Weekend camping, beginner backpackers, casual hikers
+
+**Warranty:** 3-year limited warranty
+
+---
+
+## 4-Person Family Tents
+
+### SummitDome 4P
+**SKU:** TENT-SD-4P
+**Price:** $279.99
+
+Our most popular family tent, offering spacious comfort and ease of setup for car camping and family adventures.
+
+**Features:**
+- **Weight:** 12.5 lbs (5.67 kg)
+- **Floor Area:** 64 sq ft (5.9 sq m)
+- **Center Height:** 68 inches (173 cm)
+- **Waterproof Rating:** 1500mm rain fly, 2000mm floor
+- **Room Divider:** Removable center divider creates two separate sleeping areas
+- **Setup:** Simple dome design, 15-minute setup with color-coded poles
+
+**Best For:** Family camping, car camping, festivals
+
+**Warranty:** 2-year limited warranty
+
+---
+
+### MegaSpace 4P Cabin
+**SKU:** TENT-MS-4P
+**Price:** $399.99
+
+A cabin tent offering stand-up room and home-like comfort for families who want maximum living space at the campsite.
+
+**Features:**
+- **Weight:** 18.2 lbs (8.26 kg)
+- **Floor Area:** 80 sq ft (7.4 sq m)
+- **Center Height:** 78 inches (198 cm) - full stand-up height
+- **Waterproof Rating:** 2000mm rain fly, 3000mm floor
+- **Room Configuration:** Divides into 2 rooms with the included privacy panel
+- **Setup:** Hub-style pole system, 20-minute setup
+
+**Best For:** Extended family camping trips, base camp, glamping
+
+**Warranty:** 3-year limited warranty
+
+---
+
+## 6-Person Group Tents
+
+### BaseCamp Pro 6P
+**SKU:** TENT-BCP-6P
+**Price:** $549.99
+
+Our premium large-capacity tent designed for groups, families, or extended camping trips where comfort and durability are paramount.
+
+**Features:**
+- **Weight:** 24.8 lbs (11.25 kg)
+- **Floor Area:** 120 sq ft (11.1 sq m)
+- **Center Height:** 84 inches (213 cm)
+- **Waterproof Rating:** 3000mm rain fly, 5000mm floor
+- **Room Configuration:** 3-room design with 2 removable dividers
+- **Weather Protection:** Extended rain fly, taped seams, storm flaps over all zippers
+
+**Best For:** Large families, scout groups, long-term camping
+
+**Warranty:** 5-year limited warranty
+
+---
+
+## Specialty Tents
+
+### FourSeason Alpine 2P
+**SKU:** TENT-4SA-2P
+**Price:** $599.99
+
+Our most technical tent, engineered for mountaineering and winter camping in extreme conditions.
+
+**Features:**
+- **Weight:** 6.8 lbs (3.08 kg)
+- **Waterproof Rating:** 5000mm rain fly, 10000mm floor
+- **4-Season Construction:** Minimal mesh for warmth retention, full-coverage fly
+- **Weather Protection:** Engineered for extreme wind loads and snow accumulation
+
+**Best For:** Mountaineering, winter camping, alpine expeditions
+
+**Warranty:** Lifetime limited warranty
+
+---
+
+### UltraLite Solo 1P
+**SKU:** TENT-ULS-1P
+**Price:** $249.99
+
+The ultimate minimalist shelter for solo adventurers who count every ounce.
+
+**Features:**
+- **Weight:** 1.9 lbs (0.86 kg) including stakes
+- **Floor Area:** 17 sq ft (1.6 sq m)
+- **Waterproof Rating:** 3000mm rain fly, 5000mm floor
+- **Setup:** Trekking pole compatible (pole not included), 3-minute setup
+
+**Best For:** Ultralight backpacking, thru-hiking, fast-packing
+
+**Warranty:** 2-year limited warranty
+
+---
+
+## Rental Fleet
+
+All family and group tents above are available through the Tailwind Traders **gear rental** program.
+See the *Returns and Rentals Policy* document for daily rates, deposits, and cleaning fees.
+
+---
+
+## Care and Maintenance
+
+1. **Always dry your tent completely** before storing to prevent mold and mildew.
+2. **Store loosely** - never keep your tent compressed for extended periods.
+3. **Clean with mild soap** and water only - harsh detergents damage coatings.
+4. **Reseal seams** annually with seam sealer for maximum waterproofing.
+5. **Repair small tears** immediately with repair tape to prevent further damage.
+
+---
+
+## Contact Information
+
+**Tailwind Traders**
+Customer Service: 1-800-TAILWIND
+Email: support@tailwindtraders.com
+Website: www.tailwindtraders.com
+
+*Prices and specifications subject to change. All weights are approximate.*
+
+**Last Updated:** January 2026

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/knowledge_agent.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/knowledge_agent.py
@@ -1,0 +1,205 @@
+import os
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+# Load environment variables
+load_dotenv()
+project_endpoint = os.getenv("PROJECT_ENDPOINT")
+agent_name = os.getenv("AGENT_NAME")
+
+# Validate configuration
+if not project_endpoint or not agent_name:
+    raise ValueError("PROJECT_ENDPOINT and AGENT_NAME must be set in .env file")
+
+print(f"Connecting to project: {project_endpoint}")
+print(f"Using agent: {agent_name}\n")
+
+# Connect to the project and agent
+credential = DefaultAzureCredential(
+    exclude_environment_credential=True,
+    exclude_managed_identity_credential=True
+)
+project_client = AIProjectClient(
+    credential=credential,
+    endpoint=project_endpoint
+)
+
+# Get the OpenAI client
+openai_client = project_client.get_openai_client()
+
+# Get the agent
+agent = project_client.agents.get(agent_name=agent_name)
+print(f"Connected to agent: {agent.name} (id: {agent.id})\n")
+
+# Create a new conversation
+conversation = openai_client.conversations.create(items=[])
+print(f"Created conversation (id: {conversation.id})\n")
+
+
+# Conversation history for context (client-side tracking)
+conversation_history = []
+
+
+def send_message_to_agent(user_message):
+    """
+    Send a message to the agent and handle the response using the conversations API.
+    """
+    try:
+        print("\nAgent: ", end="", flush=True)
+
+        # Add user message to the conversation
+        openai_client.conversations.items.create(
+            conversation_id=conversation.id,
+            items=[{"type": "message", "role": "user", "content": user_message}],
+        )
+
+        # Store in conversation history (client-side)
+        conversation_history.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        # Create a response using the agent
+        response = openai_client.responses.create(
+            conversation=conversation.id,
+            extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+            input=""
+        )
+
+        # Check if the response output contains an MCP approval request
+        approval_request = None
+        if hasattr(response, 'output') and response.output:
+            for item in response.output:
+                if hasattr(item, 'type') and item.type == 'mcp_approval_request':
+                    approval_request = item
+                    break
+
+        # Handle approval request if present
+        if approval_request:
+            print(f"[Approval required for: {approval_request.name}]\n")
+            print(f"Server: {approval_request.server_label}")
+
+            # Parse and display the arguments (optional, for transparency)
+            import json
+            try:
+                args = json.loads(approval_request.arguments)
+                print(f"Arguments: {json.dumps(args, indent=2)}\n")
+            except Exception:
+                print(f"Arguments: {approval_request.arguments}\n")
+
+            # Prompt user for approval
+            approval_input = input("Approve this action? (yes/no): ").strip().lower()
+
+            if approval_input in ['yes', 'y']:
+                print("Approving action...\n")
+
+                # Create approval response item
+                approval_response = {
+                    "type": "mcp_approval_response",
+                    "approval_request_id": approval_request.id,
+                    "approve": True
+                }
+            else:
+                print("Action denied.\n")
+
+                # Create denial response item
+                approval_response = {
+                    "type": "mcp_approval_response",
+                    "approval_request_id": approval_request.id,
+                    "approve": False
+                }
+
+            # Add the approval response to the conversation
+            openai_client.conversations.items.create(
+                conversation_id=conversation.id,
+                items=[approval_response]
+            )
+
+            # Get the actual response after approval/denial
+            response = openai_client.responses.create(
+                conversation=conversation.id,
+                extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+                input=""
+            )
+
+        # Extract the response text
+        if response and response.output_text:
+            response_text = response.output_text
+
+            print(f"{response_text}\n")
+
+            # Check for citations if available
+            if hasattr(response, 'citations') and response.citations:
+                print("\nSources:")
+                for citation in response.citations:
+                    print(f"  - {citation.content if hasattr(citation, 'content') else 'Knowledge Base'}")
+
+            # Store in conversation history (client-side)
+            conversation_history.append({
+                "role": "assistant",
+                "content": response_text
+            })
+
+            return response_text
+        else:
+            print("No response received.\n")
+            return None
+    except Exception as e:
+        print(f"\n\nError: {str(e)}\n")
+        return None
+
+
+def display_conversation_history():
+    """
+    Display the full conversation history.
+    """
+    print("\n" + "=" * 60)
+    print("CONVERSATION HISTORY")
+    print("=" * 60 + "\n")
+
+    for turn in conversation_history:
+        role = turn["role"].upper()
+        content = turn["content"]
+        print(f"{role}: {content}\n")
+
+    print("=" * 60 + "\n")
+
+
+def main():
+    """
+    Main interaction loop.
+    """
+    print("Tailwind Traders Knowledge Assistant")
+    print("Ask questions about our products, store policies, returns, rentals, and suppliers.")
+    print("Type 'history' to see conversation history, or 'quit' to exit.\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+
+            if not user_input:
+                continue
+
+            if user_input.lower() == 'quit':
+                print("\nEnding conversation...")
+                break
+
+            if user_input.lower() == 'history':
+                display_conversation_history()
+                continue
+
+            # Send message and get response
+            send_message_to_agent(user_input)
+
+        except KeyboardInterrupt:
+            print("\n\nInterrupted by user.")
+            break
+        except Exception as e:
+            print(f"\nUnexpected error: {str(e)}\n")
+
+    print("\nConversation ended.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/knowledge_chat_app.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/knowledge_chat_app.py
@@ -1,0 +1,91 @@
+"""
+Tailwind Traders Staff Knowledge Assistant - web chat variant (provided complete).
+
+This is an optional, friendlier version of knowledge_agent.py. Instead of a console
+loop, it serves the same Foundry IQ enterprise-knowledge agent through the shared
+Tailwind Traders web chat window (tailwind_ui.py).
+
+To keep the browser experience smooth, this variant AUTO-APPROVES the Foundry IQ
+knowledge tool when the agent asks for approval. The console client
+(knowledge_agent.py) shows the interactive yes/no approval flow instead.
+"""
+
+import os
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+from tailwind_ui import run_chat_app
+
+# Load environment variables
+load_dotenv()
+project_endpoint = os.getenv("PROJECT_ENDPOINT")
+agent_name = os.getenv("AGENT_NAME")
+
+if not project_endpoint or not agent_name:
+    raise ValueError("PROJECT_ENDPOINT and AGENT_NAME must be set in .env file")
+
+# Connect to the project and agent
+credential = DefaultAzureCredential(
+    exclude_environment_credential=True,
+    exclude_managed_identity_credential=True
+)
+project_client = AIProjectClient(
+    credential=credential,
+    endpoint=project_endpoint
+)
+openai_client = project_client.get_openai_client()
+agent = project_client.agents.get(agent_name=agent_name)
+
+# One shared conversation for the browser session
+conversation = openai_client.conversations.create(items=[])
+
+
+def respond(user_message):
+    """Route a chat message to the Foundry IQ agent and return the reply text."""
+    # Add the user's message to the conversation
+    openai_client.conversations.items.create(
+        conversation_id=conversation.id,
+        items=[{"type": "message", "role": "user", "content": user_message}],
+    )
+
+    # Ask the agent to respond
+    response = openai_client.responses.create(
+        conversation=conversation.id,
+        extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+        input=""
+    )
+
+    # Auto-approve any Foundry IQ knowledge-tool approval request
+    approval_request = None
+    if getattr(response, "output", None):
+        for item in response.output:
+            if getattr(item, "type", None) == "mcp_approval_request":
+                approval_request = item
+                break
+
+    if approval_request:
+        openai_client.conversations.items.create(
+            conversation_id=conversation.id,
+            items=[{
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request.id,
+                "approve": True,
+            }],
+        )
+        response = openai_client.responses.create(
+            conversation=conversation.id,
+            extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
+            input=""
+        )
+
+    return response.output_text or "No response received."
+
+
+if __name__ == "__main__":
+    run_chat_app(
+        respond,
+        title="Tailwind Traders Staff Knowledge Assistant",
+        subtitle="Grounded on store policies, product catalog, returns, rentals, and supplier docs.",
+        placeholder="Ask about products, returns, rentals, or suppliers...",
+    )

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/requirements.txt
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/requirements.txt
@@ -1,0 +1,6 @@
+python-dotenv
+azure-identity
+azure-ai-projects==2.3.0
+openai
+mcp
+gradio==6.20.0

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/tailwind_ui.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/tailwind_ui.py
@@ -1,0 +1,68 @@
+"""
+Tailwind Traders – shared chat UI shell (provided).
+
+You don't need to edit this file. It gives every task in the lab the same simple
+web chat window so your agent feels like a real app instead of a console script.
+
+Each task provides a `respond` function that takes the user's message and returns
+either a plain string, or an `AgentReply` carrying text plus any image files to
+show inline (for example, a chart produced by the code interpreter). The function
+may be synchronous or asynchronous (Task 5 uses an async one for the MCP session).
+"""
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Callable
+
+import gradio as gr
+
+
+@dataclass
+class AgentReply:
+    """A single reply from the agent."""
+    text: str = ""
+    images: list = field(default_factory=list)  # local image file paths to display inline
+
+
+def run_chat_app(
+    respond: Callable,
+    title: str = "Tailwind Traders Assistant",
+    subtitle: str = "",
+    placeholder: str = "Ask the assistant...",
+    server_port: int = 7860,
+):
+    """Launch a browser chat window that routes each message to `respond`."""
+
+    async def handle(user_message, history):
+        history = (history or []) + [{"role": "user", "content": user_message}]
+
+        # Call the task's respond function (await it if it's async)
+        result = respond(user_message)
+        if inspect.isawaitable(result):
+            result = await result
+
+        if isinstance(result, str):
+            result = AgentReply(text=result)
+
+        if result and result.text:
+            history.append({"role": "assistant", "content": result.text})
+        for image_path in (result.images if result else []):
+            history.append({"role": "assistant", "content": {"path": image_path}})
+
+        return history, ""
+
+    with gr.Blocks(title=title) as demo:
+        gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
+        if subtitle:
+            gr.Markdown(subtitle)
+        chatbot = gr.Chatbot(height=460, show_label=False)
+        with gr.Row():
+            textbox = gr.Textbox(
+                placeholder=placeholder, show_label=False, scale=8, autofocus=True
+            )
+            send = gr.Button("Send", variant="primary", scale=1)
+
+        for trigger in (textbox.submit, send.click):
+            trigger(handle, [textbox, chatbot], [chatbot, textbox])
+
+    demo.launch(server_port=server_port, inbrowser=True, css="footer {visibility: hidden}", theme=gr.themes.Soft())

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/workiq_lab.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/workiq_lab.py
@@ -1,0 +1,541 @@
+"""
+Tailwind Traders - Work IQ Integration (Workplace Intelligence Agent)
+
+This application demonstrates how to build agents that access Microsoft 365
+workplace data using Work IQ (a Model Context Protocol server for M365 Copilot).
+
+Scenarios covered:
+1. Meeting Prep - Get context for upcoming meetings
+2. Project Status - Track project updates from M365 data
+3. Action Items - Extract tasks from emails and meetings
+4. Combined Intelligence - Use both Work IQ + Foundry IQ
+5. Custom Query - Ask your own workplace questions
+
+Run this single file to explore all Work IQ capabilities.
+"""
+
+import os
+import time
+import json
+import asyncio
+from dotenv import load_dotenv
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import PromptAgentDefinition, Tool, FunctionTool
+from azure.identity import DefaultAzureCredential
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from openai.types.responses.response_input_param import FunctionCallOutput, ResponseInputParam
+
+# Load environment variables
+load_dotenv()
+
+class WorkIQLab:
+    def __init__(self):
+        """Initialize the lab with Microsoft Foundry connection."""
+        self.project_endpoint = os.getenv("PROJECT_ENDPOINT")
+        self.model_deployment = os.getenv("MODEL_DEPLOYMENT_NAME", "gpt-5")
+
+        if not self.project_endpoint:
+            print("[ERROR] PROJECT_ENDPOINT not set in .env file")
+            print("Please configure .env with your Microsoft Foundry project endpoint")
+            exit(1)
+
+        print("Connecting to Microsoft Foundry project...")
+        self.credential = DefaultAzureCredential()
+        self.project_client = None
+        self.openai_client = None
+        self.workiq_client = None
+        self.agent = None
+        self.workiq_server_params = None
+
+    def validate_workiq_setup(self):
+        """Check if Work IQ is installed and accessible."""
+        import subprocess
+
+        print("\n" + "=" * 70)
+        print("VALIDATING WORK IQ SETUP")
+        print("=" * 70)
+
+        try:
+            # Check if workiq command is available
+            result = subprocess.run(
+                ["workiq", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                shell=True
+            )
+
+            if result.returncode == 0:
+                print("[OK] Work IQ is installed")
+                print(f"   Version: {result.stdout.strip()}\n")
+                return True
+            else:
+                print("[ERROR] Work IQ not found or not working properly")
+                print("\nTo install Work IQ:")
+                print("   npm install -g @microsoft/workiq")
+                print("   workiq accept-eula\n")
+                return False
+
+        except FileNotFoundError:
+            print("[ERROR] Work IQ command not found")
+            print("\nTo install Work IQ:")
+            print("   npm install -g @microsoft/workiq")
+            print("   workiq accept-eula\n")
+            return False
+        except Exception as e:
+            print(f"[WARN] Could not validate Work IQ setup: {e}")
+            print("   Continuing anyway - you may encounter errors\n")
+            return True
+
+    def connect(self):
+        """Establish connection to Microsoft Foundry and Work IQ."""
+        try:
+            # Validate Work IQ first
+            if not self.validate_workiq_setup():
+                print("[WARN] Work IQ validation failed, but continuing...")
+                print("   Make sure Work IQ is installed and configured.\n")
+
+            # Create project client
+            self.project_client = AIProjectClient(
+                credential=self.credential,
+                endpoint=self.project_endpoint
+            )
+
+            # Get OpenAI-compatible client for Responses API
+            self.openai_client = self.project_client.get_openai_client()
+
+            # Initialize Work IQ MCP client
+            print("Connecting to Work IQ MCP server...")
+            self.workiq_server_params = StdioServerParameters(
+                command="npx",
+                args=["-y", "@microsoft/workiq", "mcp"]
+            )
+
+            # Get available tools from Work IQ
+            print("[OK] Connected to Microsoft Foundry and Work IQ MCP\n")
+
+            # Create a single agent with Work IQ tools
+            self._create_workplace_agent()
+
+            return True
+
+        except Exception as e:
+            print(f"[ERROR] Connection failed: {e}")
+            print("\nTroubleshooting:")
+            print("  1. Ensure Work IQ is installed: npm install -g @microsoft/workiq")
+            print("  2. Accept EULA: workiq accept-eula")
+            print("  3. Ensure you have M365 Copilot license and admin consent")
+            print("  4. Test with: workiq ask -q 'What meetings do I have today?'")
+            return False
+
+    def _get_workiq_tools(self):
+        """Fetch tools from Work IQ MCP server."""
+        async def _fetch():
+            async with stdio_client(self.workiq_server_params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    tools_result = await session.list_tools()
+                    return tools_result.tools
+        return asyncio.run(_fetch())
+
+    def _call_workiq_tool(self, tool_name, kwargs):
+        """Execute a Work IQ tool via MCP and return result."""
+        async def _execute():
+            async with stdio_client(self.workiq_server_params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool_name, kwargs)
+                    return result
+        return asyncio.run(_execute())
+
+    def _create_workplace_agent(self):
+        """Create the workplace intelligence agent with Work IQ tools."""
+        try:
+            print("Creating workplace intelligence agent...")
+
+            # Get Work IQ tools
+            raw_tools = self._get_workiq_tools()
+            workiq_tools = [
+                FunctionTool(
+                    name=tool.name,
+                    description=tool.description,
+                    parameters=tool.inputSchema,
+                )
+                for tool in raw_tools
+            ]
+
+            # Create agent using Responses API pattern
+            self.agent = self.project_client.agents.create_version(
+                agent_name="tailwind-workplace-agent",
+                definition=PromptAgentDefinition(
+                    model=self.model_deployment,
+                    instructions="""You are a workplace intelligence assistant for Tailwind Traders staff, with access to Microsoft 365 data through Work IQ.
+
+Your capabilities:
+- Search emails, meetings, calendar, Teams messages, and documents
+- Provide context for meetings and projects
+- Extract action items and tasks
+- Summarize communications and decisions
+
+Guidelines:
+- Always cite sources with timestamps when available
+- Respect user privacy and data sensitivity
+- Provide concise, actionable information
+- If you can't find information, explain what you searched and suggest alternatives""",
+                    tools=workiq_tools
+                )
+            )
+
+            # Store raw tools map for lookup during tool execution
+            self.raw_tools_map = {tool.name: tool for tool in raw_tools}
+
+            print(f"[OK] Created agent: {self.agent.name} (version {self.agent.version})\n")
+
+        except Exception as e:
+            print(f"[ERROR] Failed to create agent: {e}")
+            raise
+
+    def _execute_query(self, query, scenario_name="Query"):
+        """Execute a query against the workplace agent."""
+        try:
+            print(f"\n{'=' * 70}")
+            print(f">> {scenario_name}")
+            print(f"{'=' * 70}")
+            print(f"\nQuery: {query}\n")
+            print("Processing with Work IQ tools...")
+
+            # Create conversation
+            conversation = self.openai_client.conversations.create(
+                items=[{"type": "message", "role": "user", "content": query}]
+            )
+
+            # Create response with agent
+            response = self.openai_client.responses.create(
+                conversation=conversation.id,
+                extra_body={"agent_reference": {"name": self.agent.name, "type": "agent_reference"}}
+            )
+
+            # Tool call loop
+            while True:
+                # Check for failures
+                if response.status == "failed":
+                    print(f"[ERROR] Response failed: {response.error}")
+                    return
+
+                input_list: ResponseInputParam = []
+
+                # Process function calls
+                for item in response.output:
+                    if item.type == "function_call":
+                        function_name = item.name
+                        kwargs = json.loads(item.arguments)
+
+                        print(f"   [tool] Calling Work IQ tool: {function_name}")
+
+                        # Call the tool via MCP
+                        result = self._call_workiq_tool(function_name, kwargs)
+
+                        input_list.append(
+                            FunctionCallOutput(
+                                type="function_call_output",
+                                call_id=item.call_id,
+                                output=result.content[0].text,
+                            )
+                        )
+
+                # If there were tool calls, send results back and continue loop
+                if input_list:
+                    response = self.openai_client.responses.create(
+                        input=input_list,
+                        previous_response_id=response.id,
+                        extra_body={
+                            "agent_reference": {"name": self.agent.name, "type": "agent_reference"}
+                        }
+                    )
+                else:
+                    # No tool calls - we have the final response
+                    break
+
+            # Extract and display final response
+            print("\nResponse:")
+            print("-" * 70)
+
+            if response.output_text:
+                print(response.output_text)
+            else:
+                print("No response received from agent.")
+
+            print("-" * 70)
+
+        except Exception as e:
+            print(f"\n[ERROR] Error executing query: {e}")
+            print("\nPossible issues:")
+            print("  - Work IQ MCP server not responding")
+            print("  - No M365 Copilot license or admin consent")
+            print("  - Agent doesn't have access to requested data")
+
+    def show_menu(self):
+        """Display the main menu."""
+        print("\n" + "=" * 70)
+        print("        TAILWIND TRADERS: WORK IQ - WORKPLACE INTELLIGENCE")
+        print("=" * 70)
+        print("\nChoose a scenario:\n")
+        print("  1. Meeting Prep")
+        print("     Get context for your next meeting")
+        print()
+        print("  2. Project Status")
+        print("     Check latest updates on a project")
+        print()
+        print("  3. Action Items")
+        print("     Find your open tasks and action items")
+        print()
+        print("  4. Combined Intelligence")
+        print("     Search both workplace data AND knowledge base")
+        print()
+        print("  5. Custom Query")
+        print("     Ask your own workplace question")
+        print()
+        print("  6. View Work IQ Capabilities")
+        print()
+        print("  0. Exit")
+        print("\n" + "=" * 70)
+
+    def scenario_1_meeting_prep(self):
+        """Scenario 1: Meeting preparation with context."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 1: MEETING PREP")
+        print("=" * 70)
+        print("\nThis scenario helps you prepare for meetings by gathering")
+        print("context from emails, previous meetings, and shared documents.\n")
+
+        # Get meeting topic from user
+        meeting_topic = input("Enter meeting topic or time (e.g., '2pm meeting', 'Spring Catalog Planning'): ").strip()
+
+        if not meeting_topic:
+            meeting_topic = "my next meeting"
+
+        query = f"""Help me prepare for {meeting_topic}. Please:
+1. Find the meeting details (time, attendees, agenda)
+2. Search for recent emails about this topic
+3. Look for previous meetings on this topic
+4. Summarize key points and decisions I should know
+5. Suggest discussion points or questions
+
+Provide a concise prep summary with sources."""
+
+        self._execute_query(query, "Meeting Prep")
+
+    def scenario_2_project_status(self):
+        """Scenario 2: Project status tracking."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 2: PROJECT STATUS")
+        print("=" * 70)
+        print("\nThis scenario tracks project updates by searching across")
+        print("emails, Teams chats, meetings, and shared documents.\n")
+
+        # Get project name from user
+        project_name = input("Enter project name (e.g., 'Spring Catalog Launch', 'Store Refresh'): ").strip()
+
+        if not project_name:
+            project_name = "current projects"
+
+        query = f"""Give me a status update on {project_name}. Please:
+1. Search recent emails and Teams messages about this project
+2. Find related meetings and their outcomes
+3. Identify recent decisions and changes
+4. List any blockers or issues mentioned
+5. Summarize next steps and deadlines
+
+Provide a concise status report with sources and dates."""
+
+        self._execute_query(query, "Project Status")
+
+    def scenario_3_action_items(self):
+        """Scenario 3: Action item extraction."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 3: ACTION ITEMS")
+        print("=" * 70)
+        print("\nThis scenario extracts your open tasks and action items")
+        print("from meetings, emails, and Teams messages.\n")
+
+        # Optional: time filter
+        time_filter = input("Time range (e.g., 'this week', 'last 3 days', or press Enter for 'recent'): ").strip()
+
+        if not time_filter:
+            time_filter = "the past week"
+
+        query = f"""Find my open action items and tasks from {time_filter}. Please:
+1. Search meeting notes for assigned action items
+2. Look for task-related emails sent to me
+3. Check Teams messages where I was mentioned or assigned tasks
+4. Identify items with deadlines or due dates
+5. Categorize by urgency if possible
+
+Provide a prioritized list with sources, deadlines, and who assigned each item."""
+
+        self._execute_query(query, "Action Items")
+
+    def scenario_4_combined_intelligence(self):
+        """Scenario 4: Work IQ + Foundry IQ combined."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 4: COMBINED INTELLIGENCE")
+        print("=" * 70)
+        print("\nThis scenario demonstrates using BOTH Work IQ (workplace signals)")
+        print("and Foundry IQ (knowledge base) together for comprehensive context.\n")
+        print("[NOTE] This requires Foundry IQ search to be configured in your project.\n")
+
+        topic = input("Enter topic to research (workplace + knowledge base): ").strip()
+
+        if not topic:
+            topic = "our store return and rental policies"
+
+        query = f"""Research {topic} using both workplace data and knowledge base. Please:
+
+FROM WORKPLACE DATA (Work IQ):
+1. Search recent emails and messages about this topic
+2. Find relevant meetings and discussions
+3. Identify who has been involved and what was decided
+
+FROM KNOWLEDGE BASE (Foundry IQ):
+4. Search official documentation
+5. Find policies, guidelines, or procedures
+
+SYNTHESIS:
+6. Compare workplace discussions with official documentation
+7. Identify any gaps or inconsistencies
+8. Provide a comprehensive summary with sources from both
+
+Label each piece of information with its source (workplace or knowledge base)."""
+
+        self._execute_query(query, "Combined Intelligence")
+
+    def scenario_5_custom_query(self):
+        """Scenario 5: User-defined custom query."""
+        print("\n" + "=" * 70)
+        print("SCENARIO 5: CUSTOM QUERY")
+        print("=" * 70)
+        print("\nAsk any workplace question! Examples:")
+        print("  - What did my manager say about the spring catalog?")
+        print("  - Find emails about the Q4 inventory count")
+        print("  - What did the store operations team discuss yesterday?")
+        print("  - Show me shared documents about supplier lead times")
+        print("  - Summarize this week's team standups\n")
+
+        custom_query = input("Your workplace question: ").strip()
+
+        if not custom_query:
+            print("\n[WARN] No query entered. Returning to menu.")
+            return
+
+        self._execute_query(custom_query, "Custom Query")
+
+    def show_capabilities(self):
+        """Display Work IQ capabilities and architecture."""
+        print("\n" + "=" * 70)
+        print("WORK IQ CAPABILITIES")
+        print("=" * 70)
+        print("\nWhat is Work IQ?")
+        print("-" * 70)
+        print("Work IQ is Microsoft's contextual intelligence layer for Microsoft 365.")
+        print("It provides AI agents with access to workplace data through the")
+        print("Model Context Protocol (MCP).\n")
+
+        print("Data Sources:")
+        print("  - Emails (Outlook)")
+        print("  - Calendar and meetings")
+        print("  - Teams messages and chats")
+        print("  - OneDrive and SharePoint documents")
+        print("  - People and organizational data")
+        print("  - Notifications and signals\n")
+
+        print("Security & Privacy:")
+        print("  - Respects existing M365 permissions")
+        print("  - Uses Microsoft Entra ID authentication")
+        print("  - Requires M365 Copilot license")
+        print("  - Requires admin consent for organizational use")
+        print("  - All data access is logged and auditable\n")
+
+        print("Work IQ vs Foundry IQ:")
+        print("  Work IQ:    Workplace signals (who said what, when)")
+        print("  Foundry IQ: Knowledge base (curated documents, data)")
+        print("  Together:   Complete context for decision-making\n")
+
+        print("MCP Architecture:")
+        print("  1. Work IQ runs as MCP server (npx @microsoft/workiq mcp)")
+        print("  2. Agent connects via StdioMCPClient")
+        print("  3. Agent calls Work IQ tools to query M365")
+        print("  4. Work IQ returns data with proper permissions")
+        print("  5. Agent synthesizes and presents results\n")
+
+        print("Use Cases:")
+        print("  - Meeting preparation and context")
+        print("  - Project status tracking")
+        print("  - Action item extraction")
+        print("  - Document discovery and search")
+        print("  - Communication summarization")
+        print("  - Team activity monitoring")
+        print("  - Decision history and rationale\n")
+
+        print("=" * 70)
+        input("\nPress Enter to return to menu...")
+
+    def cleanup(self):
+        """Clean up resources."""
+        try:
+            if self.agent:
+                print("\nCleaning up resources...")
+                self.project_client.agents.delete_version(
+                    agent_name=self.agent.name,
+                    version=self.agent.version
+                )
+                print("[OK] Agent deleted")
+        except Exception as e:
+            print(f"[WARN] Cleanup warning: {e}")
+
+    def run(self):
+        """Main application loop."""
+        print("\n" + "=" * 70)
+        print("   TAILWIND TRADERS: WORK IQ - WORKPLACE INTELLIGENCE FOR AI AGENTS")
+        print("=" * 70)
+        print("\nThis lab demonstrates how to build AI agents that access")
+        print("Microsoft 365 workplace data using Work IQ.\n")
+
+        # Connect to services
+        if not self.connect():
+            print("\n[ERROR] Failed to connect. Please check your configuration.")
+            return
+
+        # Main menu loop
+        while True:
+            self.show_menu()
+            choice = input("\nSelect option (0-6): ").strip()
+
+            if choice == "1":
+                self.scenario_1_meeting_prep()
+            elif choice == "2":
+                self.scenario_2_project_status()
+            elif choice == "3":
+                self.scenario_3_action_items()
+            elif choice == "4":
+                self.scenario_4_combined_intelligence()
+            elif choice == "5":
+                self.scenario_5_custom_query()
+            elif choice == "6":
+                self.show_capabilities()
+            elif choice == "0":
+                print("\nExiting lab...")
+                break
+            else:
+                print("\n[WARN] Invalid option. Please choose 0-6.")
+
+            input("\nPress Enter to continue...")
+
+        # Cleanup
+        self.cleanup()
+        print("\n[OK] Lab complete! Thank you for exploring Work IQ.\n")
+
+
+if __name__ == "__main__":
+    lab = WorkIQLab()
+    lab.run()

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/README.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/README.md
@@ -1,0 +1,129 @@
+# Lab B — Solution (complete code)
+
+This folder contains **finished, working versions** of every code file learners write in
+*Integrate agents with enterprise knowledge and Microsoft 365*. Use it to unblock a stuck
+learner, verify expected behavior, or run the scenario end to end.
+
+All code tasks share a **single** `Python/` folder (one virtual environment, one `.env`),
+exactly like the starter code learners work in:
+
+```
+Solution/
+└─ Python/
+   ├─ knowledge_agent.py      # Task 1 (core) — console client for the Foundry IQ agent + approval loop
+   ├─ knowledge_chat_app.py   # Task 1 (optional) — same agent in a web chat window (auto-approves)
+   ├─ workiq_lab.py           # Task 4 — Work IQ workplace intelligence (menu-driven, 5 scenarios)
+   ├─ tailwind_ui.py          # shared Gradio chat shell (provided; not edited by learners)
+   ├─ requirements.txt        # shared dependencies for all tasks
+   ├─ .env.example            # copy to .env and fill in
+   └─ data/                   # Tailwind Traders knowledge base (grounding docs)
+```
+
+Two of the four tasks are **portal publishing workflows** (Task 2: Microsoft Teams, Task 3:
+Microsoft 365 Copilot). They add no new Python — you publish the Task 1 agent through the
+Foundry portal — so there are no solution files for them.
+
+---
+
+## Setup helpers and modular (per-task) labs
+
+This lab can be completed end to end **or one task at a time**. Two things make that possible:
+
+- **Per-task instruction pages** — `Instructions/Exercises/B0-getting-started.md` (shared setup)
+  plus `B1`–`B4` (one page per task). Each task page tells a standalone learner exactly what it
+  needs and how to fast-forward.
+- **Setup scripts** in `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/`:
+  - `check_env.py --task N` — preflight-checks that `.env` has the keys task *N* needs.
+  - `bootstrap_agent.py` — **fast-forwards the Task 1 grounding step in code**: creates and
+    grounds `tailwind-knowledge-agent` (File Search over the `data/` knowledge base) and writes
+    `AGENT_NAME` to `.env`, so learners can start against a working agent without the portal.
+    Idempotent; pass `--force` to recreate.
+
+Both scripts run from the **starter** `Python/` folder and use the shared virtual environment
+and `.env`.
+
+> **Note**: Task 1 in the portal grounds the agent with **Foundry IQ** (a knowledge source with
+> agentic retrieval and an approval step). `bootstrap_agent.py` uses the simpler **File Search**
+> tool so learners get a working grounded agent without the portal steps. The client code you run
+> against either agent is identical.
+
+### Optional: provision infrastructure with azd
+
+Instead of creating the project by hand, `azure.yaml` + `infra/` let you provision a Foundry
+project and model deployment with one command:
+
+```
+azd up      # create the project + model deployment, writes Python/.env
+azd down    # remove everything when you're done
+```
+
+The manual portal path is still the default — azd is offered as **Option B** in Getting started
+for learners who prefer infrastructure as code.
+
+> **Note**: the azd path is bicep-validated but has not been deployment-tested in this repo yet.
+
+---
+
+## What YOU must do to run this solution (the agent can't do these for you)
+
+Everything below requires an Azure subscription and interactive sign-in, so it can't be
+automated in the repo. Do these once, then run each task.
+
+### 1. Azure / Microsoft Foundry setup
+1. Have an **Azure subscription** with access to **Microsoft Foundry (Azure AI Foundry)**.
+2. Create (or open) a **Foundry project** and copy its **Project Endpoint**.
+3. **Deploy a model** (for example `gpt-4o`) in that project and note the **deployment name**.
+4. Make sure your signed-in identity has the **Azure AI User** role (or equivalent) on the project.
+
+### 2. Sign in locally
+```
+az login
+```
+Sign in with the same account that has access to the project.
+
+### 3. Create the Foundry IQ knowledge agent (Task 1 — required for the code clients)
+The Task 1 clients load an agent **by name** that you create in the portal:
+1. In the Foundry portal, create an agent named **`tailwind-knowledge-agent`**.
+2. Add a **Foundry IQ knowledge source** and index the Tailwind Traders docs from `Python/data/`.
+3. Give it instructions to answer store staff questions from the knowledge base. Save the agent.
+
+> **Shortcut**: instead of the portal grounding above, run `python setup/bootstrap_agent.py` from
+> the `Python/` folder to create and ground `tailwind-knowledge-agent` in code (File Search) and
+> write `AGENT_NAME`.
+
+### 4. Set up the environment once (shared by all code tasks)
+From the `Python/` folder:
+```
+python -m venv labenv
+.\labenv\Scripts\Activate.ps1        # Windows PowerShell
+pip install -r requirements.txt
+```
+Then copy `.env.example` to `.env` and fill in the values (all tasks read the same file):
+- `PROJECT_ENDPOINT` — used by the code tasks
+- `MODEL_DEPLOYMENT_NAME` — used by Task 4 (Work IQ)
+- `AGENT_NAME=tailwind-knowledge-agent` — used by the Task 1 code clients
+
+### 5. Run each task
+Code tasks run from the single `Python/` folder:
+
+| Task | Command | What you get |
+|------|---------|--------------|
+| 1 | `python knowledge_agent.py` | Console chat: agent answers from the knowledge base; you approve the Foundry IQ tool interactively |
+| 1 (web) | `python knowledge_chat_app.py` | Browser chat at `http://localhost:7860`; same agent, auto-approves the knowledge tool |
+| 2 | *(portal)* | Publish the Task 1 agent to **Microsoft Teams** — no code |
+| 3 | *(portal)* | Publish the Task 1 agent to **Microsoft 365 Copilot** — no code |
+| 4 | `python workiq_lab.py` | Menu-driven console app: agent queries Microsoft 365 through Work IQ (5 scenarios) |
+
+For the web variant (Task 1): the browser opens automatically. **Close the tab and press Ctrl+C**
+in the terminal to stop the app. Task 4 deletes its agent version on exit.
+
+> **Work IQ prerequisites (Task 4)**: an M365 Copilot license, admin consent, and the Work IQ CLI
+> installed (`npm install -g @microsoft/workiq`, then `workiq accept-eula`). See B4 for details.
+
+---
+
+## Quick sanity checks that DON'T need Azure
+- `python -m py_compile <file>` — all solution files compile.
+- The knowledge base under `Python/data/` is what the agent is grounded on; ask the running agent
+  about the **90-day return window**, **premium gear rental rates**, or **supplier lead times** to
+  confirm grounding works.

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/azure.yaml
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/azure.yaml
@@ -1,0 +1,41 @@
+# azd configuration for the Tailwind Traders enterprise-knowledge lab (OPTIONAL infra path).
+#
+# This is a convenience for learners/instructors who want to provision the
+# Foundry project + model deployment with a single command instead of creating
+# them by hand in the portal. It is entirely optional — the lab's default path
+# is still to create the project in the Foundry portal during setup.
+#
+# Usage:
+#     azd auth login
+#     azd up            # provisions the resources below, then fills in Python/.env
+#
+# When you're done with the lab:
+#     azd down          # deletes everything it created
+#
+# What it provisions (see infra/main.bicep):
+#   - A Microsoft Foundry (Azure AI Services) resource
+#   - A Foundry project
+#   - One chat model deployment
+#
+# After provisioning, the postprovision hook writes PROJECT_ENDPOINT and
+# MODEL_DEPLOYMENT_NAME into Python/.env for you.
+
+name: tailwind-traders-lab-b
+metadata:
+  template: mslearn-ai-agents/B-integrate-agents-with-enterprise-knowledge-and-m365
+
+# This template provisions infrastructure only — there is no app for azd to
+# deploy. You run the lab's Python scripts yourself from the Python/ folder.
+
+hooks:
+  postprovision:
+    windows:
+      shell: pwsh
+      run: ./setup/write_env.ps1
+      continueOnError: false
+      interactive: false
+    posix:
+      shell: sh
+      run: ./setup/write_env.sh
+      continueOnError: false
+      interactive: false

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/infra/main.bicep
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/infra/main.bicep
@@ -1,0 +1,65 @@
+// Optional azd infrastructure for the Tailwind Traders lab.
+//
+// Provisions a Microsoft Foundry (Azure AI Services) resource, a Foundry
+// project, and one chat model deployment — the same resources you would
+// otherwise create by hand in the Foundry portal.
+//
+// azd calls this at subscription scope: it creates the resource group and
+// then everything inside it (see infra/resources.bicep).
+
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the azd environment — used to name and tag resources.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Name of the chat model to deploy (for example, gpt-4o).')
+param modelName string = 'gpt-4o'
+
+@description('Version of the chat model to deploy.')
+param modelVersion string = '2024-11-20'
+
+@description('The deployment name the lab uses (MODEL_DEPLOYMENT_NAME in .env).')
+param modelDeploymentName string = 'gpt-4o'
+
+@description('Model deployment capacity, in thousands of tokens per minute.')
+param modelCapacity int = 30
+
+// azd tags every resource in an environment with this so it can manage them.
+var tags = { 'azd-env-name': environmentName }
+
+// A short, deterministic token keeps globally-unique names stable per env.
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module ai 'resources.bicep' = {
+  name: 'foundry'
+  scope: resourceGroup
+  params: {
+    location: location
+    tags: tags
+    accountName: 'foundry-${resourceToken}'
+    projectName: 'proj-${resourceToken}'
+    modelName: modelName
+    modelVersion: modelVersion
+    modelDeploymentName: modelDeploymentName
+    modelCapacity: modelCapacity
+  }
+}
+
+// azd writes these outputs into the azd environment; the postprovision hook
+// then copies them into Python/.env for the lab scripts to read.
+output PROJECT_ENDPOINT string = ai.outputs.projectEndpoint
+output MODEL_DEPLOYMENT_NAME string = ai.outputs.modelDeploymentName
+output AZURE_LOCATION string = location
+output AZURE_RESOURCE_GROUP string = resourceGroup.name

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/infra/main.parameters.json
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/infra/main.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "modelName": {
+      "value": "${MODEL_NAME=gpt-4o}"
+    },
+    "modelVersion": {
+      "value": "${MODEL_VERSION=2024-11-20}"
+    },
+    "modelDeploymentName": {
+      "value": "${MODEL_DEPLOYMENT_NAME=gpt-4o}"
+    },
+    "modelCapacity": {
+      "value": "${MODEL_CAPACITY=30}"
+    }
+  }
+}

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/infra/resources.bicep
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/infra/resources.bicep
@@ -1,0 +1,84 @@
+// Foundry account + project + model deployment for the lab.
+// Deployed into the resource group created by main.bicep.
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags applied to every resource.')
+param tags object = {}
+
+@description('Globally-unique name for the Foundry (Azure AI Services) account.')
+param accountName string
+
+@description('Name of the Foundry project.')
+param projectName string
+
+@description('Name of the chat model to deploy.')
+param modelName string
+
+@description('Version of the chat model to deploy.')
+param modelVersion string
+
+@description('Deployment name the lab uses (MODEL_DEPLOYMENT_NAME in .env).')
+param modelDeploymentName string
+
+@description('Model deployment capacity, in thousands of tokens per minute.')
+param modelCapacity int
+
+// The Microsoft Foundry resource (an Azure AI Services account with project
+// support). allowProjectManagement enables the new Foundry project experience.
+resource account 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
+  name: accountName
+  location: location
+  tags: tags
+  kind: 'AIServices'
+  sku: {
+    name: 'S0'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    allowProjectManagement: true
+    // Use the account name as the custom subdomain so the project endpoint
+    // resolves to https://<accountName>.services.ai.azure.com/...
+    customSubDomainName: accountName
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource project 'Microsoft.CognitiveServices/accounts/projects@2025-06-01' = {
+  parent: account
+  name: projectName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {}
+}
+
+// Deploy the chat model. The deployment's name is what the lab references as
+// MODEL_DEPLOYMENT_NAME. Model deployments live on the account, not the project.
+resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
+  parent: account
+  name: modelDeploymentName
+  sku: {
+    name: 'GlobalStandard'
+    capacity: modelCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: modelName
+      version: modelVersion
+    }
+  }
+}
+
+// Project endpoint in the form the lab's .env expects:
+//   https://<account>.services.ai.azure.com/api/projects/<project>
+output projectEndpoint string = 'https://${account.name}.services.ai.azure.com/api/projects/${project.name}'
+output modelDeploymentName string = modelDeployment.name
+output accountName string = account.name
+output projectName string = project.name

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/bootstrap_agent.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/bootstrap_agent.py
@@ -1,0 +1,180 @@
+"""
+Fast-forward setup for the Tailwind Traders enterprise-knowledge lab.
+
+Task 1 has you build an enterprise-knowledge agent and ground it on the Tailwind
+Traders knowledge base. If you'd rather jump straight to connecting from code (or
+to an optional task), run this once to create a grounded agent for you:
+
+    python setup/bootstrap_agent.py
+
+It reproduces, in code, the grounding step Task 1 has you do in the portal:
+
+  * creates an agent named 'tailwind-knowledge-agent'
+  * grounds it on the Tailwind Traders knowledge docs with the File Search tool
+  * writes AGENT_NAME=tailwind-knowledge-agent into Python/.env
+
+Prerequisites: PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME set in Python/.env
+(run 'azd up', or fill them in from the portal), and 'az login' completed.
+
+If you'd rather learn the portal workflow, skip this script and do Task 1
+instead — the end result is a grounded knowledge agent either way.
+
+Note: The portal Task 1 grounds the agent with Foundry IQ (a knowledge source
+with agentic retrieval and an approval step). This script uses the simpler File
+Search tool so you have a working grounded agent for the code clients without the
+portal steps. The code you write against it is identical.
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+    FileSearchTool,
+    PromptAgentDefinition,
+)
+from azure.core.exceptions import ResourceNotFoundError
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
+
+AGENT_NAME = "tailwind-knowledge-agent"
+
+# The same instructions Task 1 has you give the agent in the portal.
+INSTRUCTIONS = """You are the Tailwind Traders staff knowledge assistant.
+You help store staff answer questions about products, store operations, returns, rentals, and suppliers.
+
+Guidelines:
+- Always be friendly and helpful
+- Use the Tailwind Traders knowledge base to answer questions accurately
+- Cite the document you used when you can
+- If you don't know the answer, admit it and suggest contacting the relevant team directly"""
+
+# Resolve paths relative to this file so the script works from any directory.
+LAB_ROOT = Path(__file__).resolve().parent.parent
+PYTHON_DIR = LAB_ROOT / "Python"
+ENV_PATH = PYTHON_DIR / ".env"
+DATA_DIR = PYTHON_DIR / "data"
+
+
+def fail(message):
+    print(f"\nERROR: {message}")
+    sys.exit(1)
+
+
+def upload_file(openai_client, path):
+    """Upload a local file and return its file id."""
+    if not path.exists():
+        fail(f"Expected data file not found: {path}")
+    print(f"  Uploading {path.name} ...")
+    with open(path, "rb") as handle:
+        uploaded = openai_client.files.create(file=handle, purpose="assistants")
+    return uploaded.id
+
+
+def build_vector_store(openai_client, file_ids):
+    """Create a vector store for File Search and wait until it's indexed."""
+    print("  Creating vector store for the Tailwind Traders knowledge base ...")
+    vector_store = openai_client.vector_stores.create(
+        name="ks-tailwindproducts",
+        file_ids=file_ids,
+    )
+
+    # Wait for the files to finish indexing so the agent can search them immediately.
+    for _ in range(30):
+        current = openai_client.vector_stores.retrieve(vector_store_id=vector_store.id)
+        if current.status == "completed":
+            break
+        if current.status == "failed":
+            fail("Vector store indexing failed. Check the uploaded files and try again.")
+        time.sleep(2)
+
+    return vector_store.id
+
+
+def agent_exists(project_client):
+    try:
+        project_client.agents.get(agent_name=AGENT_NAME)
+        return True
+    except ResourceNotFoundError:
+        return False
+
+
+def set_env_value(key, value):
+    """Add or update a key in Python/.env, preserving the other entries."""
+    lines = ENV_PATH.read_text(encoding="utf-8").splitlines() if ENV_PATH.exists() else []
+    prefix = f"{key}="
+    replaced = False
+    for index, line in enumerate(lines):
+        if line.strip().startswith(prefix) or line.strip().startswith(f"{key} ="):
+            lines[index] = f"{key}={value}"
+            replaced = True
+            break
+    if not replaced:
+        lines.append(f"{key}={value}")
+    ENV_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create and ground the tailwind-knowledge-agent."
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Create a new version even if the agent already exists.",
+    )
+    args = parser.parse_args()
+
+    load_dotenv(ENV_PATH)
+    project_endpoint = os.getenv("PROJECT_ENDPOINT")
+    model_deployment = os.getenv("MODEL_DEPLOYMENT_NAME")
+
+    if not project_endpoint:
+        fail("PROJECT_ENDPOINT is not set in Python/.env. Run 'azd up' or set it from the portal.")
+    if not model_deployment:
+        fail("MODEL_DEPLOYMENT_NAME is not set in Python/.env. Set it to your deployed model name.")
+
+    data_files = sorted(DATA_DIR.glob("*.md"))
+    if not data_files:
+        fail(f"No knowledge documents found in {DATA_DIR}.")
+
+    print("Connecting to your Foundry project ...")
+    with (
+        DefaultAzureCredential() as credential,
+        AIProjectClient(endpoint=project_endpoint, credential=credential) as project_client,
+        project_client.get_openai_client() as openai_client,
+    ):
+        if agent_exists(project_client) and not args.force:
+            print(f"\nAgent '{AGENT_NAME}' already exists - nothing to do.")
+            print("Re-run with --force to add a new grounded version.")
+            set_env_value("AGENT_NAME", AGENT_NAME)
+            print(f"Ensured AGENT_NAME={AGENT_NAME} in {ENV_PATH}")
+            return
+
+        print(f"Grounding the agent (this uploads {len(data_files)} knowledge documents):")
+        file_ids = [upload_file(openai_client, path) for path in data_files]
+        vector_store_id = build_vector_store(openai_client, file_ids)
+
+        file_search = FileSearchTool(vector_store_ids=[vector_store_id])
+
+        print("Creating the agent ...")
+        agent = project_client.agents.create_version(
+            agent_name=AGENT_NAME,
+            definition=PromptAgentDefinition(
+                model=model_deployment,
+                instructions=INSTRUCTIONS,
+                tools=[file_search],
+            ),
+        )
+        print(f"  Created '{agent.name}' (version {agent.version}).")
+
+    set_env_value("AGENT_NAME", AGENT_NAME)
+    print(f"\nWrote AGENT_NAME={AGENT_NAME} to {ENV_PATH}")
+    print("You're ready to connect from code: run 'python knowledge_agent.py' from the Python folder.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
@@ -1,0 +1,143 @@
+"""
+Preflight check for the Tailwind Traders enterprise-knowledge lab.
+
+Each task in this lab can be completed on its own. Before you start a task,
+run this script to confirm your .env file has everything that task needs:
+
+    python setup/check_env.py --task 4
+
+It never changes anything — it only reads your .env and tells you what (if
+anything) is missing, so you can fix it before running the task.
+
+Tasks and what they need:
+
+    Task 1  (core, code)   PROJECT_ENDPOINT, AGENT_NAME   (the Foundry IQ agent)
+    Task 2  (portal)       no .env needed — you publish to Teams in the portal
+    Task 3  (portal)       no .env needed — you publish to M365 Copilot in the portal
+    Task 4  (code)         PROJECT_ENDPOINT, MODEL_DEPLOYMENT_NAME
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+# Which .env keys each task needs to run on its own.
+TASK_REQUIREMENTS = {
+    1: ["PROJECT_ENDPOINT", "AGENT_NAME"],
+    2: [],
+    3: [],
+    4: ["PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME"],
+}
+
+# Placeholder text shipped in .env.example — present but not yet filled in.
+PLACEHOLDERS = {
+    "",
+    "your_project_endpoint_here",
+    "your_model_deployment_name_here",
+    "your-project-endpoint",
+    "your-model-deployment-name",
+    "your-agent-name",
+    "<your-project-endpoint>",
+    "<your-model-deployment-name>",
+    "<your-agent-name>",
+}
+
+# How to fix each key, shown only when it's missing.
+FIX_HINTS = {
+    "PROJECT_ENDPOINT": (
+        "Copy your project endpoint from the Foundry portal (or the Foundry Toolkit "
+        "VS Code extension: right-click the project deployment > Copy Project Endpoint), "
+        "or run 'azd up' to provision one, then set PROJECT_ENDPOINT in .env."
+    ),
+    "MODEL_DEPLOYMENT_NAME": (
+        "Set MODEL_DEPLOYMENT_NAME to the name of your deployed model "
+        "(for example, gpt-4o). You can see it in the Foundry portal under your project."
+    ),
+    "AGENT_NAME": (
+        "Task 1 needs the Foundry IQ enterprise-knowledge agent. Either build it in the "
+        "portal and set AGENT_NAME=tailwind-knowledge-agent, or fast-forward the grounding "
+        "step by running: python setup/bootstrap_agent.py"
+    ),
+}
+
+
+def find_env_file():
+    """Return the .env next to the lab's Python folder, wherever this is run from."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        Path.cwd() / ".env",
+        here.parent / "Python" / ".env",
+        here.parent / ".env",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # Default to the Python-folder location even if it doesn't exist yet.
+    return here.parent / "Python" / ".env"
+
+
+def load_values(env_path):
+    """Merge real environment variables over .env file values (env wins)."""
+    values = {}
+    if env_path.exists():
+        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+    for key in ("PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME", "AGENT_NAME"):
+        if os.environ.get(key):
+            values[key] = os.environ[key]
+    return values
+
+
+def is_set(values, key):
+    """A key counts as set if it's present and not a leftover placeholder."""
+    value = (values.get(key) or "").strip()
+    return bool(value) and value not in PLACEHOLDERS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that your .env has what a given lab task needs."
+    )
+    parser.add_argument(
+        "--task",
+        type=int,
+        choices=sorted(TASK_REQUIREMENTS),
+        required=True,
+        help="Which task you're about to start (1-4).",
+    )
+    args = parser.parse_args()
+
+    env_path = find_env_file()
+    values = load_values(env_path)
+    required = TASK_REQUIREMENTS[args.task]
+
+    print(f"Checking readiness for Task {args.task}")
+    print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
+    print()
+
+    if not required:
+        print(f"Task {args.task} is completed entirely in the portal - no .env needed.")
+        print("When you're ready for a code task, run this again with --task 1 or --task 4.")
+        return 0
+
+    missing = [key for key in required if not is_set(values, key)]
+
+    for key in required:
+        mark = "OK " if is_set(values, key) else "MISSING"
+        print(f"  [{mark}] {key}")
+
+    if not missing:
+        print()
+        print(f"You're ready to start Task {args.task}.")
+        return 0
+
+    print()
+    print("Set the following before starting this task:")
+    for key in missing:
+        print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.ps1
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.ps1
@@ -1,0 +1,36 @@
+# Copies the endpoint + model deployment name that 'azd up' just provisioned
+# into the lab's Python/.env, so the task scripts can read them.
+#
+# azd runs this automatically after provisioning (see azure.yaml). It sets the
+# bicep outputs as environment variables, which we read here.
+
+$ErrorActionPreference = 'Stop'
+
+$envPath = Join-Path $PSScriptRoot '..\Python\.env'
+$examplePath = Join-Path $PSScriptRoot '..\Python\.env.example'
+
+# Start from the existing .env, or the example if there isn't one yet.
+if (-not (Test-Path $envPath)) {
+    if (Test-Path $examplePath) { Copy-Item $examplePath $envPath }
+    else { New-Item -ItemType File -Path $envPath | Out-Null }
+}
+
+function Set-EnvValue([string]$key, [string]$value) {
+    if ([string]::IsNullOrWhiteSpace($value)) { return }
+    $lines = @(Get-Content $envPath)
+    $set = $false
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match "^\s*$key\s*=") {
+            $lines[$i] = "$key=$value"
+            $set = $true
+        }
+    }
+    if (-not $set) { $lines += "$key=$value" }
+    Set-Content -Path $envPath -Value $lines
+}
+
+Set-EnvValue 'PROJECT_ENDPOINT' $env:PROJECT_ENDPOINT
+Set-EnvValue 'MODEL_DEPLOYMENT_NAME' $env:MODEL_DEPLOYMENT_NAME
+
+Write-Host "Updated $envPath with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
+Write-Host "Task 1 also needs a grounded agent: run 'python setup/bootstrap_agent.py' to create it."

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.sh
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copies the endpoint + model deployment name that 'azd up' just provisioned
+# into the lab's Python/.env, so the task scripts can read them.
+#
+# azd runs this automatically after provisioning (see azure.yaml). It sets the
+# bicep outputs as environment variables, which we read here.
+
+set -e
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+env_path="$script_dir/../Python/.env"
+example_path="$script_dir/../Python/.env.example"
+
+# Start from the existing .env, or the example if there isn't one yet.
+if [ ! -f "$env_path" ]; then
+    if [ -f "$example_path" ]; then cp "$example_path" "$env_path"; else : > "$env_path"; fi
+fi
+
+set_env_value() {
+    key="$1"
+    value="$2"
+    [ -z "$value" ] && return 0
+    if grep -qE "^[[:space:]]*$key[[:space:]]*=" "$env_path"; then
+        # Replace the existing line.
+        tmp="${env_path}.tmp"
+        sed "s|^[[:space:]]*$key[[:space:]]*=.*|$key=$value|" "$env_path" > "$tmp"
+        mv "$tmp" "$env_path"
+    else
+        printf '%s=%s\n' "$key" "$value" >> "$env_path"
+    fi
+}
+
+set_env_value "PROJECT_ENDPOINT" "$PROJECT_ENDPOINT"
+set_env_value "MODEL_DEPLOYMENT_NAME" "$MODEL_DEPLOYMENT_NAME"
+
+echo "Updated $env_path with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
+echo "Task 1 also needs a grounded agent: run 'python setup/bootstrap_agent.py' to create it."

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/.env.example
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/.env.example
@@ -1,0 +1,17 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# In VS Code, Foundry Toolkit > right-click your active project > Copy Project Endpoint,
+# or copy it from the Microsoft Foundry portal project overview page.
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (for example, gpt-4o) — used by every task
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here
+
+# Task 3 (connect remote agents with A2A) runs three local agent servers.
+# These ship pre-filled — you normally don't need to change them.
+SERVER_URL=localhost
+TITLE_AGENT_PORT=10007
+OUTLINE_AGENT_PORT=10008
+ROUTING_AGENT_PORT=10009

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/client.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/client.py
@@ -1,0 +1,36 @@
+""" Client code that connects to the routing agent """
+
+import os
+import asyncio
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+server = os.environ["SERVER_URL"]
+port = os.environ["ROUTING_AGENT_PORT"]
+
+def send_prompt(prompt: str):
+    url = f"http://{server}:{port}/message"
+    payload = {"message": prompt}
+    try:
+        response = requests.post(url, json=payload)
+        if response.status_code == 200:
+            return response.json().get("response", "No response from agent.")
+        else:
+            return f"Error {response.status_code}: {response.text}"
+    except Exception as e:
+        return f"Request failed: {e}"
+
+async def main():
+    print("Enter a prompt for the Tailwind Traders trip planner. Type 'quit' to exit.")
+    while True:
+        user_input = input("User: ")
+        if user_input.lower() == "quit":
+            print("Goodbye!")
+            break
+        response = send_prompt(user_input)
+        print(f"Agent: {response}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/data.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/data.txt
@@ -1,0 +1,4 @@
+date,description,amount
+07-Mar-2025,trailhead shuttle,24.00
+07-Mar-2025,guide team dinner,65.50
+07-Mar-2025,campsite permit,125.90

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/expense_agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/expense_agent.py
@@ -1,0 +1,56 @@
+import os
+import asyncio
+from pathlib import Path
+from typing import Annotated
+from dotenv import load_dotenv
+
+# Add references
+
+
+load_dotenv()
+
+
+async def main():
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    # Load the trip expenses data file
+    script_dir = Path(__file__).parent
+    file_path = script_dir / 'data.txt'
+    with file_path.open('r') as file:
+        data = file.read() + "\n"
+
+    # Ask for a prompt
+    user_prompt = input(f"Here is the trip expense data in your file:\n\n{data}\n\nWhat would you like me to do with it?\n\n")
+
+    # Run the async agent code
+    await process_expenses_data(user_prompt, data)
+
+
+async def process_expenses_data(prompt, expenses_data):
+
+    # Create a foundry chat client
+
+
+    # Initialize an agent with the tool and instructions
+
+
+    # Create a session and use the agent to process the expenses data
+    try:
+        # A session keeps the conversation history across the agent run
+        session = agent.create_session()
+        # Invoke the agent with the prompt and the trip expenses data
+        response = await agent.run(f"{prompt}: {expenses_data}", session=session)
+        # Display the response
+        print(f"\n# Agent:\n{response.text}")
+    except Exception as e:
+        # Something went wrong
+        print(e)
+
+
+# Create a tool function for the email functionality
+
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/feedback_agents.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/feedback_agents.py
@@ -1,0 +1,52 @@
+import asyncio
+import os
+from typing import cast
+from dotenv import load_dotenv
+
+# Add references
+
+
+load_dotenv()
+
+async def main():
+    # Agent instructions
+    summarizer_instructions="""
+    Summarize the customer's feedback in one short sentence. Keep it neutral and concise.
+    Example output:
+    Tent zipper broke on the first night of a trip.
+    Customer praises the guided kayak tour.
+    """
+
+    classifier_instructions="""
+    Classify the feedback as one of the following: Positive, Negative, or Feature request.
+    """
+
+    action_instructions="""
+    Based on the summary and classification, suggest the next action in one short sentence.
+    Example output:
+    Escalate as a high-priority defect for the gear team.
+    Log as positive feedback to share with the trips team.
+    Log as enhancement request for the product backlog.
+    """
+
+    # Create the chat client
+
+
+    # Create agents
+
+
+    # Initialize the current feedback
+
+
+    # Build sequential orchestration
+
+
+    # Run and collect outputs
+
+
+    # Display outputs
+
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/outline_agent/agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/outline_agent/agent.py
@@ -1,0 +1,72 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip itinerary outline """
+
+import os
+
+from azure.ai.agents import AgentsClient
+from azure.ai.agents.models import Agent, MessageRole, ListSortOrder
+from azure.identity import DefaultAzureCredential
+
+class OutlineAgent:
+
+    def __init__(self):
+
+        # Create the agents client
+        self.client = AgentsClient(
+            endpoint=os.environ['PROJECT_ENDPOINT'],
+            credential=DefaultAzureCredential(
+                exclude_environment_credential=True,
+                exclude_managed_identity_credential=True
+            )
+        )
+
+        self.agent: Agent | None = None
+
+    async def create_agent(self) -> Agent:
+        if self.agent:
+            return self.agent
+
+        # Create the itinerary agent
+        self.agent = self.client.create_agent(
+            model=os.environ['MODEL_DEPLOYMENT_NAME'],
+            name='trip-itinerary-agent',
+            instructions="""
+            You are a helpful trip planning assistant for Tailwind Traders.
+            Based on the provided trip title or destination, write a concise itinerary outline with 4 to 6 key stages.
+            Each stage should be 5 to 10 words long, suitable for structuring a short guided-trip plan.
+            """,
+        )
+        return self.agent
+
+    async def run_conversation(self, user_message: str) -> list[str]:
+        if not self.agent:
+            await self.create_agent()
+
+        # Create a thread for the chat session
+        thread = self.client.threads.create()
+
+        # Send user message
+        self.client.messages.create(thread_id=thread.id, role=MessageRole.USER, content=user_message)
+
+        # Create and run the agent
+        run = self.client.runs.create_and_process(thread_id=thread.id, agent_id=self.agent.id)
+
+        if run.status == 'failed':
+            print(f'Itinerary Agent: Run failed - {run.last_error}')
+            return [f'Error: {run.last_error}']
+
+        # Get response messages
+        messages = self.client.messages.list(thread_id=thread.id, order=ListSortOrder.DESCENDING)
+        responses = []
+        for msg in messages:
+            # Only get the latest assistant response
+            if msg.role == 'assistant' and msg.text_messages:
+                for text_msg in msg.text_messages:
+                    responses.append(text_msg.text.value)
+                break 
+
+        return responses if responses else ['No response received']
+
+async def create_foundry_outline_agent() -> OutlineAgent:
+    agent = OutlineAgent()
+    await agent.create_agent()
+    return agent

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/outline_agent/agent_executor.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/outline_agent/agent_executor.py
@@ -1,0 +1,82 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip itinerary outline """
+
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import AgentCard, Part, TaskState
+from a2a.utils.message import new_agent_text_message
+from outline_agent.agent import OutlineAgent, create_foundry_outline_agent
+
+# An AgentExecutor that runs Azure AI Foundry-based agents. Adapted from the ADK agent executor pattern.
+class OutlineAgentExecutor(AgentExecutor):
+
+    def __init__(self, card: AgentCard):
+        self._card = card
+        self._foundry_agent: OutlineAgent | None = None
+
+    async def _get_or_create_agent(self) -> OutlineAgent:
+        if not self._foundry_agent:
+            self._foundry_agent = await create_foundry_outline_agent()
+        return self._foundry_agent
+
+    async def _process_request(self, message_parts: list[Part], context_id: str, task_updater: TaskUpdater) -> None:
+        # Process a user request through the Foundry agent
+
+        try:
+            # Retrieve message from A2A parts
+            user_message = message_parts[0].root.text
+
+            # Get the itinerary agent
+            agent = await self._get_or_create_agent()
+
+            # Update the task status
+            await task_updater.update_status(
+                TaskState.working,
+                message=new_agent_text_message('Itinerary Agent is processing your request...', context_id=context_id)
+            )
+
+            # Run the conversation
+            responses = await agent.run_conversation(user_message)
+
+            # Update the task with responses
+            for response in responses:
+                await task_updater.update_status(
+                    TaskState.working,
+                    message=new_agent_text_message( response, context_id=context_id)
+                )
+
+            # Mark the task as complete
+            final_message = responses[-1] if responses else 'Task completed.'
+            await task_updater.complete(
+                message=new_agent_text_message(final_message, context_id=context_id)
+            )
+
+        except Exception as e:
+            await task_updater.failed(
+                message=new_agent_text_message('Itinerary Agent failed to process the request.', 
+                context_id=context_id)
+            )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        
+        # Create task updater
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.submit()
+
+        # Start working
+        await updater.start_work()
+
+        # Process the request
+        await self._process_request(context.message.parts, context.context_id, updater)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        print(f'Itinerary Agent: Cancelling execution for context {context.context_id}')
+
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.failed(
+            message=new_agent_text_message('Task cancelled by user', context_id=context.context_id)
+        )
+
+def create_foundry_agent_executor(card: AgentCard) -> OutlineAgentExecutor:
+    return OutlineAgentExecutor(card)

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/outline_agent/server.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/outline_agent/server.py
@@ -1,0 +1,76 @@
+import os
+import uvicorn
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from dotenv import load_dotenv
+from outline_agent.agent_executor import create_foundry_agent_executor
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+load_dotenv()
+
+host = os.environ["SERVER_URL"]
+port = os.environ["OUTLINE_AGENT_PORT"]
+
+# Define agent skills
+skills = [
+    AgentSkill(
+        id='generate_itinerary',
+        name='Generate Itinerary',
+        description='Generates a guided-trip itinerary outline based on a destination',
+        tags=['outline'],
+        examples=[
+            'Can you give me an itinerary outline for this trip?',
+        ],
+    ),
+]
+
+# Create agent card
+agent_card = AgentCard(
+    name='Tailwind Traders Trip Itinerary Agent',
+    description='An intelligent itinerary generator agent powered by Azure AI Foundry. '
+    'I can help you generate itinerary outlines for Tailwind Traders guided trips.',
+    url=f'http://{host}:{port}/',
+    version='1.0.0',
+    default_input_modes=['text'],
+    default_output_modes=['text'],
+    capabilities=AgentCapabilities(streaming=True),
+    skills=skills,
+)
+
+# Create agent executor
+agent_executor = create_foundry_agent_executor(agent_card)
+
+# Create request handler
+request_handler = DefaultRequestHandler(
+    agent_executor=agent_executor, task_store=InMemoryTaskStore()
+)
+
+# Create A2A application
+a2a_app = A2AStarletteApplication(
+    agent_card=agent_card, http_handler=request_handler
+)
+
+# Get routes
+routes = a2a_app.routes()
+
+# Add health check endpoint
+async def health_check(request: Request) -> PlainTextResponse:
+    return PlainTextResponse('Tailwind Traders Trip Itinerary Agent is running!')
+
+routes.append(Route(path='/health', methods=['GET'], endpoint=health_check))
+
+# Create Starlette app
+app = Starlette(routes=routes)
+
+def main():
+    # Run the server
+    uvicorn.run(app, host=host, port=port)
+
+if __name__ == '__main__':
+    main()

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/requirements.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/requirements.txt
@@ -1,0 +1,11 @@
+python-dotenv
+azure-identity==1.25.3
+agent-framework==1.9.0
+httpx
+uvicorn
+starlette
+sse-starlette
+fastapi
+azure-ai-projects
+azure-ai-agents
+a2a-sdk==0.3.26

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/requirements.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 azure-identity==1.25.3
-agent-framework==1.9.0
+agent-framework==1.12.1
 httpx
 uvicorn
 starlette

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/routing_agent/agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/routing_agent/agent.py
@@ -1,0 +1,264 @@
+import asyncio
+import json
+import os
+import time
+import uuid
+import httpx
+
+from typing import Any, Callable
+from azure.ai.agents import AgentsClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ListSortOrder, FunctionTool, MessageRole
+from collections.abc import Callable
+from dotenv import load_dotenv
+from a2a.client import A2ACardResolver, A2AClient
+from a2a.types import (
+    AgentCard,
+    MessageSendParams,
+    SendMessageRequest,
+    SendMessageResponse,
+    SendMessageSuccessResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskStatusUpdateEvent,
+)
+
+load_dotenv()
+
+TaskCallbackArg = Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent
+TaskUpdateCallback = Callable[[TaskCallbackArg, AgentCard], Task]
+
+
+class RemoteAgentConnections:
+    """A class to hold the connections to the remote agents."""
+
+    def __init__(self, agent_card: AgentCard, agent_url: str):
+        self._httpx_client = httpx.AsyncClient(timeout=30)
+        self.agent_client = A2AClient(self._httpx_client, agent_card, url=agent_url)
+        self.card = agent_card
+
+    def get_agent(self) -> AgentCard:
+        return self.card
+
+    async def send_message(self, message_request: SendMessageRequest) -> SendMessageResponse:
+        return await self.agent_client.send_message(message_request)
+
+class RoutingAgent:
+
+    def __init__(self,task_callback: TaskUpdateCallback | None = None):
+
+        self.task_callback = task_callback
+        self.remote_agent_connections: dict[str, RemoteAgentConnections] = {}
+        self.cards: dict[str, AgentCard] = {}
+        self.agents: str = ''
+        
+        # Initialize Azure AI Agents client
+        self.agents_client = AgentsClient(
+            endpoint=os.environ["PROJECT_ENDPOINT"],
+            credential=DefaultAzureCredential(
+                exclude_environment_credential=True,
+                exclude_managed_identity_credential=True
+            )
+        )
+
+        self.azure_agent = None
+        self.current_thread = None
+
+
+    @classmethod
+    async def create(cls, remote_agent_addresses: list[str], task_callback: TaskUpdateCallback | None = None) -> 'RoutingAgent':
+        """Create and asynchronously initialize an instance of the RoutingAgent."""
+        instance = cls(task_callback)
+        await instance._async_init_components(remote_agent_addresses)
+        return instance
+    
+
+    def list_remote_agents(self) -> str:
+        if not self.remote_agent_connections:
+            return "[]"
+
+        lines = []
+        for card in self.cards.values():
+            lines.append(f"{card.name}: {card.description}")
+
+        return "[\n  " + ",\n  ".join(lines) + "\n]"
+    
+
+    async def _async_init_components(self, remote_agent_addresses: list[str]) -> None:
+        """Asynchronous part of initialization."""
+
+        # Use a single httpx.AsyncClient for all card resolutions for efficiency
+        async with httpx.AsyncClient(timeout=30) as client:
+            for address in remote_agent_addresses:
+                card_resolver = A2ACardResolver(client, address)
+                try:
+                    card = await card_resolver.get_agent_card()
+
+                    remote_connection = RemoteAgentConnections(agent_card=card, agent_url=address)
+                    self.remote_agent_connections[card.name] = remote_connection
+                    self.cards[card.name] = card
+
+                except httpx.ConnectError as e:
+                    print( f'ERROR: Failed to get agent card from {address}: {e}')
+                except Exception as e:  # Catch other potential errors
+                    print(f'ERROR: Failed to initialize connection for {address}: {e}')
+            print(f"Found remote agents: {self.list_remote_agents()}")
+
+    
+    async def send_message(self, agent_name: str, task: str):
+        # Sends a task to remote agent.
+
+        if agent_name not in self.remote_agent_connections:
+            raise ValueError(f'Agent {agent_name} not found')
+        
+        # Retrieve the remote agent's A2A client using the agent name 
+
+
+        if not client:
+            raise ValueError(f'Client not available for {agent_name}')
+        
+        message_id = str(uuid.uuid4())
+
+        # Construct the payload to send to the remote agent
+
+
+        # Wrap the payload in a SendMessageRequest object
+
+
+        # Send the message to the remote agent client and await the response
+
+
+        if not isinstance(send_response.root, SendMessageSuccessResponse):
+            print('received non-success response. Aborting get task ')
+            return
+
+        if not isinstance(send_response.root.result, Task):
+            print('received non-task response. Aborting get task ')
+            return
+
+        return send_response.root.result
+
+
+    def create_agent(self):
+        # Create an Azure AI Agent instance
+        
+        try:
+            # Create Azure AI Agent with the send_message function
+            functions = FunctionTool({self.send_message})
+            self.azure_agent = self.agents_client.create_agent(
+                model=os.environ["MODEL_DEPLOYMENT_NAME"],
+                name="routing-agent",
+                instructions=f"""
+                You are an expert Routing Delegator for Tailwind Traders guided trips.
+
+                Your role:
+                - Delegate user inquiries to appropriate specialized remote agents
+                - Provide clear and helpful responses to users
+
+                Available Agents: {self.list_remote_agents()}
+
+                Always be helpful and route requests to the most appropriate agent.""",
+                tools=functions.definitions
+            )
+
+            # Create a thread for conversation
+            self.current_thread = self.agents_client.threads.create()
+
+            return self.azure_agent
+            
+        except Exception as e:
+            print(f"Error creating Azure AI agent: {e}")
+            raise
+
+    async def process_user_message(self, user_message: str) -> str:
+
+        if not hasattr(self, 'azure_agent') or not self.azure_agent:
+            return "Azure AI Agent not initialized. Please ensure the agent is properly created."
+        
+        if not hasattr(self, 'current_thread') or not self.current_thread:
+            return "Azure AI Thread not initialized. Please ensure the agent is properly created."
+        
+        try:
+            # Create message in the thread
+            self.agents_client.messages.create(
+                thread_id=self.current_thread.id, 
+                role=MessageRole.User, 
+                content=user_message
+            )
+
+            # Create and run the agent
+            run = self.agents_client.runs.create(
+                thread_id=self.current_thread.id, 
+                agent_id=self.azure_agent.id
+            )
+            
+            # Need to await send_message function
+            while run.status in ["queued", "in_progress", "requires_action"]:
+                time.sleep(1)
+                run = self.agents_client.runs.get(thread_id=self.current_thread.id, run_id=run.id)
+
+                if run.status == "requires_action":
+                    tool_calls = run.required_action.submit_tool_outputs.tool_calls
+                    tool_outputs = []
+                    
+                    for tool_call in tool_calls:
+                        function_name = tool_call.function.name
+                        function_args = json.loads(tool_call.function.arguments)
+                        
+                        if function_name == "send_message":
+                            try:
+                                result = await self.send_message(agent_name=function_args["agent_name"], task=function_args["task"])
+                                output = json.dumps(result.model_dump() if hasattr(result, 'model_dump') else str(result))
+
+                            except Exception as e:
+                                output = json.dumps({"error": str(e)})
+                        else:
+                            output = json.dumps({"error": f"Unknown function: {function_name}"})
+                        
+                        tool_outputs.append({"tool_call_id": tool_call.id,  "output": output})
+                
+                    # Submit the tool outputs
+                    self.agents_client.runs.submit_tool_outputs(
+                        thread_id=self.current_thread.id, run_id=run.id, tool_outputs=tool_outputs
+                    )
+
+            if run.status == "failed":
+                error_info = f"Run error: {run.last_error}"
+                print(error_info)
+                return f"Error processing request: {error_info}"
+
+            # Return the response
+            messages = self.agents_client.messages.list(thread_id=self.current_thread.id, order=ListSortOrder.DESCENDING)
+            for msg in messages:
+                if msg.role == MessageRole.AGENT and msg.text_messages:
+                    last_text = msg.text_messages[-1]
+                    return last_text.text.value
+            
+            return "No response received from agent."
+            
+        except Exception as e:
+            error_msg = f"Error in process_user_message: {e}"
+            print(error_msg)
+            return f"An error occurred while processing your message."
+
+
+async def _get_initialized_routing_agent_sync() -> RoutingAgent:
+
+    async def _async_main() -> RoutingAgent:
+        routing_agent_instance = await RoutingAgent.create(
+            remote_agent_addresses=[
+                f"http://{os.environ["SERVER_URL"]}:{os.environ["TITLE_AGENT_PORT"]}",
+                f"http://{os.environ["SERVER_URL"]}:{os.environ["OUTLINE_AGENT_PORT"]}",
+            ]
+        )
+        # Create the Azure AI agent
+        routing_agent_instance.create_agent()
+        return routing_agent_instance
+
+    try:
+        return asyncio.run(_async_main())
+    except RuntimeError as e:
+        raise
+
+# Initialize the routing agent
+routing_agent = _get_initialized_routing_agent_sync()

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/routing_agent/server.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/routing_agent/server.py
@@ -1,0 +1,51 @@
+import os
+import asyncio
+from fastapi import FastAPI, Request
+from dotenv import load_dotenv
+from contextlib import asynccontextmanager
+from routing_agent.agent import RoutingAgent  
+
+load_dotenv()
+
+routing_agent = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global routing_agent
+    print("Starting up: Initializing routing agent...")
+    routing_agent = await RoutingAgent.create([
+        f"http://{os.environ["SERVER_URL"]}:{os.environ["TITLE_AGENT_PORT"]}",
+        f"http://{os.environ["SERVER_URL"]}:{os.environ["OUTLINE_AGENT_PORT"]}",
+    ])
+    routing_agent.create_agent()
+    print("Routing agent initialized.")
+    yield
+
+app = FastAPI(lifespan=lifespan)
+
+@app.post("/message")
+async def handle_message(request: Request):
+    print("Agent: Processing request, please wait.")
+
+    data = await request.json()
+    user_message = data.get("message")
+
+    if not user_message:
+        return {"error": "No message provided."}
+    
+    try:
+        response = await routing_agent.process_user_message(user_message)
+
+    except Exception as e:
+        return {"error": f"Failed to process message: {str(e)}"}
+    
+    return {"response": response}
+
+@app.get("/health")
+async def health_check():
+    return {"status": "Routing agent is running!"}
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.environ["ROUTING_AGENT_PORT"])
+    uvicorn.run(app, host=os.environ["SERVER_URL"], port=port, reload=True)

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/run_all.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/run_all.py
@@ -1,0 +1,120 @@
+""" Runs each agent server and starts the client """
+
+import asyncio
+import subprocess
+import sys
+import time
+import signal
+import httpx
+import os
+import threading
+from dotenv import load_dotenv
+
+load_dotenv()
+
+server_url = os.environ["SERVER_URL"]
+servers = [
+    {
+        "name": "title_agent_server",
+        "module": "title_agent.server:app",
+        "port": os.environ["TITLE_AGENT_PORT"]
+    },
+    {
+        "name": "outline_agent_server",
+        "module": "outline_agent.server:app",
+        "port": os.environ["OUTLINE_AGENT_PORT"]
+    },
+    {
+        "name": "routing_agent_server",
+        "module": "routing_agent.server:app",
+        "port": os.environ["ROUTING_AGENT_PORT"]
+    },
+]
+
+server_procs = []
+
+async def wait_for_server_ready(server, timeout=30):
+    async with httpx.AsyncClient() as client:
+        start = time.time()
+        while True:
+            try:
+                health_url = f"http://{server_url}:{server['port']}/health"
+                r = await client.get(health_url, timeout=2)
+                if r.status_code == 200:
+                    print(f"[ready] {server['name']} is healthy and ready!")
+                    return True
+            except Exception:
+                pass
+            if time.time() - start > timeout:
+                print(f"[error] Timeout waiting for server health at {health_url}")
+                return False
+            await asyncio.sleep(1)
+
+def stream_subprocess_output(process):
+    while True:
+        line = process.stdout.readline()
+        if not line:
+            break
+        print(line.rstrip())
+
+
+async def run_client_main():
+    from client import main as client_main
+    await client_main()
+
+async def main():
+    print("[start] Starting server subprocesses...")
+    for server in servers:
+        cmd = [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            server["module"],
+            "--host",
+            server_url,
+            "--port",
+            str(server["port"]),
+            "--log-level",
+            "info"
+        ]
+
+        print(f"[start] Starting {server['name']} on port {server['port']}")
+        process = subprocess.Popen(
+            cmd,
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            universal_newlines=True,
+        )
+        server_procs.append(process)
+
+        thread = threading.Thread(target=stream_subprocess_output, args=(process,), daemon=True)
+        thread.start()
+
+        ready = await wait_for_server_ready(server)
+        if not ready:
+            print(f"[error] Server '{server['name']}' failed to start, killing process...")
+            process.kill()
+            sys.exit(1)
+
+    try:
+        await run_client_main()
+    except Exception as e:
+        print(f"[error] Client stopped: {e}")
+    finally:
+        print("[stop] Stopping server subprocess...")
+        # Terminate the server subprocess gracefully
+        for process in server_procs:
+            if process.poll() is None:  # Still running
+                if sys.platform == "win32":
+                    process.send_signal(signal.CTRL_BREAK_EVENT)
+                else:
+                    process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/title_agent/agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/title_agent/agent.py
@@ -1,0 +1,60 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip title """
+
+import os
+from azure.ai.agents import AgentsClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import Agent, ListSortOrder, MessageRole
+
+class TitleAgent:
+
+    def __init__(self):
+
+        # Create the agents client
+
+
+        self.agent: Agent | None = None
+
+    async def create_agent(self) -> Agent:
+        if self.agent:
+            return self.agent
+
+        # Create the title agent
+
+
+        return self.agent
+        
+    async def run_conversation(self, user_message: str) -> list[str]:
+        # Add a message to the thread, process it, and retrieve the response
+
+        if not self.agent:
+            await self.create_agent()
+
+        # Create a thread for the chat session
+
+
+        # Send user message
+        
+
+        # Create and run the agent
+
+
+        if run.status == 'failed':
+            print(f'Title Agent: Run failed - {run.last_error}')
+            return [f'Error: {run.last_error}']
+
+        # Get response messages
+        messages = self.client.messages.list(thread_id=thread.id, order=ListSortOrder.DESCENDING)
+        responses = []
+        for msg in messages:
+            # Only get the latest assistant response
+            if msg.role == MessageRole.AGENT and msg.text_messages:
+                for text_msg in msg.text_messages:
+                    responses.append(text_msg.text.value)
+                break 
+
+        return responses if responses else ['No response received']
+
+async def create_foundry_title_agent() -> TitleAgent:
+    agent = TitleAgent()
+    await agent.create_agent()
+    return agent

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/title_agent/agent_executor.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/title_agent/agent_executor.py
@@ -1,0 +1,72 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip title """
+
+from a2a.server.events.event_queue import EventQueue
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.tasks import TaskUpdater
+from a2a.utils import new_agent_text_message
+from a2a.types import AgentCard, Part, TaskState
+from title_agent.agent import TitleAgent, create_foundry_title_agent
+
+class FoundryAgentExecutor(AgentExecutor):
+
+    def __init__(self, card: AgentCard):
+        self._card = card
+        self._foundry_agent: TitleAgent | None = None
+
+    async def _get_or_create_agent(self) -> TitleAgent:
+        if not self._foundry_agent:
+            self._foundry_agent = await create_foundry_title_agent()
+        return self._foundry_agent
+
+    async def _process_request(self, message_parts: list[Part], context_id: str, task_updater: TaskUpdater) -> None:
+        # Process a user request through the Foundry agent
+
+        try:
+            # Retrieve message from A2A parts
+            user_message = message_parts[0].root.text
+
+            # Get the title agent
+
+
+            # Update the task status
+
+
+            # Run the agent conversation
+
+
+            # Update the task with the responses
+
+
+            # Mark the task as complete
+
+
+        except Exception as e:
+            print(f'Title Agent: Error processing request - {e}')
+            await task_updater.failed(
+                message=new_agent_text_message("Title Agent failed to process the request.", 
+                context_id=context_id)
+            )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue,):
+       
+        # Create task updater
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.submit()
+
+        # Start working
+        await updater.start_work()
+
+        # Process the request
+
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        print(f'Title Agent: Cancelling execution for context {context.context_id}')
+
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.failed(
+            message=new_agent_text_message('Task cancelled by user', context_id=context.context_id)
+        )
+
+def create_foundry_agent_executor(card: AgentCard) -> FoundryAgentExecutor:
+    return FoundryAgentExecutor(card)

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/title_agent/server.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/title_agent/server.py
@@ -1,0 +1,52 @@
+import os
+import uvicorn
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from dotenv import load_dotenv
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from title_agent.agent_executor import create_foundry_agent_executor
+
+load_dotenv()
+
+host = os.environ["SERVER_URL"]
+port = os.environ["TITLE_AGENT_PORT"]
+
+# Define agent skills
+
+
+# Create agent card
+
+
+# Create agent executor
+
+
+# Create request handler
+
+
+# Create A2A application
+
+
+# Get routes
+routes = a2a_app.routes()
+
+# Add health check endpoint
+async def health_check(request: Request) -> PlainTextResponse:
+    return PlainTextResponse('Tailwind Traders Trip Title Agent is running!')
+
+routes.append(Route(path='/health', methods=['GET'], endpoint=health_check))
+
+# Create Starlette app
+app = Starlette(routes=routes)
+
+def main():
+    # Run the server
+    uvicorn.run(app, host=host, port=port)
+
+if __name__ == '__main__':
+    main()

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/.env.example
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/.env.example
@@ -1,0 +1,17 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# In VS Code, Foundry Toolkit > right-click your active project > Copy Project Endpoint,
+# or copy it from the Microsoft Foundry portal project overview page.
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (for example, gpt-4o) — used by every task
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here
+
+# Task 3 (connect remote agents with A2A) runs three local agent servers.
+# These ship pre-filled — you normally don't need to change them.
+SERVER_URL=localhost
+TITLE_AGENT_PORT=10007
+OUTLINE_AGENT_PORT=10008
+ROUTING_AGENT_PORT=10009

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/client.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/client.py
@@ -1,0 +1,36 @@
+""" Client code that connects to the routing agent """
+
+import os
+import asyncio
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+server = os.environ["SERVER_URL"]
+port = os.environ["ROUTING_AGENT_PORT"]
+
+def send_prompt(prompt: str):
+    url = f"http://{server}:{port}/message"
+    payload = {"message": prompt}
+    try:
+        response = requests.post(url, json=payload)
+        if response.status_code == 200:
+            return response.json().get("response", "No response from agent.")
+        else:
+            return f"Error {response.status_code}: {response.text}"
+    except Exception as e:
+        return f"Request failed: {e}"
+
+async def main():
+    print("Enter a prompt for the Tailwind Traders trip planner. Type 'quit' to exit.")
+    while True:
+        user_input = input("User: ")
+        if user_input.lower() == "quit":
+            print("Goodbye!")
+            break
+        response = send_prompt(user_input)
+        print(f"Agent: {response}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/data.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/data.txt
@@ -1,0 +1,4 @@
+date,description,amount
+07-Mar-2025,trailhead shuttle,24.00
+07-Mar-2025,guide team dinner,65.50
+07-Mar-2025,campsite permit,125.90

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/expense_agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/expense_agent.py
@@ -1,0 +1,88 @@
+"""
+Task 1 (Core) - Tailwind Traders trip-expense agent, built with the Microsoft Agent Framework.
+
+This is a single agent with one custom tool. The agent reads a guide's trip-expense
+data, itemizes it, and uses the submit_claim tool to "email" a reimbursement claim to
+the Tailwind Traders finance desk. The @tool decorator generates the tool schema from
+the function signature, and agent.run() runs the whole tool-calling loop for you.
+"""
+
+import os
+import asyncio
+from pathlib import Path
+from typing import Annotated
+from dotenv import load_dotenv
+
+# Add references
+from agent_framework import tool, Agent
+from agent_framework.foundry import FoundryChatClient
+from azure.identity import AzureCliCredential
+from pydantic import Field
+
+load_dotenv()
+
+
+async def main():
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    # Load the trip expenses data file
+    script_dir = Path(__file__).parent
+    file_path = script_dir / 'data.txt'
+    with file_path.open('r') as file:
+        data = file.read() + "\n"
+
+    # Ask for a prompt
+    user_prompt = input(f"Here is the trip expense data in your file:\n\n{data}\n\nWhat would you like me to do with it?\n\n")
+
+    # Run the async agent code
+    await process_expenses_data(user_prompt, data)
+
+
+async def process_expenses_data(prompt, expenses_data):
+
+    # Create a foundry chat client
+    client = FoundryChatClient(
+        project_endpoint=os.getenv("PROJECT_ENDPOINT"),
+        model=os.getenv("MODEL_DEPLOYMENT_NAME"),
+        credential=AzureCliCredential(),
+    )
+
+    # Initialize an agent with the tool and instructions
+    agent = Agent(
+        client=client,
+        name="TripExpenseAgent",
+        instructions="""You are an AI assistant for Tailwind Traders trip-expense claims.
+                    At the user's request, create an expense claim and use the submit_claim tool to send an email to expenses@tailwindtraders.com with the subject 'Trip Expense Claim' and a body that contains the itemized expenses with a total.
+                    Then confirm to the user that you've done so. Don't ask for any more information from the user, just use the data provided to create the email.""",
+        tools=[submit_claim],
+    )
+
+    # Create a session and use the agent to process the expenses data
+    try:
+        # A session keeps the conversation history across the agent run
+        session = agent.create_session()
+        # Invoke the agent with the prompt and the trip expenses data
+        response = await agent.run(f"{prompt}: {expenses_data}", session=session)
+        # Display the response
+        print(f"\n# Agent:\n{response.text}")
+    except Exception as e:
+        # Something went wrong
+        print(e)
+
+
+# Create a tool function for the email functionality
+@tool(approval_mode="never_require")
+def submit_claim(
+    to: Annotated[str, Field(description="Who to send the email to")],
+    subject: Annotated[str, Field(description="The subject of the email.")],
+    body: Annotated[str, Field(description="The text body of the email.")],
+):
+    """Submit a Tailwind Traders trip-expense claim by sending an email."""
+    print("\nTo:", to)
+    print("Subject:", subject)
+    print(body, "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/feedback_agents.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/feedback_agents.py
@@ -1,0 +1,94 @@
+"""
+Task 2 (Optional) - Multi-agent sequential orchestration with the Microsoft Agent Framework.
+
+Three Tailwind Traders agents work together in a pipeline to triage a piece of customer
+feedback: a Summarizer condenses it, a Classifier labels it, and an Action agent recommends
+the next step. SequentialBuilder runs them in order and collects every agent's output.
+"""
+
+import asyncio
+import os
+from typing import cast
+from dotenv import load_dotenv
+
+# Add references
+from agent_framework import Message
+from agent_framework.foundry import FoundryChatClient
+from agent_framework.orchestrations import SequentialBuilder
+from azure.identity import AzureCliCredential
+
+load_dotenv()
+
+async def main():
+    # Agent instructions
+    summarizer_instructions="""
+    Summarize the customer's feedback in one short sentence. Keep it neutral and concise.
+    Example output:
+    Tent zipper broke on the first night of a trip.
+    Customer praises the guided kayak tour.
+    """
+
+    classifier_instructions="""
+    Classify the feedback as one of the following: Positive, Negative, or Feature request.
+    """
+
+    action_instructions="""
+    Based on the summary and classification, suggest the next action in one short sentence.
+    Example output:
+    Escalate as a high-priority defect for the gear team.
+    Log as positive feedback to share with the trips team.
+    Log as enhancement request for the product backlog.
+    """
+
+    # Create the chat client
+    credential = AzureCliCredential()
+    chat_client = FoundryChatClient(
+        credential=credential,
+        project_endpoint=os.getenv("PROJECT_ENDPOINT"),
+        model=os.getenv("MODEL_DEPLOYMENT_NAME"),
+    )
+
+    # Create agents
+    summarizer_agent = chat_client.as_agent(
+        name="summarizer",
+        instructions=summarizer_instructions,
+    )
+
+    classifier_agent = chat_client.as_agent(
+        name="classifier",
+        instructions=classifier_instructions,
+    )
+
+    action_agent = chat_client.as_agent(
+        name="action",
+        instructions=action_instructions,
+    )
+
+    # Initialize the current feedback
+    feedback="""
+    I use your trail-finder app before every hike, and it works well overall.
+    But when I'm checking the map at night on the trail, the bright screen is really harsh on my eyes.
+    If you added a dark mode option, it would make it much more comfortable to use in low light.
+    """
+
+    # Build sequential orchestration
+    workflow = SequentialBuilder(
+        participants=[summarizer_agent, classifier_agent, action_agent],
+        output_from="all",
+    ).build()
+
+    # Run and collect outputs
+    result = await workflow.run(f"Customer feedback: {feedback}")
+    outputs = result.get_outputs()
+
+    # Display outputs
+    i = 1
+    for response in outputs:
+        for msg in cast(list[Message], response.messages):
+            name = msg.author_name or ("assistant" if msg.role == "assistant" else "user")
+            print(f"{'-' * 60}\n{i:02d} [{name}]\n{msg.text}")
+            i += 1
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/outline_agent/agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/outline_agent/agent.py
@@ -1,0 +1,72 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip itinerary outline """
+
+import os
+
+from azure.ai.agents import AgentsClient
+from azure.ai.agents.models import Agent, MessageRole, ListSortOrder
+from azure.identity import DefaultAzureCredential
+
+class OutlineAgent:
+
+    def __init__(self):
+
+        # Create the agents client
+        self.client = AgentsClient(
+            endpoint=os.environ['PROJECT_ENDPOINT'],
+            credential=DefaultAzureCredential(
+                exclude_environment_credential=True,
+                exclude_managed_identity_credential=True
+            )
+        )
+
+        self.agent: Agent | None = None
+
+    async def create_agent(self) -> Agent:
+        if self.agent:
+            return self.agent
+
+        # Create the itinerary agent
+        self.agent = self.client.create_agent(
+            model=os.environ['MODEL_DEPLOYMENT_NAME'],
+            name='trip-itinerary-agent',
+            instructions="""
+            You are a helpful trip planning assistant for Tailwind Traders.
+            Based on the provided trip title or destination, write a concise itinerary outline with 4 to 6 key stages.
+            Each stage should be 5 to 10 words long, suitable for structuring a short guided-trip plan.
+            """,
+        )
+        return self.agent
+
+    async def run_conversation(self, user_message: str) -> list[str]:
+        if not self.agent:
+            await self.create_agent()
+
+        # Create a thread for the chat session
+        thread = self.client.threads.create()
+
+        # Send user message
+        self.client.messages.create(thread_id=thread.id, role=MessageRole.USER, content=user_message)
+
+        # Create and run the agent
+        run = self.client.runs.create_and_process(thread_id=thread.id, agent_id=self.agent.id)
+
+        if run.status == 'failed':
+            print(f'Itinerary Agent: Run failed - {run.last_error}')
+            return [f'Error: {run.last_error}']
+
+        # Get response messages
+        messages = self.client.messages.list(thread_id=thread.id, order=ListSortOrder.DESCENDING)
+        responses = []
+        for msg in messages:
+            # Only get the latest assistant response
+            if msg.role == 'assistant' and msg.text_messages:
+                for text_msg in msg.text_messages:
+                    responses.append(text_msg.text.value)
+                break 
+
+        return responses if responses else ['No response received']
+
+async def create_foundry_outline_agent() -> OutlineAgent:
+    agent = OutlineAgent()
+    await agent.create_agent()
+    return agent

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/outline_agent/agent_executor.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/outline_agent/agent_executor.py
@@ -1,0 +1,82 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip itinerary outline """
+
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import AgentCard, Part, TaskState
+from a2a.utils.message import new_agent_text_message
+from outline_agent.agent import OutlineAgent, create_foundry_outline_agent
+
+# An AgentExecutor that runs Azure AI Foundry-based agents. Adapted from the ADK agent executor pattern.
+class OutlineAgentExecutor(AgentExecutor):
+
+    def __init__(self, card: AgentCard):
+        self._card = card
+        self._foundry_agent: OutlineAgent | None = None
+
+    async def _get_or_create_agent(self) -> OutlineAgent:
+        if not self._foundry_agent:
+            self._foundry_agent = await create_foundry_outline_agent()
+        return self._foundry_agent
+
+    async def _process_request(self, message_parts: list[Part], context_id: str, task_updater: TaskUpdater) -> None:
+        # Process a user request through the Foundry agent
+
+        try:
+            # Retrieve message from A2A parts
+            user_message = message_parts[0].root.text
+
+            # Get the itinerary agent
+            agent = await self._get_or_create_agent()
+
+            # Update the task status
+            await task_updater.update_status(
+                TaskState.working,
+                message=new_agent_text_message('Itinerary Agent is processing your request...', context_id=context_id)
+            )
+
+            # Run the conversation
+            responses = await agent.run_conversation(user_message)
+
+            # Update the task with responses
+            for response in responses:
+                await task_updater.update_status(
+                    TaskState.working,
+                    message=new_agent_text_message( response, context_id=context_id)
+                )
+
+            # Mark the task as complete
+            final_message = responses[-1] if responses else 'Task completed.'
+            await task_updater.complete(
+                message=new_agent_text_message(final_message, context_id=context_id)
+            )
+
+        except Exception as e:
+            await task_updater.failed(
+                message=new_agent_text_message('Itinerary Agent failed to process the request.', 
+                context_id=context_id)
+            )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        
+        # Create task updater
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.submit()
+
+        # Start working
+        await updater.start_work()
+
+        # Process the request
+        await self._process_request(context.message.parts, context.context_id, updater)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        print(f'Itinerary Agent: Cancelling execution for context {context.context_id}')
+
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.failed(
+            message=new_agent_text_message('Task cancelled by user', context_id=context.context_id)
+        )
+
+def create_foundry_agent_executor(card: AgentCard) -> OutlineAgentExecutor:
+    return OutlineAgentExecutor(card)

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/outline_agent/server.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/outline_agent/server.py
@@ -1,0 +1,76 @@
+import os
+import uvicorn
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from dotenv import load_dotenv
+from outline_agent.agent_executor import create_foundry_agent_executor
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+load_dotenv()
+
+host = os.environ["SERVER_URL"]
+port = os.environ["OUTLINE_AGENT_PORT"]
+
+# Define agent skills
+skills = [
+    AgentSkill(
+        id='generate_itinerary',
+        name='Generate Itinerary',
+        description='Generates a guided-trip itinerary outline based on a destination',
+        tags=['outline'],
+        examples=[
+            'Can you give me an itinerary outline for this trip?',
+        ],
+    ),
+]
+
+# Create agent card
+agent_card = AgentCard(
+    name='Tailwind Traders Trip Itinerary Agent',
+    description='An intelligent itinerary generator agent powered by Azure AI Foundry. '
+    'I can help you generate itinerary outlines for Tailwind Traders guided trips.',
+    url=f'http://{host}:{port}/',
+    version='1.0.0',
+    default_input_modes=['text'],
+    default_output_modes=['text'],
+    capabilities=AgentCapabilities(streaming=True),
+    skills=skills,
+)
+
+# Create agent executor
+agent_executor = create_foundry_agent_executor(agent_card)
+
+# Create request handler
+request_handler = DefaultRequestHandler(
+    agent_executor=agent_executor, task_store=InMemoryTaskStore()
+)
+
+# Create A2A application
+a2a_app = A2AStarletteApplication(
+    agent_card=agent_card, http_handler=request_handler
+)
+
+# Get routes
+routes = a2a_app.routes()
+
+# Add health check endpoint
+async def health_check(request: Request) -> PlainTextResponse:
+    return PlainTextResponse('Tailwind Traders Trip Itinerary Agent is running!')
+
+routes.append(Route(path='/health', methods=['GET'], endpoint=health_check))
+
+# Create Starlette app
+app = Starlette(routes=routes)
+
+def main():
+    # Run the server
+    uvicorn.run(app, host=host, port=port)
+
+if __name__ == '__main__':
+    main()

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/requirements.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/requirements.txt
@@ -1,0 +1,11 @@
+python-dotenv
+azure-identity==1.25.3
+agent-framework==1.9.0
+httpx
+uvicorn
+starlette
+sse-starlette
+fastapi
+azure-ai-projects
+azure-ai-agents
+a2a-sdk==0.3.26

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/requirements.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 azure-identity==1.25.3
-agent-framework==1.9.0
+agent-framework==1.12.1
 httpx
 uvicorn
 starlette

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/routing_agent/agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/routing_agent/agent.py
@@ -1,0 +1,270 @@
+import asyncio
+import json
+import os
+import time
+import uuid
+import httpx
+
+from typing import Any, Callable
+from azure.ai.agents import AgentsClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ListSortOrder, FunctionTool, MessageRole
+from collections.abc import Callable
+from dotenv import load_dotenv
+from a2a.client import A2ACardResolver, A2AClient
+from a2a.types import (
+    AgentCard,
+    MessageSendParams,
+    SendMessageRequest,
+    SendMessageResponse,
+    SendMessageSuccessResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskStatusUpdateEvent,
+)
+
+load_dotenv()
+
+TaskCallbackArg = Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent
+TaskUpdateCallback = Callable[[TaskCallbackArg, AgentCard], Task]
+
+
+class RemoteAgentConnections:
+    """A class to hold the connections to the remote agents."""
+
+    def __init__(self, agent_card: AgentCard, agent_url: str):
+        self._httpx_client = httpx.AsyncClient(timeout=30)
+        self.agent_client = A2AClient(self._httpx_client, agent_card, url=agent_url)
+        self.card = agent_card
+
+    def get_agent(self) -> AgentCard:
+        return self.card
+
+    async def send_message(self, message_request: SendMessageRequest) -> SendMessageResponse:
+        return await self.agent_client.send_message(message_request)
+
+class RoutingAgent:
+
+    def __init__(self,task_callback: TaskUpdateCallback | None = None):
+
+        self.task_callback = task_callback
+        self.remote_agent_connections: dict[str, RemoteAgentConnections] = {}
+        self.cards: dict[str, AgentCard] = {}
+        self.agents: str = ''
+        
+        # Initialize Azure AI Agents client
+        self.agents_client = AgentsClient(
+            endpoint=os.environ["PROJECT_ENDPOINT"],
+            credential=DefaultAzureCredential(
+                exclude_environment_credential=True,
+                exclude_managed_identity_credential=True
+            )
+        )
+
+        self.azure_agent = None
+        self.current_thread = None
+
+
+    @classmethod
+    async def create(cls, remote_agent_addresses: list[str], task_callback: TaskUpdateCallback | None = None) -> 'RoutingAgent':
+        """Create and asynchronously initialize an instance of the RoutingAgent."""
+        instance = cls(task_callback)
+        await instance._async_init_components(remote_agent_addresses)
+        return instance
+    
+
+    def list_remote_agents(self) -> str:
+        if not self.remote_agent_connections:
+            return "[]"
+
+        lines = []
+        for card in self.cards.values():
+            lines.append(f"{card.name}: {card.description}")
+
+        return "[\n  " + ",\n  ".join(lines) + "\n]"
+    
+
+    async def _async_init_components(self, remote_agent_addresses: list[str]) -> None:
+        """Asynchronous part of initialization."""
+
+        # Use a single httpx.AsyncClient for all card resolutions for efficiency
+        async with httpx.AsyncClient(timeout=30) as client:
+            for address in remote_agent_addresses:
+                card_resolver = A2ACardResolver(client, address)
+                try:
+                    card = await card_resolver.get_agent_card()
+
+                    remote_connection = RemoteAgentConnections(agent_card=card, agent_url=address)
+                    self.remote_agent_connections[card.name] = remote_connection
+                    self.cards[card.name] = card
+
+                except httpx.ConnectError as e:
+                    print( f'ERROR: Failed to get agent card from {address}: {e}')
+                except Exception as e:  # Catch other potential errors
+                    print(f'ERROR: Failed to initialize connection for {address}: {e}')
+            print(f"Found remote agents: {self.list_remote_agents()}")
+
+    
+    async def send_message(self, agent_name: str, task: str):
+        # Sends a task to remote agent.
+
+        if agent_name not in self.remote_agent_connections:
+            raise ValueError(f'Agent {agent_name} not found')
+        
+        # Retrieve the remote agent's A2A client using the agent name 
+        client = self.remote_agent_connections[agent_name]
+
+        if not client:
+            raise ValueError(f'Client not available for {agent_name}')
+        
+        message_id = str(uuid.uuid4())
+
+        # Construct the payload to send to the remote agent
+        payload: dict[str, Any] = {
+            'message': {
+                'role': 'user',
+                'parts': [{'kind': 'text', 'text': task}],
+                'messageId': message_id,
+            },
+        }
+
+        # Wrap the payload in a SendMessageRequest object
+        message_request = SendMessageRequest(id=message_id, params=MessageSendParams.model_validate(payload))
+
+        # Send the message to the remote agent client and await the response
+        send_response: SendMessageResponse = await client.send_message(message_request=message_request)
+
+        if not isinstance(send_response.root, SendMessageSuccessResponse):
+            print('received non-success response. Aborting get task ')
+            return
+
+        if not isinstance(send_response.root.result, Task):
+            print('received non-task response. Aborting get task ')
+            return
+
+        return send_response.root.result
+
+
+    def create_agent(self):
+        # Create an Azure AI Agent instance
+        
+        try:
+            # Create Azure AI Agent with the send_message function
+            functions = FunctionTool({self.send_message})
+            self.azure_agent = self.agents_client.create_agent(
+                model=os.environ["MODEL_DEPLOYMENT_NAME"],
+                name="routing-agent",
+                instructions=f"""
+                You are an expert Routing Delegator for Tailwind Traders guided trips.
+
+                Your role:
+                - Delegate user inquiries to appropriate specialized remote agents
+                - Provide clear and helpful responses to users
+
+                Available Agents: {self.list_remote_agents()}
+
+                Always be helpful and route requests to the most appropriate agent.""",
+                tools=functions.definitions
+            )
+
+            # Create a thread for conversation
+            self.current_thread = self.agents_client.threads.create()
+
+            return self.azure_agent
+            
+        except Exception as e:
+            print(f"Error creating Azure AI agent: {e}")
+            raise
+
+    async def process_user_message(self, user_message: str) -> str:
+
+        if not hasattr(self, 'azure_agent') or not self.azure_agent:
+            return "Azure AI Agent not initialized. Please ensure the agent is properly created."
+        
+        if not hasattr(self, 'current_thread') or not self.current_thread:
+            return "Azure AI Thread not initialized. Please ensure the agent is properly created."
+        
+        try:
+            # Create message in the thread
+            self.agents_client.messages.create(
+                thread_id=self.current_thread.id, 
+                role=MessageRole.User, 
+                content=user_message
+            )
+
+            # Create and run the agent
+            run = self.agents_client.runs.create(
+                thread_id=self.current_thread.id, 
+                agent_id=self.azure_agent.id
+            )
+            
+            # Need to await send_message function
+            while run.status in ["queued", "in_progress", "requires_action"]:
+                time.sleep(1)
+                run = self.agents_client.runs.get(thread_id=self.current_thread.id, run_id=run.id)
+
+                if run.status == "requires_action":
+                    tool_calls = run.required_action.submit_tool_outputs.tool_calls
+                    tool_outputs = []
+                    
+                    for tool_call in tool_calls:
+                        function_name = tool_call.function.name
+                        function_args = json.loads(tool_call.function.arguments)
+                        
+                        if function_name == "send_message":
+                            try:
+                                result = await self.send_message(agent_name=function_args["agent_name"], task=function_args["task"])
+                                output = json.dumps(result.model_dump() if hasattr(result, 'model_dump') else str(result))
+
+                            except Exception as e:
+                                output = json.dumps({"error": str(e)})
+                        else:
+                            output = json.dumps({"error": f"Unknown function: {function_name}"})
+                        
+                        tool_outputs.append({"tool_call_id": tool_call.id,  "output": output})
+                
+                    # Submit the tool outputs
+                    self.agents_client.runs.submit_tool_outputs(
+                        thread_id=self.current_thread.id, run_id=run.id, tool_outputs=tool_outputs
+                    )
+
+            if run.status == "failed":
+                error_info = f"Run error: {run.last_error}"
+                print(error_info)
+                return f"Error processing request: {error_info}"
+
+            # Return the response
+            messages = self.agents_client.messages.list(thread_id=self.current_thread.id, order=ListSortOrder.DESCENDING)
+            for msg in messages:
+                if msg.role == MessageRole.AGENT and msg.text_messages:
+                    last_text = msg.text_messages[-1]
+                    return last_text.text.value
+            
+            return "No response received from agent."
+            
+        except Exception as e:
+            error_msg = f"Error in process_user_message: {e}"
+            print(error_msg)
+            return f"An error occurred while processing your message."
+
+
+async def _get_initialized_routing_agent_sync() -> RoutingAgent:
+
+    async def _async_main() -> RoutingAgent:
+        routing_agent_instance = await RoutingAgent.create(
+            remote_agent_addresses=[
+                f"http://{os.environ["SERVER_URL"]}:{os.environ["TITLE_AGENT_PORT"]}",
+                f"http://{os.environ["SERVER_URL"]}:{os.environ["OUTLINE_AGENT_PORT"]}",
+            ]
+        )
+        # Create the Azure AI agent
+        routing_agent_instance.create_agent()
+        return routing_agent_instance
+
+    try:
+        return asyncio.run(_async_main())
+    except RuntimeError as e:
+        raise
+
+# Initialize the routing agent
+routing_agent = _get_initialized_routing_agent_sync()

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/routing_agent/server.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/routing_agent/server.py
@@ -1,0 +1,51 @@
+import os
+import asyncio
+from fastapi import FastAPI, Request
+from dotenv import load_dotenv
+from contextlib import asynccontextmanager
+from routing_agent.agent import RoutingAgent  
+
+load_dotenv()
+
+routing_agent = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global routing_agent
+    print("Starting up: Initializing routing agent...")
+    routing_agent = await RoutingAgent.create([
+        f"http://{os.environ["SERVER_URL"]}:{os.environ["TITLE_AGENT_PORT"]}",
+        f"http://{os.environ["SERVER_URL"]}:{os.environ["OUTLINE_AGENT_PORT"]}",
+    ])
+    routing_agent.create_agent()
+    print("Routing agent initialized.")
+    yield
+
+app = FastAPI(lifespan=lifespan)
+
+@app.post("/message")
+async def handle_message(request: Request):
+    print("Agent: Processing request, please wait.")
+
+    data = await request.json()
+    user_message = data.get("message")
+
+    if not user_message:
+        return {"error": "No message provided."}
+    
+    try:
+        response = await routing_agent.process_user_message(user_message)
+
+    except Exception as e:
+        return {"error": f"Failed to process message: {str(e)}"}
+    
+    return {"response": response}
+
+@app.get("/health")
+async def health_check():
+    return {"status": "Routing agent is running!"}
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.environ["ROUTING_AGENT_PORT"])
+    uvicorn.run(app, host=os.environ["SERVER_URL"], port=port, reload=True)

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/run_all.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/run_all.py
@@ -1,0 +1,120 @@
+""" Runs each agent server and starts the client """
+
+import asyncio
+import subprocess
+import sys
+import time
+import signal
+import httpx
+import os
+import threading
+from dotenv import load_dotenv
+
+load_dotenv()
+
+server_url = os.environ["SERVER_URL"]
+servers = [
+    {
+        "name": "title_agent_server",
+        "module": "title_agent.server:app",
+        "port": os.environ["TITLE_AGENT_PORT"]
+    },
+    {
+        "name": "outline_agent_server",
+        "module": "outline_agent.server:app",
+        "port": os.environ["OUTLINE_AGENT_PORT"]
+    },
+    {
+        "name": "routing_agent_server",
+        "module": "routing_agent.server:app",
+        "port": os.environ["ROUTING_AGENT_PORT"]
+    },
+]
+
+server_procs = []
+
+async def wait_for_server_ready(server, timeout=30):
+    async with httpx.AsyncClient() as client:
+        start = time.time()
+        while True:
+            try:
+                health_url = f"http://{server_url}:{server['port']}/health"
+                r = await client.get(health_url, timeout=2)
+                if r.status_code == 200:
+                    print(f"[ready] {server['name']} is healthy and ready!")
+                    return True
+            except Exception:
+                pass
+            if time.time() - start > timeout:
+                print(f"[error] Timeout waiting for server health at {health_url}")
+                return False
+            await asyncio.sleep(1)
+
+def stream_subprocess_output(process):
+    while True:
+        line = process.stdout.readline()
+        if not line:
+            break
+        print(line.rstrip())
+
+
+async def run_client_main():
+    from client import main as client_main
+    await client_main()
+
+async def main():
+    print("[start] Starting server subprocesses...")
+    for server in servers:
+        cmd = [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            server["module"],
+            "--host",
+            server_url,
+            "--port",
+            str(server["port"]),
+            "--log-level",
+            "info"
+        ]
+
+        print(f"[start] Starting {server['name']} on port {server['port']}")
+        process = subprocess.Popen(
+            cmd,
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            universal_newlines=True,
+        )
+        server_procs.append(process)
+
+        thread = threading.Thread(target=stream_subprocess_output, args=(process,), daemon=True)
+        thread.start()
+
+        ready = await wait_for_server_ready(server)
+        if not ready:
+            print(f"[error] Server '{server['name']}' failed to start, killing process...")
+            process.kill()
+            sys.exit(1)
+
+    try:
+        await run_client_main()
+    except Exception as e:
+        print(f"[error] Client stopped: {e}")
+    finally:
+        print("[stop] Stopping server subprocess...")
+        # Terminate the server subprocess gracefully
+        for process in server_procs:
+            if process.poll() is None:  # Still running
+                if sys.platform == "win32":
+                    process.send_signal(signal.CTRL_BREAK_EVENT)
+                else:
+                    process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/title_agent/agent.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/title_agent/agent.py
@@ -1,0 +1,73 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip title """
+
+import os
+from azure.ai.agents import AgentsClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import Agent, ListSortOrder, MessageRole
+
+class TitleAgent:
+
+    def __init__(self):
+
+        # Create the agents client
+        self.client = AgentsClient(
+            endpoint=os.environ['PROJECT_ENDPOINT'],
+            credential=DefaultAzureCredential(
+                exclude_environment_credential=True,
+                exclude_managed_identity_credential=True
+            )
+        )
+
+        self.agent: Agent | None = None
+
+    async def create_agent(self) -> Agent:
+        if self.agent:
+            return self.agent
+
+        # Create the title agent
+        self.agent = self.client.create_agent(
+            model=os.environ['MODEL_DEPLOYMENT_NAME'],
+            name='trip-title-agent',
+            instructions="""
+            You are a helpful trip marketing assistant for Tailwind Traders.
+            Given a region or activity the customer wants to explore, suggest a single clear and catchy guided-trip title.
+            """,
+        )
+
+        return self.agent
+
+    async def run_conversation(self, user_message: str) -> list[str]:
+        # Add a message to the thread, process it, and retrieve the response
+
+        if not self.agent:
+            await self.create_agent()
+
+        # Create a thread for the chat session
+        thread = self.client.threads.create()
+
+        # Send user message
+        self.client.messages.create(thread_id=thread.id, role=MessageRole.USER, content=user_message)
+
+        # Create and run the agent
+        run = self.client.runs.create_and_process(thread_id=thread.id, agent_id=self.agent.id)
+
+        if run.status == 'failed':
+            print(f'Title Agent: Run failed - {run.last_error}')
+            return [f'Error: {run.last_error}']
+
+        # Get response messages
+        messages = self.client.messages.list(thread_id=thread.id, order=ListSortOrder.DESCENDING)
+        responses = []
+        for msg in messages:
+            # Only get the latest assistant response
+            if msg.role == MessageRole.AGENT and msg.text_messages:
+                for text_msg in msg.text_messages:
+                    responses.append(text_msg.text.value)
+                break 
+
+        return responses if responses else ['No response received']
+
+async def create_foundry_title_agent() -> TitleAgent:
+    agent = TitleAgent()
+    await agent.create_agent()
+    return agent

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/title_agent/agent_executor.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/title_agent/agent_executor.py
@@ -1,0 +1,82 @@
+""" Tailwind Traders Foundry Agent that generates a guided-trip title """
+
+from a2a.server.events.event_queue import EventQueue
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.tasks import TaskUpdater
+from a2a.utils import new_agent_text_message
+from a2a.types import AgentCard, Part, TaskState
+from title_agent.agent import TitleAgent, create_foundry_title_agent
+
+class FoundryAgentExecutor(AgentExecutor):
+
+    def __init__(self, card: AgentCard):
+        self._card = card
+        self._foundry_agent: TitleAgent | None = None
+
+    async def _get_or_create_agent(self) -> TitleAgent:
+        if not self._foundry_agent:
+            self._foundry_agent = await create_foundry_title_agent()
+        return self._foundry_agent
+
+    async def _process_request(self, message_parts: list[Part], context_id: str, task_updater: TaskUpdater) -> None:
+        # Process a user request through the Foundry agent
+
+        try:
+            # Retrieve message from A2A parts
+            user_message = message_parts[0].root.text
+
+            # Get the title agent
+            agent = await self._get_or_create_agent()
+
+            # Update the task status
+            await task_updater.update_status(
+                TaskState.working,
+                message=new_agent_text_message('Title Agent is processing your request...', context_id=context_id),
+            )
+
+            # Run the agent conversation
+            responses = await agent.run_conversation(user_message)
+
+            # Update the task with the responses
+            for response in responses:
+                await task_updater.update_status(
+                    TaskState.working,
+                    message=new_agent_text_message(response, context_id=context_id),
+                )
+
+            # Mark the task as complete
+            final_message = responses[-1] if responses else 'Task completed.'
+            await task_updater.complete(
+                message=new_agent_text_message(final_message, context_id=context_id)
+            )
+
+        except Exception as e:
+            print(f'Title Agent: Error processing request - {e}')
+            await task_updater.failed(
+                message=new_agent_text_message("Title Agent failed to process the request.", 
+                context_id=context_id)
+            )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue,):
+       
+        # Create task updater
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.submit()
+
+        # Start working
+        await updater.start_work()
+
+        # Process the request
+        await self._process_request(context.message.parts, context.context_id, updater)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        print(f'Title Agent: Cancelling execution for context {context.context_id}')
+
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.failed(
+            message=new_agent_text_message('Task cancelled by user', context_id=context.context_id)
+        )
+
+def create_foundry_agent_executor(card: AgentCard) -> FoundryAgentExecutor:
+    return FoundryAgentExecutor(card)

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/title_agent/server.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/title_agent/server.py
@@ -1,0 +1,76 @@
+import os
+import uvicorn
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from dotenv import load_dotenv
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from title_agent.agent_executor import create_foundry_agent_executor
+
+load_dotenv()
+
+host = os.environ["SERVER_URL"]
+port = os.environ["TITLE_AGENT_PORT"]
+
+# Define agent skills
+skills = [
+    AgentSkill(
+        id='generate_trip_title',
+        name='Generate Trip Title',
+        description='Generates a guided-trip title based on a region or activity',
+        tags=['title'],
+        examples=[
+            'Can you give me a title for a hiking trip in Patagonia?',
+        ],
+    ),
+]
+
+# Create agent card
+agent_card = AgentCard(
+    name='Tailwind Traders Trip Title Agent',
+    description='An intelligent trip-title generator agent powered by Foundry. '
+    'I can help you generate catchy titles for Tailwind Traders guided trips.',
+    url=f'http://{host}:{port}/',
+    version='1.0.0',
+    default_input_modes=['text'],
+    default_output_modes=['text'],
+    capabilities=AgentCapabilities(),
+    skills=skills,
+)
+
+# Create agent executor
+agent_executor = create_foundry_agent_executor(agent_card)
+
+# Create request handler
+request_handler = DefaultRequestHandler(
+    agent_executor=agent_executor, task_store=InMemoryTaskStore()
+)
+
+# Create A2A application
+a2a_app = A2AStarletteApplication(
+    agent_card=agent_card, http_handler=request_handler
+)
+
+# Get routes
+routes = a2a_app.routes()
+
+# Add health check endpoint
+async def health_check(request: Request) -> PlainTextResponse:
+    return PlainTextResponse('Tailwind Traders Trip Title Agent is running!')
+
+routes.append(Route(path='/health', methods=['GET'], endpoint=health_check))
+
+# Create Starlette app
+app = Starlette(routes=routes)
+
+def main():
+    # Run the server
+    uvicorn.run(app, host=host, port=port)
+
+if __name__ == '__main__':
+    main()

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/README.md
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/README.md
@@ -1,0 +1,110 @@
+# Lab C — Solution (complete code)
+
+This folder contains **finished, working versions** of every code file learners write in
+*Build multi-agent solutions with the Agent Framework*. Use it to unblock a stuck learner,
+verify expected behavior, or run the whole scenario end to end.
+
+All tasks share a **single** `Python/` folder (one virtual environment, one `.env`), exactly
+like the starter code learners work in:
+
+```
+Solution/
+└─ Python/
+   ├─ expense_agent.py        # Task 1 — single agent with a tool (Microsoft Agent Framework)
+   ├─ data.txt                #   Task 1 — Tailwind Traders guided-trip expense data
+   ├─ feedback_agents.py      # Task 2 — sequential orchestration of three agents (MAF)
+   ├─ run_all.py              # Task 3 — launches the three A2A agent servers
+   ├─ client.py               # Task 3 — chat client that talks to the routing agent
+   ├─ title_agent/            #   Task 3 — remote agent: suggests a guided-trip title
+   ├─ outline_agent/          #   Task 3 — remote agent: drafts a trip itinerary outline
+   └─ routing_agent/          #   Task 3 — orchestrator that delegates to the remote agents via A2A
+```
+
+The whole lab is built on the **Microsoft Agent Framework (MAF)**. Task 1 and Task 2 use the
+native MAF path — `FoundryChatClient` + `@tool` + `Agent` + `agent.create_session()` +
+`agent.run(..., session=)` -> `result.text`. Task 3 keeps the Foundry SDK inner agents and
+adds the **A2A** protocol so agents in separate processes can call each other.
+
+---
+
+## Setup helpers and modular (per-task) labs
+
+This lab can be completed end to end **or one task at a time**. Two things make that possible:
+
+- **Per-task instruction pages** — `Instructions/Exercises/C0-getting-started.md` (shared setup)
+  plus `C1`–`C3` (one page per task). Each task page tells a standalone learner exactly what it
+  needs and how to fast-forward.
+- **Setup scripts** in `Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/`:
+  - `check_env.py --task N` — preflight-checks that `.env` has the keys task *N* needs.
+
+Both scripts run from the **starter** `Python/` folder and use the shared virtual environment
+and `.env`.
+
+### Optional: provision infrastructure with azd
+
+Instead of creating the project by hand, `azure.yaml` + `infra/` let you provision a Foundry
+project and model deployment with one command:
+
+```
+azd up      # create the project + model deployment, writes Python/.env
+azd down    # remove everything when you're done
+```
+
+The manual portal path is still the default — azd is offered as **Option B** in Getting started
+for learners who prefer infrastructure as code.
+
+> **Note**: the azd path is bicep-validated but has not been deployment-tested in this repo yet.
+
+---
+
+## What YOU must do to run this solution (the agent can't do these for you)
+
+Everything below requires an Azure subscription and interactive sign-in, so it can't be
+automated in the repo. Do these once, then run each task.
+
+### 1. Azure / Microsoft Foundry setup
+1. Have an **Azure subscription** with access to **Microsoft Foundry (Azure AI Foundry)**.
+2. Create (or open) a **Foundry project** and copy its **Project Endpoint**.
+3. **Deploy a model** (for example `gpt-4o`) in that project and note the **deployment name**.
+4. Make sure your signed-in identity has the **Azure AI User** role (or equivalent) on the project.
+
+### 2. Sign in locally
+```
+az login
+```
+Sign in with the same account that has access to the project. Every task authenticates with
+`DefaultAzureCredential`, so a missing or expired `az login` is the most common reason a task
+fails at run time.
+
+### 3. Set up the environment once (shared by all tasks)
+From the `Python/` folder:
+```
+python -m venv labenv
+.\labenv\Scripts\Activate.ps1        # Windows PowerShell
+pip install -r requirements.txt
+```
+Then copy `.env.example` to `.env` and fill in the values (all tasks read the same file):
+- `PROJECT_ENDPOINT` — used by every task
+- `MODEL_DEPLOYMENT_NAME` — used by every task
+- `SERVER_URL`, `TITLE_AGENT_PORT`, `OUTLINE_AGENT_PORT`, `ROUTING_AGENT_PORT` — used by Task 3
+  (these ship pre-filled in `.env.example`)
+
+### 4. Run each task
+All commands run from the single `Python/` folder:
+
+| Task | Command | What you get |
+|------|---------|--------------|
+| 1 | `python expense_agent.py` | Console output: the agent reads `data.txt`, then calls the `submit_claim` tool to email an expense claim |
+| 2 | `python feedback_agents.py` | Console output: three agents summarize, classify, and recommend an action on customer feedback, in sequence |
+| 3 | `python run_all.py` (leave running), then in a second terminal `python client.py` | The three A2A agent servers start; the routing agent delegates your request to the trip-title and trip-itinerary agents |
+
+For Task 3, `run_all.py` starts the `title_agent`, `outline_agent`, and `routing_agent`
+servers. Wait for all three to report ready, then run `client.py` in another terminal and chat.
+Press Ctrl+C in the `run_all.py` terminal to stop every server.
+
+---
+
+## Quick sanity checks that DON'T need Azure
+- `python -m py_compile <file>` — all solution files compile.
+- From `Python/`: `python -c "print(open('data.txt').read())"` prints the Tailwind Traders
+  guided-trip expense data that Task 1's agent reads.

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/azure.yaml
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/azure.yaml
@@ -1,0 +1,41 @@
+# azd configuration for the Tailwind Traders multi-agent lab (OPTIONAL infra path).
+#
+# This is a convenience for learners/instructors who want to provision the
+# Foundry project + model deployment with a single command instead of creating
+# them by hand in the portal. It is entirely optional — the lab's default path
+# is still to create the project in the Foundry portal during setup.
+#
+# Usage:
+#     azd auth login
+#     azd up            # provisions the resources below, then fills in Python/.env
+#
+# When you're done with the lab:
+#     azd down          # deletes everything it created
+#
+# What it provisions (see infra/main.bicep):
+#   - A Microsoft Foundry (Azure AI Services) resource
+#   - A Foundry project
+#   - One chat model deployment
+#
+# After provisioning, the postprovision hook writes PROJECT_ENDPOINT and
+# MODEL_DEPLOYMENT_NAME into Python/.env for you.
+
+name: tailwind-traders-multi-agent-lab
+metadata:
+  template: mslearn-ai-agents/C-build-multi-agent-solutions-with-agent-framework
+
+# This template provisions infrastructure only — there is no app for azd to
+# deploy. You run the lab's Python scripts yourself from the Python/ folder.
+
+hooks:
+  postprovision:
+    windows:
+      shell: pwsh
+      run: ./setup/write_env.ps1
+      continueOnError: false
+      interactive: false
+    posix:
+      shell: sh
+      run: ./setup/write_env.sh
+      continueOnError: false
+      interactive: false

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/infra/main.bicep
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/infra/main.bicep
@@ -1,0 +1,65 @@
+// Optional azd infrastructure for the Tailwind Traders lab.
+//
+// Provisions a Microsoft Foundry (Azure AI Services) resource, a Foundry
+// project, and one chat model deployment — the same resources you would
+// otherwise create by hand in the Foundry portal.
+//
+// azd calls this at subscription scope: it creates the resource group and
+// then everything inside it (see infra/resources.bicep).
+
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the azd environment — used to name and tag resources.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Name of the chat model to deploy (for example, gpt-4o).')
+param modelName string = 'gpt-4o'
+
+@description('Version of the chat model to deploy.')
+param modelVersion string = '2024-11-20'
+
+@description('The deployment name the lab uses (MODEL_DEPLOYMENT_NAME in .env).')
+param modelDeploymentName string = 'gpt-4o'
+
+@description('Model deployment capacity, in thousands of tokens per minute.')
+param modelCapacity int = 30
+
+// azd tags every resource in an environment with this so it can manage them.
+var tags = { 'azd-env-name': environmentName }
+
+// A short, deterministic token keeps globally-unique names stable per env.
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module ai 'resources.bicep' = {
+  name: 'foundry'
+  scope: resourceGroup
+  params: {
+    location: location
+    tags: tags
+    accountName: 'foundry-${resourceToken}'
+    projectName: 'proj-${resourceToken}'
+    modelName: modelName
+    modelVersion: modelVersion
+    modelDeploymentName: modelDeploymentName
+    modelCapacity: modelCapacity
+  }
+}
+
+// azd writes these outputs into the azd environment; the postprovision hook
+// then copies them into Python/.env for the lab scripts to read.
+output PROJECT_ENDPOINT string = ai.outputs.projectEndpoint
+output MODEL_DEPLOYMENT_NAME string = ai.outputs.modelDeploymentName
+output AZURE_LOCATION string = location
+output AZURE_RESOURCE_GROUP string = resourceGroup.name

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/infra/main.parameters.json
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/infra/main.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "modelName": {
+      "value": "${MODEL_NAME=gpt-4o}"
+    },
+    "modelVersion": {
+      "value": "${MODEL_VERSION=2024-11-20}"
+    },
+    "modelDeploymentName": {
+      "value": "${MODEL_DEPLOYMENT_NAME=gpt-4o}"
+    },
+    "modelCapacity": {
+      "value": "${MODEL_CAPACITY=30}"
+    }
+  }
+}

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/infra/resources.bicep
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/infra/resources.bicep
@@ -1,0 +1,84 @@
+// Foundry account + project + model deployment for the lab.
+// Deployed into the resource group created by main.bicep.
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags applied to every resource.')
+param tags object = {}
+
+@description('Globally-unique name for the Foundry (Azure AI Services) account.')
+param accountName string
+
+@description('Name of the Foundry project.')
+param projectName string
+
+@description('Name of the chat model to deploy.')
+param modelName string
+
+@description('Version of the chat model to deploy.')
+param modelVersion string
+
+@description('Deployment name the lab uses (MODEL_DEPLOYMENT_NAME in .env).')
+param modelDeploymentName string
+
+@description('Model deployment capacity, in thousands of tokens per minute.')
+param modelCapacity int
+
+// The Microsoft Foundry resource (an Azure AI Services account with project
+// support). allowProjectManagement enables the new Foundry project experience.
+resource account 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
+  name: accountName
+  location: location
+  tags: tags
+  kind: 'AIServices'
+  sku: {
+    name: 'S0'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    allowProjectManagement: true
+    // Use the account name as the custom subdomain so the project endpoint
+    // resolves to https://<accountName>.services.ai.azure.com/...
+    customSubDomainName: accountName
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource project 'Microsoft.CognitiveServices/accounts/projects@2025-06-01' = {
+  parent: account
+  name: projectName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {}
+}
+
+// Deploy the chat model. The deployment's name is what the lab references as
+// MODEL_DEPLOYMENT_NAME. Model deployments live on the account, not the project.
+resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
+  parent: account
+  name: modelDeploymentName
+  sku: {
+    name: 'GlobalStandard'
+    capacity: modelCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: modelName
+      version: modelVersion
+    }
+  }
+}
+
+// Project endpoint in the form the lab's .env expects:
+//   https://<account>.services.ai.azure.com/api/projects/<project>
+output projectEndpoint string = 'https://${account.name}.services.ai.azure.com/api/projects/${project.name}'
+output modelDeploymentName string = modelDeployment.name
+output accountName string = account.name
+output projectName string = project.name

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
@@ -1,0 +1,164 @@
+"""
+Preflight check for the Tailwind Traders multi-agent lab.
+
+Each task in this lab can be completed on its own. Before you start a task,
+run this script to confirm your .env file has everything that task needs:
+
+    python setup/check_env.py --task 1
+
+It never changes anything — it only reads your .env and tells you what (if
+anything) is missing, so you can fix it before running the task.
+
+Tasks and what they need:
+
+    Task 1  (code)   PROJECT_ENDPOINT, MODEL_DEPLOYMENT_NAME
+    Task 2  (code)   PROJECT_ENDPOINT, MODEL_DEPLOYMENT_NAME
+    Task 3  (code)   PROJECT_ENDPOINT, MODEL_DEPLOYMENT_NAME,
+                     SERVER_URL, TITLE_AGENT_PORT, OUTLINE_AGENT_PORT,
+                     ROUTING_AGENT_PORT
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+# Which .env keys each task needs to run on its own.
+TASK_REQUIREMENTS = {
+    1: ["PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME"],
+    2: ["PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME"],
+    3: [
+        "PROJECT_ENDPOINT",
+        "MODEL_DEPLOYMENT_NAME",
+        "SERVER_URL",
+        "TITLE_AGENT_PORT",
+        "OUTLINE_AGENT_PORT",
+        "ROUTING_AGENT_PORT",
+    ],
+}
+
+# Every key this lab might read, used when merging real environment variables.
+ALL_KEYS = [
+    "PROJECT_ENDPOINT",
+    "MODEL_DEPLOYMENT_NAME",
+    "SERVER_URL",
+    "TITLE_AGENT_PORT",
+    "OUTLINE_AGENT_PORT",
+    "ROUTING_AGENT_PORT",
+]
+
+# Placeholder text shipped in .env.example — present but not yet filled in.
+PLACEHOLDERS = {
+    "",
+    "your_project_endpoint_here",
+    "your_model_deployment_name_here",
+    "your-project-endpoint",
+    "your-model-deployment-name",
+    "<your-project-endpoint>",
+    "<your-model-deployment-name>",
+}
+
+# How to fix each key, shown only when it's missing.
+FIX_HINTS = {
+    "PROJECT_ENDPOINT": (
+        "Copy your project endpoint from the Foundry portal (or the Foundry Toolkit "
+        "VS Code extension: right-click the project deployment > Copy Project Endpoint), "
+        "or run 'azd up' to provision one, then set PROJECT_ENDPOINT in .env."
+    ),
+    "MODEL_DEPLOYMENT_NAME": (
+        "Set MODEL_DEPLOYMENT_NAME to the name of your deployed model "
+        "(for example, gpt-4o). You can see it in the Foundry portal under your project."
+    ),
+    "SERVER_URL": (
+        "Task 3 runs the remote agents locally. Set SERVER_URL=localhost "
+        "(this ships pre-filled in .env.example)."
+    ),
+    "TITLE_AGENT_PORT": (
+        "Task 3 needs a port for the trip-title agent. Set TITLE_AGENT_PORT=10007 "
+        "(this ships pre-filled in .env.example)."
+    ),
+    "OUTLINE_AGENT_PORT": (
+        "Task 3 needs a port for the trip-itinerary agent. Set OUTLINE_AGENT_PORT=10008 "
+        "(this ships pre-filled in .env.example)."
+    ),
+    "ROUTING_AGENT_PORT": (
+        "Task 3 needs a port for the routing agent. Set ROUTING_AGENT_PORT=10009 "
+        "(this ships pre-filled in .env.example)."
+    ),
+}
+
+
+def find_env_file():
+    """Return the .env next to the lab's Python folder, wherever this is run from."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        Path.cwd() / ".env",
+        here.parent / "Python" / ".env",
+        here.parent / ".env",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # Default to the Python-folder location even if it doesn't exist yet.
+    return here.parent / "Python" / ".env"
+
+
+def load_values(env_path):
+    """Merge real environment variables over .env file values (env wins)."""
+    values = {}
+    if env_path.exists():
+        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+    for key in ALL_KEYS:
+        if os.environ.get(key):
+            values[key] = os.environ[key]
+    return values
+
+
+def is_set(values, key):
+    """A key counts as set if it's present and not a leftover placeholder."""
+    value = (values.get(key) or "").strip()
+    return bool(value) and value not in PLACEHOLDERS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that your .env has what a given lab task needs."
+    )
+    parser.add_argument(
+        "--task",
+        type=int,
+        choices=sorted(TASK_REQUIREMENTS),
+        required=True,
+        help="Which task you're about to start (1-3).",
+    )
+    args = parser.parse_args()
+
+    env_path = find_env_file()
+    values = load_values(env_path)
+    required = TASK_REQUIREMENTS[args.task]
+
+    print(f"Checking readiness for Task {args.task}")
+    print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
+    print()
+
+    missing = [key for key in required if not is_set(values, key)]
+
+    for key in required:
+        mark = "OK " if is_set(values, key) else "MISSING"
+        print(f"  [{mark}] {key}")
+
+    if not missing:
+        print()
+        print(f"You're ready to start Task {args.task}.")
+        return 0
+
+    print()
+    print("Set the following before starting this task:")
+    for key in missing:
+        print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/write_env.ps1
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/write_env.ps1
@@ -1,0 +1,36 @@
+# Copies the endpoint + model deployment name that 'azd up' just provisioned
+# into the lab's Python/.env, so the task scripts can read them.
+#
+# azd runs this automatically after provisioning (see azure.yaml). It sets the
+# bicep outputs as environment variables, which we read here.
+
+$ErrorActionPreference = 'Stop'
+
+$envPath = Join-Path $PSScriptRoot '..\Python\.env'
+$examplePath = Join-Path $PSScriptRoot '..\Python\.env.example'
+
+# Start from the existing .env, or the example if there isn't one yet.
+if (-not (Test-Path $envPath)) {
+    if (Test-Path $examplePath) { Copy-Item $examplePath $envPath }
+    else { New-Item -ItemType File -Path $envPath | Out-Null }
+}
+
+function Set-EnvValue([string]$key, [string]$value) {
+    if ([string]::IsNullOrWhiteSpace($value)) { return }
+    $lines = @(Get-Content $envPath)
+    $set = $false
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match "^\s*$key\s*=") {
+            $lines[$i] = "$key=$value"
+            $set = $true
+        }
+    }
+    if (-not $set) { $lines += "$key=$value" }
+    Set-Content -Path $envPath -Value $lines
+}
+
+Set-EnvValue 'PROJECT_ENDPOINT' $env:PROJECT_ENDPOINT
+Set-EnvValue 'MODEL_DEPLOYMENT_NAME' $env:MODEL_DEPLOYMENT_NAME
+
+Write-Host "Updated $envPath with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
+Write-Host "Task 3 (remote agents) also reads SERVER_URL and the *_PORT values, which ship pre-filled in .env.example."

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/write_env.sh
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/write_env.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copies the endpoint + model deployment name that 'azd up' just provisioned
+# into the lab's Python/.env, so the task scripts can read them.
+#
+# azd runs this automatically after provisioning (see azure.yaml). It sets the
+# bicep outputs as environment variables, which we read here.
+
+set -e
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+env_path="$script_dir/../Python/.env"
+example_path="$script_dir/../Python/.env.example"
+
+# Start from the existing .env, or the example if there isn't one yet.
+if [ ! -f "$env_path" ]; then
+    if [ -f "$example_path" ]; then cp "$example_path" "$env_path"; else : > "$env_path"; fi
+fi
+
+set_env_value() {
+    key="$1"
+    value="$2"
+    [ -z "$value" ] && return 0
+    if grep -qE "^[[:space:]]*$key[[:space:]]*=" "$env_path"; then
+        # Replace the existing line.
+        tmp="${env_path}.tmp"
+        sed "s|^[[:space:]]*$key[[:space:]]*=.*|$key=$value|" "$env_path" > "$tmp"
+        mv "$tmp" "$env_path"
+    else
+        printf '%s=%s\n' "$key" "$value" >> "$env_path"
+    fi
+}
+
+set_env_value "PROJECT_ENDPOINT" "$PROJECT_ENDPOINT"
+set_env_value "MODEL_DEPLOYMENT_NAME" "$MODEL_DEPLOYMENT_NAME"
+
+echo "Updated $env_path with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
+echo "Task 3 (remote agents) also reads SERVER_URL and the *_PORT values, which ship pre-filled in .env.example."

--- a/Labfiles/D-design-agent-workflows-in-foundry/Python/.env.example
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Python/.env.example
@@ -1,0 +1,8 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual value.
+
+# Microsoft Foundry Project Endpoint.
+# In the workflow visualizer, select Code > .env variables and copy the
+# AZURE_EXISTING_AIPROJECT_ENDPOINT value, or copy the Project Endpoint from
+# the Microsoft Foundry portal project overview page.
+PROJECT_ENDPOINT="your_project_endpoint"

--- a/Labfiles/D-design-agent-workflows-in-foundry/Python/requirements.txt
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Python/requirements.txt
@@ -1,0 +1,5 @@
+python-dotenv
+azure-identity
+azure-ai-projects==2.0.0b4
+aiohttp
+gradio==6.20.0

--- a/Labfiles/D-design-agent-workflows-in-foundry/Python/tailwind_ui.py
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Python/tailwind_ui.py
@@ -1,0 +1,67 @@
+"""
+Tailwind Traders - shared chat UI shell (provided).
+
+You don't need to edit this file. It gives the client-app task a simple web
+chat window so your workflow feels like a real app instead of a console script.
+
+The task provides a `respond` function that takes the user's message and returns
+either a plain string, or an `AgentReply` carrying text plus any image files to
+show inline. The function may be synchronous or asynchronous.
+"""
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Callable
+
+import gradio as gr
+
+
+@dataclass
+class AgentReply:
+    """A single reply from the assistant."""
+    text: str = ""
+    images: list = field(default_factory=list)  # local image file paths to display inline
+
+
+def run_chat_app(
+    respond: Callable,
+    title: str = "Tailwind Traders Support Triage",
+    subtitle: str = "",
+    placeholder: str = "Type a message to start the workflow...",
+    server_port: int = 7860,
+):
+    """Launch a browser chat window that routes each message to `respond`."""
+
+    async def handle(user_message, history):
+        history = (history or []) + [{"role": "user", "content": user_message}]
+
+        # Call the task's respond function (await it if it's async)
+        result = respond(user_message)
+        if inspect.isawaitable(result):
+            result = await result
+
+        if isinstance(result, str):
+            result = AgentReply(text=result)
+
+        if result and result.text:
+            history.append({"role": "assistant", "content": result.text})
+        for image_path in (result.images if result else []):
+            history.append({"role": "assistant", "content": {"path": image_path}})
+
+        return history, ""
+
+    with gr.Blocks(title=title) as demo:
+        gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
+        if subtitle:
+            gr.Markdown(subtitle)
+        chatbot = gr.Chatbot(height=460, show_label=False)
+        with gr.Row():
+            textbox = gr.Textbox(
+                placeholder=placeholder, show_label=False, scale=8, autofocus=True
+            )
+            send = gr.Button("Send", variant="primary", scale=1)
+
+        for trigger in (textbox.submit, send.click):
+            trigger(handle, [textbox, chatbot], [chatbot, textbox])
+
+    demo.launch(server_port=server_port, inbrowser=True, css="footer {visibility: hidden}", theme=gr.themes.Soft())

--- a/Labfiles/D-design-agent-workflows-in-foundry/Python/workflow.py
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Python/workflow.py
@@ -1,0 +1,40 @@
+import os, json, re
+from dotenv import load_dotenv
+
+# Add references
+
+
+def print_workflow_output(output_text):
+    tickets = re.findall(r"(\{.*?\})(.*?)(?=\{|$)", output_text, re.DOTALL)
+
+    if not tickets:
+        print(output_text)
+        return
+
+    for ticket_number, (ticket_json, response_text) in enumerate(tickets, start=1):
+        ticket = json.loads(ticket_json)
+
+        print("\n" + "=" * 80)
+        print(f"Ticket {ticket_number}: {ticket['category']} ({ticket['confidence']:.0%} confidence)")
+        print("-" * 80)
+        print(f"Issue: {ticket['customer_issue']}")
+        print("\nResponse:")
+        print(response_text.strip())
+    print("=" * 80 + "\n")
+
+load_dotenv()
+endpoint = os.environ["PROJECT_ENDPOINT"]
+
+# Connect to the AI Project client
+
+
+    # Specify the workflow
+    
+
+    # Create a conversation and run the workflow
+
+
+    # Process events from the workflow run
+ 
+
+    # Clean up resources

--- a/Labfiles/D-design-agent-workflows-in-foundry/README.md
+++ b/Labfiles/D-design-agent-workflows-in-foundry/README.md
@@ -1,0 +1,50 @@
+# Lab D — Design agent workflows in Microsoft Foundry (files)
+
+Starter assets for the **Design agent workflows in Microsoft Foundry** lab, reskinned to
+the **Tailwind Traders** scenario (an outdoor-gear retailer that also runs guided trips).
+You design a customer-support **ticket classification and routing workflow** in the
+Foundry visual workflow designer, then optionally drive it from a client app.
+
+Most of this lab is built **in the Foundry portal** — there's very little code. The files
+here are the copy/paste assets for the portal steps, plus an optional client app.
+
+```
+D-design-agent-workflows-in-foundry/
+├─ assets/
+│  ├─ sample_tickets.json   # the ticket array for the Set variable node
+│  └─ agent-prompts.md      # triage + resolution prompts, JSON schema, node messages
+├─ Python/                  # starter for the optional client-app task (D4)
+│  ├─ workflow.py           #   fill-in-the-blanks workflow invoker (console)
+│  ├─ tailwind_ui.py        #   shared Gradio chat shell (provided; not edited)
+│  ├─ requirements.txt
+│  └─ .env.example
+└─ Solution/
+   ├─ Python/               # finished client-app code
+   │  ├─ workflow.py        #   console version (complete)
+   │  ├─ workflow_ui.py     #   optional web-chat version (Gradio shell)
+   │  ├─ tailwind_ui.py
+   │  ├─ requirements.txt
+   │  └─ .env.example
+   └─ README.md             # how to run the solution + no-Azure sanity checks
+```
+
+## Instruction pages
+
+Start with the landing page and getting-started, then do the core task and any optional tasks:
+
+| Page | What it covers |
+| --- | --- |
+| `Instructions/Exercises/D-design-agent-workflows-in-foundry.md` | Lab overview |
+| `Instructions/Exercises/D0-getting-started.md` | One-time setup / prerequisites |
+| `Instructions/Exercises/D1-classify-and-route-a-ticket.md` | **Core** — classify + route a ticket |
+| `Instructions/Exercises/D2-handle-low-confidence-tickets.md` | *Optional* — low-confidence handling |
+| `Instructions/Exercises/D3-generate-recommended-responses.md` | *Optional* — recommended responses |
+| `Instructions/Exercises/D4-call-your-workflow-from-a-client-app.md` | *Optional* — client app |
+
+## The Tailwind Traders scenario
+
+Support tickets are classified into one of three categories:
+
+- **Billing** — a customer was charged, refunded, or paid incorrectly. Routed to the human orders team.
+- **Gear** — faulty equipment or product setup/usage problems. Handled automatically.
+- **General** — how-to questions, availability, order history, returns. Handled automatically.

--- a/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/.env.example
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/.env.example
@@ -1,0 +1,8 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual value.
+
+# Microsoft Foundry Project Endpoint.
+# In the workflow visualizer, select Code > .env variables and copy the
+# AZURE_EXISTING_AIPROJECT_ENDPOINT value, or copy the Project Endpoint from
+# the Microsoft Foundry portal project overview page.
+PROJECT_ENDPOINT="your_project_endpoint"

--- a/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/requirements.txt
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/requirements.txt
@@ -1,0 +1,5 @@
+python-dotenv
+azure-identity
+azure-ai-projects==2.0.0b4
+aiohttp
+gradio==6.20.0

--- a/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/tailwind_ui.py
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/tailwind_ui.py
@@ -1,0 +1,67 @@
+"""
+Tailwind Traders - shared chat UI shell (provided).
+
+You don't need to edit this file. It gives the client-app task a simple web
+chat window so your workflow feels like a real app instead of a console script.
+
+The task provides a `respond` function that takes the user's message and returns
+either a plain string, or an `AgentReply` carrying text plus any image files to
+show inline. The function may be synchronous or asynchronous.
+"""
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Callable
+
+import gradio as gr
+
+
+@dataclass
+class AgentReply:
+    """A single reply from the assistant."""
+    text: str = ""
+    images: list = field(default_factory=list)  # local image file paths to display inline
+
+
+def run_chat_app(
+    respond: Callable,
+    title: str = "Tailwind Traders Support Triage",
+    subtitle: str = "",
+    placeholder: str = "Type a message to start the workflow...",
+    server_port: int = 7860,
+):
+    """Launch a browser chat window that routes each message to `respond`."""
+
+    async def handle(user_message, history):
+        history = (history or []) + [{"role": "user", "content": user_message}]
+
+        # Call the task's respond function (await it if it's async)
+        result = respond(user_message)
+        if inspect.isawaitable(result):
+            result = await result
+
+        if isinstance(result, str):
+            result = AgentReply(text=result)
+
+        if result and result.text:
+            history.append({"role": "assistant", "content": result.text})
+        for image_path in (result.images if result else []):
+            history.append({"role": "assistant", "content": {"path": image_path}})
+
+        return history, ""
+
+    with gr.Blocks(title=title) as demo:
+        gr.Markdown(f"## \U0001F3D4\uFE0F {title}")
+        if subtitle:
+            gr.Markdown(subtitle)
+        chatbot = gr.Chatbot(height=460, show_label=False)
+        with gr.Row():
+            textbox = gr.Textbox(
+                placeholder=placeholder, show_label=False, scale=8, autofocus=True
+            )
+            send = gr.Button("Send", variant="primary", scale=1)
+
+        for trigger in (textbox.submit, send.click):
+            trigger(handle, [textbox, chatbot], [chatbot, textbox])
+
+    demo.launch(server_port=server_port, inbrowser=True, css="footer {visibility: hidden}", theme=gr.themes.Soft())

--- a/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/workflow.py
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/workflow.py
@@ -1,0 +1,62 @@
+import os, json, re
+from dotenv import load_dotenv
+
+# Add references
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+
+def print_workflow_output(output_text):
+    tickets = re.findall(r"(\{.*?\})(.*?)(?=\{|$)", output_text, re.DOTALL)
+
+    if not tickets:
+        print(output_text)
+        return
+
+    for ticket_number, (ticket_json, response_text) in enumerate(tickets, start=1):
+        ticket = json.loads(ticket_json)
+
+        print("\n" + "=" * 80)
+        print(f"Ticket {ticket_number}: {ticket['category']} ({ticket['confidence']:.0%} confidence)")
+        print("-" * 80)
+        print(f"Issue: {ticket['customer_issue']}")
+        print("\nResponse:")
+        print(response_text.strip())
+    print("=" * 80 + "\n")
+
+load_dotenv()
+endpoint = os.environ["PROJECT_ENDPOINT"]
+
+# Connect to the AI Project client
+with (
+    DefaultAzureCredential() as credential,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
+    project_client.get_openai_client() as openai_client,
+):
+
+    # Specify the workflow
+    workflow = {
+        "name": "Tailwind-Traders-Support-Triage"
+    }
+
+    # Create a conversation and run the workflow
+    conversation = openai_client.conversations.create()
+    print(f"Created conversation (id: {conversation.id})")
+
+    stream = openai_client.responses.create(
+        conversation=conversation.id,
+        extra_body={"agent_reference": {"name": workflow["name"], "type": "agent_reference"}},
+        input="Start",
+        stream=True,
+    )
+
+    # Process events from the workflow run
+    for event in stream:
+        if (event.type == "response.completed"):
+            print("\nResponse completed:")
+            response = openai_client.responses.retrieve(event.response.id)
+            print_workflow_output(response.output_text)
+
+    # Clean up resources
+    openai_client.conversations.delete(conversation_id=conversation.id)
+    print("\nConversation deleted")

--- a/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/workflow_ui.py
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Solution/Python/workflow_ui.py
@@ -1,0 +1,79 @@
+"""
+Tailwind Traders - Support Triage workflow, web chat edition (optional).
+
+This is the same workflow invocation as `workflow.py`, but instead of printing to
+the console it runs behind the shared Gradio chat shell (`tailwind_ui.py`). Type any
+message in the browser (for example, "Start processing support tickets") and the
+assistant runs the portal workflow and shows the classified, routed tickets inline.
+
+You focus on the workflow code; you don't edit `tailwind_ui.py`.
+"""
+
+import os, json, re
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from tailwind_ui import run_chat_app
+
+# The workflow you built and saved in the Foundry portal
+workflow = {
+    "name": "Tailwind-Traders-Support-Triage"
+}
+
+_openai_client = None
+
+
+def get_openai_client():
+    """Create the OpenAI client lazily so the module can be imported without Azure."""
+    global _openai_client
+    if _openai_client is None:
+        load_dotenv()
+        endpoint = os.environ["PROJECT_ENDPOINT"]
+        credential = DefaultAzureCredential()
+        project_client = AIProjectClient(endpoint=endpoint, credential=credential)
+        _openai_client = project_client.get_openai_client()
+    return _openai_client
+
+
+def format_workflow_output(output_text):
+    """Turn the raw workflow output into readable markdown for the chat window."""
+    tickets = re.findall(r"(\{.*?\})(.*?)(?=\{|$)", output_text, re.DOTALL)
+
+    if not tickets:
+        return output_text
+
+    lines = []
+    for ticket_number, (ticket_json, response_text) in enumerate(tickets, start=1):
+        ticket = json.loads(ticket_json)
+        lines.append(f"### Ticket {ticket_number}: {ticket['category']} ({ticket['confidence']:.0%} confidence)")
+        lines.append(f"**Issue:** {ticket['customer_issue']}")
+        lines.append(f"**Response:** {response_text.strip()}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def respond(user_message):
+    """Run the portal workflow once and return its formatted output."""
+    openai_client = get_openai_client()
+    conversation = openai_client.conversations.create()
+    try:
+        stream = openai_client.responses.create(
+            conversation=conversation.id,
+            extra_body={"agent_reference": {"name": workflow["name"], "type": "agent_reference"}},
+            input="Start",
+            stream=True,
+        )
+
+        replies = []
+        for event in stream:
+            if event.type == "response.completed":
+                response = openai_client.responses.retrieve(event.response.id)
+                replies.append(format_workflow_output(response.output_text))
+
+        return "\n\n".join(replies) if replies else "The workflow did not return any output."
+    finally:
+        openai_client.conversations.delete(conversation_id=conversation.id)
+
+
+if __name__ == "__main__":
+    run_chat_app(respond, title="Tailwind Traders Support Triage")

--- a/Labfiles/D-design-agent-workflows-in-foundry/Solution/README.md
+++ b/Labfiles/D-design-agent-workflows-in-foundry/Solution/README.md
@@ -1,0 +1,68 @@
+# Lab D — Solution (complete code)
+
+This folder contains a **finished, working version** of the optional client-app task
+(**D4**) in *Design agent workflows in Microsoft Foundry*. The core of this lab is built in
+the Foundry **visual workflow designer** (portal), so there's only a small amount of code —
+the client that invokes your saved workflow.
+
+```
+Solution/
+└─ Python/
+   ├─ workflow.py       # Task D4 — invoke the workflow from code (console output)
+   ├─ workflow_ui.py    #   Task D4 — same invocation behind the shared Gradio web chat
+   ├─ tailwind_ui.py    # shared Gradio chat shell (provided; not edited by learners)
+   ├─ requirements.txt
+   └─ .env.example
+```
+
+The workflow itself — the **Set variable**, **For each**, **Invoke agent**, and **If/Else**
+nodes — lives in the Foundry portal, not in this repo. Build it by following instruction
+pages **D1–D3**. The prompts, JSON schema, and node messages you paste into the portal are in
+`../assets/agent-prompts.md`.
+
+---
+
+## What YOU must do to run this solution (the agent can't do these for you)
+
+Everything below requires an Azure subscription and interactive sign-in, so it can't be
+automated in the repo.
+
+### 1. Build the workflow in the Foundry portal
+Follow **D1** (and optionally **D2**/**D3**) to create and **Save** a workflow named
+**`Tailwind-Traders-Support-Triage`**. The client loads the workflow **by name**, so the name
+must match exactly (or update the `workflow["name"]` value in `workflow.py`).
+
+### 2. Sign in locally
+```
+az login
+```
+Sign in with the same account that has access to your Foundry project. A missing or expired
+`az login` is the #1 cause of runtime errors when the client calls the project.
+
+### 3. Set up the environment
+From the `Python/` folder:
+```
+python -m venv labenv
+.\labenv\Scripts\Activate.ps1        # Windows PowerShell
+pip install -r requirements.txt
+```
+Then copy `.env.example` to `.env` and set:
+- `PROJECT_ENDPOINT` — your Foundry project endpoint (Code > **.env variables** in the
+  workflow visualizer shows it as `AZURE_EXISTING_AIPROJECT_ENDPOINT`).
+
+### 4. Run it
+| Command | What you get |
+|---------|--------------|
+| `python workflow.py` | Console output: each ticket's category, confidence, and drafted response |
+| `python workflow_ui.py` | Browser chat at `http://localhost:7860`; type a message to run the workflow, results render inline |
+
+For the web version, the browser opens automatically. **Close the tab and press Ctrl+C** in
+the terminal to stop the app. When you're finished, enter `deactivate` to exit the virtual
+environment.
+
+---
+
+## Quick sanity checks that DON'T need Azure
+- `python -m py_compile workflow.py workflow_ui.py tailwind_ui.py` — all solution files compile.
+- `python -c "import workflow_ui; print(workflow_ui.format_workflow_output('{\"customer_issue\":\"x\",\"category\":\"Gear\",\"confidence\":0.92}Try a factory reset.'))"`
+  formats one ticket into readable markdown without contacting Azure.

--- a/Labfiles/D-design-agent-workflows-in-foundry/assets/agent-prompts.md
+++ b/Labfiles/D-design-agent-workflows-in-foundry/assets/agent-prompts.md
@@ -1,0 +1,137 @@
+# Workflow assets — copy/paste reference
+
+These are the exact values used by the **Tailwind Traders Support Triage** workflow you
+build in the portal (Tasks D1–D3). They're collected here so you can copy them straight
+into the workflow visualizer instead of retyping. The instruction pages tell you *where*
+each value goes.
+
+---
+
+## Sample support tickets (Set variable node — `Local.SupportTickets`)
+
+Also available as [`sample_tickets.json`](./sample_tickets.json).
+
+```json
+[
+    "The GPS on my TrailMate hiking watch keeps losing signal even after I did a full factory reset.",
+    "Is there a way to see all of my past orders and download them as receipts?",
+    "I was charged twice for the same tent order last Friday and my card statement shows two payments. Can someone fix this?"
+]
+```
+
+The three tickets deliberately cover one of each category: **Gear** (watch losing signal),
+**General** (viewing/downloading orders), and **Billing** (a duplicate charge).
+
+---
+
+## Triage agent — JSON Schema response format
+
+```json
+{
+"name": "category_response",
+"schema": {
+    "type": "object",
+    "properties": {
+        "customer_issue": {
+            "type": "string"
+        },
+        "category": {
+            "type": "string"
+        },
+        "confidence": {
+            "type": "number"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "customer_issue",
+        "category",
+        "confidence"
+    ]
+},
+"strict": true
+}
+```
+
+## Triage agent — Instructions
+
+```output
+Classify the customer's support message into exactly ONE category from the list below. Provide a confidence score from 0 to 1.
+
+Billing
+- Charges, refunds, duplicate payments
+- Missing or incorrect refunds on an order
+- Being charged the wrong price for an order or a gear rental
+
+Gear
+- Faulty, damaged, or defective equipment
+- Product setup, pairing, or usage problems
+- Unexpected behavior from gear or gadgets
+
+General
+- How-to questions
+- Product, trip, or stock availability
+- Order history, receipts, returns, or website navigation
+
+Important rules
+- Questions about viewing, downloading, or exporting orders or receipts are General, not Billing
+- Billing ONLY applies when money was charged, refunded, or paid incorrectly
+```
+
+---
+
+## Low-confidence message (Deliver a message node — Task D2)
+
+```output
+The support ticket classification has low confidence. Requesting more details about the issue: "{Local.CurrentTicket}"
+```
+
+## Confidence condition (If/Else node — Task D2)
+
+```output
+Local.TriageOutputJson.confidence > 0.6
+```
+
+---
+
+## Category routing condition (If/Else node — Task D1)
+
+```output
+Local.TriageOutputJson.category = "Billing"
+```
+
+## Billing escalation message (Deliver a message node — Task D1)
+
+```output
+Escalate billing issue to the Tailwind Traders orders team.
+```
+
+---
+
+## Resolution agent — Instructions (Task D3)
+
+```output
+You are a customer support resolution assistant for Tailwind Traders, an outdoor-gear retailer that also runs guided trips.
+
+Your task is to draft a clear, professional, and friendly support response based on the issue category and customer message.
+
+Guidelines:
+If the issue category is Gear:
+Suggest 1-2 common troubleshooting steps at a high level.
+
+Avoid asking for serial numbers, order numbers, or sensitive data.
+
+Do not imply fault by the customer.
+If the issue category is General:
+Provide a concise, helpful explanation or guidance.
+Keep the response under 5 sentences.
+
+Tone:
+Professional, calm, and supportive
+Clear and concise
+No emojis
+
+Output:
+Return only the drafted response text.
+Do not include internal reasoning or analysis.
+```

--- a/Labfiles/D-design-agent-workflows-in-foundry/assets/sample_tickets.json
+++ b/Labfiles/D-design-agent-workflows-in-foundry/assets/sample_tickets.json
@@ -1,0 +1,5 @@
+[
+    "The GPS on my TrailMate hiking watch keeps losing signal even after I did a full factory reset.",
+    "Is there a way to see all of my past orders and download them as receipts?",
+    "I was charged twice for the same tent order last Friday and my card statement shows two payments. Can someone fix this?"
+]

--- a/Labfiles/D-design-agent-workflows-in-foundry/setup/check_env.py
+++ b/Labfiles/D-design-agent-workflows-in-foundry/setup/check_env.py
@@ -1,0 +1,128 @@
+"""
+Preflight check for the Tailwind Traders workflow lab.
+
+Each task in this lab can be completed on its own. Before you start a task,
+run this script to confirm your .env file has everything that task needs:
+
+    python setup/check_env.py --task 4
+
+It never changes anything - it only reads your .env and tells you what (if
+anything) is missing, so you can fix it before running the task.
+
+Tasks and what they need:
+
+    Task 1  (portal)  no .env needed - you build the workflow in the portal
+    Task 2  (portal)  no .env needed - you extend the portal workflow
+    Task 3  (portal)  no .env needed - you extend the portal workflow
+    Task 4  (code)    PROJECT_ENDPOINT   (your Foundry project endpoint)
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+# Which .env keys each task needs to run on its own.
+TASK_REQUIREMENTS = {
+    1: [],
+    2: [],
+    3: [],
+    4: ["PROJECT_ENDPOINT"],
+}
+
+# Placeholder text shipped in .env.example - present but not yet filled in.
+PLACEHOLDERS = {
+    "",
+    "your-project-endpoint",
+    "<your-project-endpoint>",
+}
+
+# How to fix each key, shown only when it's missing.
+FIX_HINTS = {
+    "PROJECT_ENDPOINT": (
+        "In the Foundry portal, open your workflow in the visualizer, select Code > "
+        ".env variables, and copy the AZURE_EXISTING_AIPROJECT_ENDPOINT value. Set "
+        "PROJECT_ENDPOINT to that value in .env."
+    ),
+}
+
+
+def find_env_file():
+    """Return the .env next to the lab's Python folder, wherever this is run from."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        Path.cwd() / ".env",
+        here.parent / "Python" / ".env",
+        here.parent / ".env",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # Default to the Python-folder location even if it doesn't exist yet.
+    return here.parent / "Python" / ".env"
+
+
+def load_values(env_path):
+    """Merge real environment variables over .env file values (env wins)."""
+    values = {}
+    if env_path.exists():
+        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+    for key in ("PROJECT_ENDPOINT",):
+        if os.environ.get(key):
+            values[key] = os.environ[key]
+    return values
+
+
+def is_set(values, key):
+    """A key counts as set if it's present and not a leftover placeholder."""
+    value = (values.get(key) or "").strip()
+    return bool(value) and value not in PLACEHOLDERS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that your .env has what a given lab task needs."
+    )
+    parser.add_argument(
+        "--task",
+        type=int,
+        choices=sorted(TASK_REQUIREMENTS),
+        required=True,
+        help="Which task you're about to start (1-4).",
+    )
+    args = parser.parse_args()
+
+    env_path = find_env_file()
+    values = load_values(env_path)
+    required = TASK_REQUIREMENTS[args.task]
+
+    print(f"Checking readiness for Task {args.task}")
+    print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
+    print()
+
+    if not required:
+        print(f"Task {args.task} is completed entirely in the Foundry portal - no .env needed.")
+        print("When you're ready for the code task, run this again with --task 4.")
+        return 0
+
+    missing = [key for key in required if not is_set(values, key)]
+
+    for key in required:
+        mark = "OK " if is_set(values, key) else "MISSING"
+        print(f"  [{mark}] {key}")
+
+    if not missing:
+        print()
+        print(f"You're ready to start Task {args.task}.")
+        return 0
+
+    print()
+    print("Set the following before starting this task:")
+    for key in missing:
+        print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Consolidates the remaining small labs into **three bigger, scenario-driven labs**, completing the "10 small labs -> 4 bigger labs" effort (Lab A shipped previously). All three follow the **Lab A recipe** and share the **Tailwind Traders** scenario (outdoor-gear retailer + guided-trips outfitter). SDK topics/APIs are unchanged from the source labs — only reskinned and restructured.

Built by three parallel autopilot sub-sessions, each on its own branch, merged here into one PR.

## New labs

| New lab | Consolidates | Core path (required) | Optional (extend) |
|---|---|---|---|
| **B — Integrate agents with enterprise knowledge and Microsoft 365** | 04 + 05a + 05b | Enterprise-knowledge agent with Foundry IQ | Publish to Teams · Publish to M365 Copilot · Work IQ |
| **C — Build multi-agent solutions with the Agent Framework** | 07 + 08 + 09 | Single agent with a tool (MAF-native throughout) | Sequential orchestration · Remote agents (A2A) |
| **D — Design agent workflows in Microsoft Foundry** | 06 | Classify + route a support ticket | Low-confidence handling · Recommended responses · Client app |

## Applied recipe (per lab)
- Tailwind Traders reskin of all data, prompts, agent names, and narrative.
- Standalone-by-default framing with "Continuing from a previous task?" skip-ahead notes; per-page subtitle + **Next:** footer.
- Landing page + getting-started + one page per section (core first, then optional).
- Complete runnable `Solution/` tree + README alongside starter code; setup scripts (`check_env.py`, `bootstrap` where useful).
- Gradio web UI shell (`tailwind_ui.py`, `gradio==6.20.0`) where a chat client fits (B and D); C is console-only, faithful to its sources.
- MAF is the **native/primary** path for Lab C (no raw-SDK-vs-MAF hybrid); C3 (A2A) keeps lab 09's SDK steps technically identical.

## Scope & validation
- **Additive only** — originals 01–09 and Lab A are untouched; each lab lives in its own `Labfiles/` folder + `Instructions/Exercises` pages (disjoint, merged cleanly with no conflicts).
- **Static validation only** (no Azure calls): all Python files across the three labs compile; imports/SDK symbols resolve; console strings ASCII-safe; no stray legacy brand references in new files.

## Follow-up commit (agent-framework bump, callout + modularity normalization)
- **agent-framework bumped `1.9.0` -> `1.12.1`** across the consolidated labs (A and C). 1.12.1 resolves the `[all]`/a2a extras that 1.9.0 could not. Verified Lab A and Lab C `requirements.txt` resolve cleanly (Lab C keeps its `a2a-sdk==0.3.26` pin via a compatible `agent-framework-a2a` build; C3's A2A code is unchanged). MAF symbols used by Lab A/C (`tool`, `Agent`, `MCPStdioTool`, `Message`, `FoundryChatClient`, `SequentialBuilder`, `Agent.run`, session creation) all import on 1.12.1. Legacy `07`/`08` are intentionally left on their original pin — this PR stays scoped to A–D.
- **Callout style normalized:** Lab D's "Continuing from a previous task?" note (D2/D3/D4) changed from nested `> >` to a single `>` separate callout, matching Labs A/B/C. No nested callouts remain in B/C/D.
- **Lab D modularity parity:** added `Labfiles/D-design-agent-workflows-in-foundry/setup/check_env.py` (preflight, mirrors A/B/C) and wired a `check_env --task 4` verification step into D4.

## Reviewer notes
- **azd/bicep** in B and C is lint-only, never deployment-tested.

Left open for review.