### PR TITLE
Add Linux/macOS/WSL venv setup commands to exercise docs

### DIFF
--- a/Instructions/Exercises/01-build-agent-portal-and-vscode.md
+++ b/Instructions/Exercises/01-build-agent-portal-and-vscode.md
@@ -444,6 +444,14 @@ Now let's create a client application that interacts with your agent programmati
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```bash
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
     ```bash
    az login
     ```

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -113,6 +113,14 @@ For this exercise, you'll use starter code that will help you connect to your Fo
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
 1. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the project deployment resource in the Foundry Toolkit VS Code extension) and ensure that the MODEL_DEPLOYMENT_NAME variable is set to your model deployment name. Use **Ctrl+S** to save the file after making these changes.
 
 Now you're ready to create an AI agent that uses MCP server tools to access external data sources and APIs.

--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -109,6 +109,14 @@ For this exercise, you'll use starter code that will help you connect to your Fo
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
 1. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the project deployment resource in the Foundry Toolkit extension) and ensure that the MODEL_DEPLOYMENT_NAME variable is set to your model deployment name. Use **Ctrl+S** to save the file after making these changes.
 
 Now you're ready to create an AI agent that uses MCP server tools to access external data sources and APIs.

--- a/Instructions/Exercises/06-build-workflow-ms-foundry.md
+++ b/Instructions/Exercises/06-build-workflow-ms-foundry.md
@@ -377,6 +377,14 @@ For this exercise, you'll use starter code that will help you connect to your Fo
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
 6. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the code tab of the workflow visualizer). Use **Ctrl+S** to save the file after making these changes.
 
 ### Invoke the workflow from code

--- a/Instructions/Exercises/07-agent-framework.md
+++ b/Instructions/Exercises/07-agent-framework.md
@@ -109,6 +109,14 @@ For this exercise, you'll use starter code that will help you connect to your Fo
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
 1. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the project deployment resource in the Foundry Toolkit extension) and ensure that the MODEL_DEPLOYMENT_NAME variable is set to your model deployment name. Use **Ctrl+S** to save the file after making these changes.
 
 Now you're ready to create an AI agent that uses a custom tool to process expenses data.

--- a/Instructions/Exercises/08-agent-framework-multi-agents.md
+++ b/Instructions/Exercises/08-agent-framework-multi-agents.md
@@ -115,6 +115,14 @@ For this exercise, you'll use starter code that will help you connect to your Fo
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
 1. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the project deployment resource in the Foundry Toolkit extension) and ensure that the MODEL_DEPLOYMENT_NAME variable is set to your model deployment name. Use **Ctrl+S** to save the file after making these changes.
 
 ## Create AI agents

--- a/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
+++ b/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
@@ -134,6 +134,14 @@ For this exercise, you'll use starter code that will help you connect to your Fo
    pip install -r requirements.txt
     ```
 
+    On Linux, macOS, or WSL, use:
+
+    ```
+   python3 -m venv labenv
+   source labenv/bin/activate
+   pip install -r requirements.txt
+    ```
+
 1. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the project deployment resource in the Foundry Toolkit extension) and ensure that the MODEL_DEPLOYMENT_NAME variable is set to your model deployment name. Use **Ctrl+S** to save the file after making these changes.
 
 ## Create a discoverable agent


### PR DESCRIPTION
## Summary
- The Python environment setup steps in 7 exercise docs only showed the Windows PowerShell activation command (`.\labenv\Scripts\Activate.ps1`), which fails on Linux, macOS, and WSL bash shells (`python` not found, wrong activation path, leading to pip failing with `externally-managed-environment` against the system interpreter).
- Added the Linux/macOS/WSL equivalent (`python3 -m venv labenv`, `source labenv/bin/activate`, `pip install -r requirements.txt`) alongside the existing Windows instructions in each affected exercise:
  - 01-build-agent-portal-and-vscode.md
  - 02-agent-custom-tools.md
  - 03-mcp-integration.md
  - 06-build-workflow-ms-foundry.md
  - 07-agent-framework.md
  - 08-agent-framework-multi-agents.md
  - 09-multi-remote-agents-with-a2a.md

## Test plan
- [x] Verified the added Linux commands (`python3 -m venv`, `source .../activate`, `pip install -r requirements.txt`) work correctly in a WSL2/Debian bash shell
- [x] Confirmed Windows instructions are unchanged