### PR TITLE
[Pilot] C# client for 01-build-agent-portal-and-vscode using Microsoft Agent Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,5 @@ obj/
 
 # Output files
 analysis_results.json
+agent_outputs/
 output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,11 @@ Thumbs.db
 # Azure
 .azure/
 
+# .NET
+bin/
+obj/
+*.user
+
 # Output files
 analysis_results.json
 output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ Thumbs.db
 bin/
 obj/
 *.user
+.vs/
 
 # Output files
 analysis_results.json

--- a/Instructions/Exercises/01-build-agent-portal-and-vscode.md
+++ b/Instructions/Exercises/01-build-agent-portal-and-vscode.md
@@ -22,9 +22,9 @@ Before starting this exercise, ensure you have:
 
 - An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) or later installed, **or** the [.NET 8 SDK](https://dotnet.microsoft.com/download) or later if you're following the C# version of the client application
 - [Git](https://git-scm.com/downloads) installed on your local machine
-- Basic familiarity with Azure AI services and Python programming
+- Basic familiarity with Azure AI services and Python or C# programming
 
 > \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
 
@@ -205,7 +205,11 @@ Now let's create a client application that interacts with your agent programmati
 
 1. When prompted, select **Open** to open the cloned repository in VS Code.
 
-1. Once the repository opens, select **File > Open Folder** and navigate to `mslearn-ai-agents/Labfiles/01-build-agent-portal-and-vscode/Python`, then choose **Select Folder**.
+This exercise provides starter code for both Python and C#. Follow the section below for the language you're using.
+
+### Python
+
+1. Select **File > Open Folder** and navigate to `mslearn-ai-agents/Labfiles/01-build-agent-portal-and-vscode/Python`, then choose **Select Folder**.
 
 1. In the Explorer pane, open the `agent_with_functions.py` file. If the file is empty, replace its contents with the following code.
 
@@ -417,7 +421,7 @@ Now let's create a client application that interacts with your agent programmati
 
 1. Save the `agent_with_functions.py` file (**Ctrl+S** or **File > Save**).
 
-### Configure environment and run the application
+#### Configure environment and run the application
 
 1. In the Explorer pane, you'll see `.env.example` and `requirements.txt` files already present in the folder.
 
@@ -452,6 +456,50 @@ Now let's create a client application that interacts with your agent programmati
 
     ```bash
    python agent_with_functions.py
+    ```
+
+### C#
+
+> **Tip**: This C# client uses the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) (`Microsoft.Agents.AI.Foundry`) instead of the raw Azure AI Projects SDK calls used by the Python client. The package is still prerelease, so APIs may change before general availability.
+
+1. Select **File > Open Folder** and navigate to `mslearn-ai-agents/Labfiles/01-build-agent-portal-and-vscode/CSharp`, then choose **Select Folder**.
+
+1. In the Explorer pane, open the `Program.cs` file and review the code. Unlike the Python starter file, `Program.cs` already contains a complete implementation, since the goal here is to show how the Microsoft Agent Framework simplifies talking to an agent that's already defined in the portal. The file:
+
+    - Loads your `.env` file and connects to the Foundry project with `AIProjectClient` and `DefaultAzureCredential`
+    - Finds the `it-support-agent` you created in the portal by name, using `AgentAdministrationClient.GetAgentAsync(...)`, and wraps it as a `FoundryAgent` with `AsAIAgent(...)` — the agent's instructions, file search, and code interpreter tools all stay defined in the portal, not in this code
+    - Creates an `AgentSession` to keep the conversation's context across turns, then loops on console input, calling `agent.RunAsync(userInput, session)` for each message
+    - Downloads any files Code Interpreter generates (like charts) using `ContainerClient`, the same way the Python client's `download_container_file` function does
+
+#### Configure environment and run the application
+
+1. In the Explorer pane, you'll see a `.env.example` file already present in the folder.
+
+1. Duplicate the `.env.example` file, and rename it to `.env`.
+
+1. In the `.env` file, replace `your_project_endpoint_here` with your actual project endpoint:
+
+    ```
+   PROJECT_ENDPOINT=<your_project_endpoint>
+   AGENT_NAME=it-support-agent
+    ```
+
+    **To get your project endpoint:** In VS Code, open the **Foundry Toolkit** extension, right-click on your active project, and select **Copy Endpoint**. If **Copy Endpoint** isn't available in your installed version of Foundry Toolkit, open the Microsoft Foundry portal, go to your project, and copy the project endpoint from the project overview page instead.
+
+1. Save the `.env` file (**Ctrl+S** or **File > Save**).
+
+1. Open a terminal in VS Code (**Terminal > New Terminal**) and navigate to the working directory.
+
+1. Sign in to Azure so the application can authenticate:
+
+    ```bash
+   az login
+    ```
+
+1. Run the application (this restores the required NuGet packages automatically on first run):
+
+    ```bash
+   dotnet run
     ```
 
 ## Test the client application

--- a/Labfiles/01-build-agent-portal-and-vscode/CSharp/.env.example
+++ b/Labfiles/01-build-agent-portal-and-vscode/CSharp/.env.example
@@ -1,0 +1,11 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# Get this from the Foundry project
+# In VS Code, you can try Foundry Toolkit > right-click your active project > Copy Endpoint
+# If that option isn't available, copy the endpoint from the Microsoft Foundry portal project overview page
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# Agent name (created in the portal)
+AGENT_NAME=it-support-agent

--- a/Labfiles/01-build-agent-portal-and-vscode/CSharp/ITSupportAgentClient.csproj
+++ b/Labfiles/01-build-agent-portal-and-vscode/CSharp/ITSupportAgentClient.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <NoWarn>$(NoWarn);OPENAI001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.16.0-preview.260730.1" />
+  </ItemGroup>
+
+</Project>

--- a/Labfiles/01-build-agent-portal-and-vscode/CSharp/Program.cs
+++ b/Labfiles/01-build-agent-portal-and-vscode/CSharp/Program.cs
@@ -25,14 +25,22 @@ if (string.IsNullOrWhiteSpace(projectEndpoint) || projectEndpoint == "your_proje
 }
 
 Console.WriteLine("Connecting to Microsoft Foundry project...");
-AIProjectClient projectClient = new(new Uri(projectEndpoint), new DefaultAzureCredential());
+// AzureCliCredential (rather than DefaultAzureCredential) is used here because this app is
+// meant to run locally against the "az login" session from the setup steps. DefaultAzureCredential
+// also tries ManagedIdentityCredential first, which can throw (instead of just being "unavailable")
+// on machines without IMDS -- e.g. WSL -- aborting the credential chain before it ever reaches
+// AzureCliCredential. See https://aka.ms/azsdk/net/identity/managedidentitycredential/troubleshoot
+AIProjectClient projectClient = new(new Uri(projectEndpoint), new AzureCliCredential());
 
 FoundryAgent agent;
 try
 {
     Console.WriteLine($"Loading agent: {agentName}");
+    System.Diagnostics.Stopwatch loadStopwatch = System.Diagnostics.Stopwatch.StartNew();
     ProjectsAgentRecord agentRecord = await projectClient.AgentAdministrationClient.GetAgentAsync(agentName);
     agent = projectClient.AsAIAgent(agentRecord);
+    loadStopwatch.Stop();
+    Console.WriteLine($"[GetAgentAsync took {loadStopwatch.Elapsed.TotalSeconds:F1}s]");
 }
 catch (Exception ex)
 {
@@ -78,7 +86,10 @@ while (true)
     Console.WriteLine();
     Console.WriteLine("[Agent is thinking...]");
 
+    System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
     AgentResponse response = await agent.RunAsync(userInput, session);
+    stopwatch.Stop();
+    Console.WriteLine($"[RunAsync took {stopwatch.Elapsed.TotalSeconds:F1}s]");
 
     if (!string.IsNullOrWhiteSpace(response.Text))
     {

--- a/Labfiles/01-build-agent-portal-and-vscode/CSharp/Program.cs
+++ b/Labfiles/01-build-agent-portal-and-vscode/CSharp/Program.cs
@@ -1,0 +1,188 @@
+// IT Support Agent client — C# / Microsoft Agent Framework port of the Python
+// agent_with_functions.py sample. Connects to the agent created in the Foundry
+// portal (with File search and Code interpreter already attached) and chats
+// with it from the console, saving any files or charts it generates.
+
+using Azure.AI.Projects;
+using Azure.AI.Projects.Agents;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
+using Microsoft.Extensions.AI;
+using OpenAI.Containers;
+using OpenAI.Responses;
+
+LoadDotEnv();
+
+string? projectEndpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
+string agentName = Environment.GetEnvironmentVariable("AGENT_NAME") ?? "it-support-agent";
+
+if (string.IsNullOrWhiteSpace(projectEndpoint) || projectEndpoint == "your_project_endpoint_here")
+{
+    Console.WriteLine("Error: PROJECT_ENDPOINT environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+Console.WriteLine("Connecting to Microsoft Foundry project...");
+AIProjectClient projectClient = new(new Uri(projectEndpoint), new DefaultAzureCredential());
+
+FoundryAgent agent;
+try
+{
+    Console.WriteLine($"Loading agent: {agentName}");
+    ProjectsAgentRecord agentRecord = await projectClient.AgentAdministrationClient.GetAgentAsync(agentName);
+    agent = projectClient.AsAIAgent(agentRecord);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Error: could not find agent '{agentName}' in the project ({ex.Message})");
+    Console.WriteLine("Make sure you created it in the Foundry portal and that AGENT_NAME matches its name.");
+    return;
+}
+
+Console.WriteLine($"Connected to agent: {agent.Name} (id: {agent.Id})");
+
+// Used to download files (like generated charts) that Code Interpreter writes to its sandbox.
+ContainerClient containerClient = projectClient.GetProjectOpenAIClient().GetContainerClient();
+DirectoryInfo outputDir = new(Path.Combine(Directory.GetCurrentDirectory(), "agent_outputs"));
+HashSet<string> downloadedFiles = [];
+
+// A session keeps the conversation (and its history) alive across turns.
+AgentSession session = await agent.CreateSessionAsync();
+
+Console.WriteLine();
+Console.WriteLine(new string('=', 60));
+Console.WriteLine("IT Support Agent Ready!");
+Console.WriteLine("Ask questions, request data analysis, or get help.");
+Console.WriteLine("Type 'exit' to quit.");
+Console.WriteLine(new string('=', 60));
+Console.WriteLine();
+
+while (true)
+{
+    Console.Write("You: ");
+    string userInput = (Console.ReadLine() ?? string.Empty).Trim();
+
+    if (userInput.Length == 0)
+    {
+        continue;
+    }
+
+    if (userInput is "exit" or "quit" or "bye")
+    {
+        Console.WriteLine("Goodbye!");
+        break;
+    }
+
+    Console.WriteLine();
+    Console.WriteLine("[Agent is thinking...]");
+
+    AgentResponse response = await agent.RunAsync(userInput, session);
+
+    if (!string.IsNullOrWhiteSpace(response.Text))
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Agent: {response.Text}");
+        Console.WriteLine();
+    }
+
+    await SaveGeneratedFilesAsync(response, containerClient, outputDir, downloadedFiles);
+}
+
+// Downloads any files Code Interpreter generated this turn (e.g. charts, CSVs) and
+// saves them locally, printing where each one landed.
+static async Task SaveGeneratedFilesAsync(
+    AgentResponse response,
+    ContainerClient containerClient,
+    DirectoryInfo outputDir,
+    HashSet<string> downloadedFiles)
+{
+    foreach (AIContent content in response.Messages.SelectMany(m => m.Contents))
+    {
+        if (content.Annotations is null)
+        {
+            continue;
+        }
+
+        foreach (AIAnnotation annotation in content.Annotations)
+        {
+            if (annotation is not CitationAnnotation { RawRepresentation: ContainerFileCitationMessageAnnotation containerCitation })
+            {
+                continue;
+            }
+
+            string key = $"{containerCitation.ContainerId}/{containerCitation.FileId}";
+            if (!downloadedFiles.Add(key))
+            {
+                continue;
+            }
+
+            BinaryData fileData = await containerClient.DownloadContainerFileAsync(
+                containerCitation.ContainerId,
+                containerCitation.FileId);
+
+            if (!outputDir.Exists)
+            {
+                outputDir.Create();
+            }
+
+            string safeFilename = Path.GetFileName(containerCitation.Filename ?? $"{containerCitation.FileId}.bin");
+            string outputPath = GetUniqueOutputPath(outputDir, safeFilename);
+            await File.WriteAllBytesAsync(outputPath, fileData.ToArray());
+
+            Console.WriteLine($"[Agent generated a file - saved to: {outputPath}]");
+        }
+    }
+}
+
+// Avoids clobbering a file from an earlier turn that happens to share a name.
+static string GetUniqueOutputPath(DirectoryInfo outputDir, string filename)
+{
+    string stem = Path.GetFileNameWithoutExtension(filename);
+    string suffix = Path.GetExtension(filename);
+    string outputPath = Path.Combine(outputDir.FullName, filename);
+
+    int counter = 1;
+    while (File.Exists(outputPath))
+    {
+        outputPath = Path.Combine(outputDir.FullName, $"{stem}_{counter}{suffix}");
+        counter++;
+    }
+
+    return outputPath;
+}
+
+// Minimal ".env" loader so this project can reuse the same .env file format as
+// the Python sample, without adding a NuGet dependency just for that.
+static void LoadDotEnv()
+{
+    string envPath = Path.Combine(Directory.GetCurrentDirectory(), ".env");
+    if (!File.Exists(envPath))
+    {
+        return;
+    }
+
+    foreach (string rawLine in File.ReadAllLines(envPath))
+    {
+        string line = rawLine.Trim();
+        if (line.Length == 0 || line.StartsWith('#'))
+        {
+            continue;
+        }
+
+        int separatorIndex = line.IndexOf('=');
+        if (separatorIndex <= 0)
+        {
+            continue;
+        }
+
+        string key = line[..separatorIndex].Trim();
+        string value = line[(separatorIndex + 1)..].Trim().Trim('"');
+
+        if (Environment.GetEnvironmentVariable(key) is null)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/Labfiles/01-build-agent-portal-and-vscode/CSharp/README.md
+++ b/Labfiles/01-build-agent-portal-and-vscode/CSharp/README.md
@@ -1,0 +1,59 @@
+# IT Support Agent client (C# / Microsoft Agent Framework)
+
+This is a C# port of the [`Python/agent_with_functions.py`](../Python/agent_with_functions.py) client from this exercise, built with the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) instead of a raw `azure-ai-projects` + OpenAI Responses API call. It connects to the `it-support-agent` you create in the [exercise](../../../Instructions/Exercises/01-build-agent-portal-and-vscode.md) via the Foundry portal (with **File search** and **Code interpreter** already attached) and chats with it from the console.
+
+> **Status**: pilot / community contribution. `Microsoft.Agents.AI.Foundry` is still prerelease, so APIs may change before GA.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download) or later
+- The `it-support-agent` created in [Create a Microsoft Foundry Project](../../../Instructions/Exercises/01-build-agent-portal-and-vscode.md#create-a-microsoft-foundry-project) and [Configure your agent with instructions and grounding data](../../../Instructions/Exercises/01-build-agent-portal-and-vscode.md#configure-your-agent-with-instructions-and-grounding-data)
+- The [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli), signed in with `az login`
+
+## Setup
+
+1. Duplicate `.env.example` and rename it to `.env`.
+
+2. In `.env`, replace `your_project_endpoint_here` with your project endpoint (copy it from the Foundry Toolkit extension or the project overview page in the Foundry portal):
+
+    ```
+   PROJECT_ENDPOINT=<your_project_endpoint>
+   AGENT_NAME=it-support-agent
+    ```
+
+3. Sign in to Azure so `DefaultAzureCredential` can authenticate:
+
+    ```bash
+   az login
+    ```
+
+4. Restore and run:
+
+    ```bash
+   dotnet run
+    ```
+
+## Try it
+
+Once the agent is ready, test both tools it was configured with in the portal:
+
+```
+What's the policy for password resets?
+```
+
+```
+Create a line chart showing memory usage trends over time
+```
+
+Generated charts and cited files are saved to the `agent_outputs` folder, with the local path printed in the terminal. Type `exit` to quit.
+
+## How it maps to the Python sample
+
+| Python (`agent_with_functions.py`) | C# (`Program.cs`) |
+| --- | --- |
+| `AIProjectClient` + raw OpenAI `conversations`/`responses` calls | `AIProjectClient.AgentAdministrationClient.GetAgentAsync(name)` + `AsAIAgent(...)` from Microsoft Agent Framework, returning a `FoundryAgent` |
+| Manually created `conversation` | `AgentSession` from `agent.CreateSessionAsync()` |
+| `openai_client.responses.create(...)` in a loop | `agent.RunAsync(userInput, session)` |
+| `download_container_file` walking `container_file_citation` annotations | `ContainerClient.DownloadContainerFileAsync` walking `CitationAnnotation` / `ContainerFileCitationMessageAnnotation` |
+
+See [Microsoft Foundry provider docs](https://learn.microsoft.com/agent-framework/agents/providers/microsoft-foundry) for more on the `AsAIAgent` patterns used here.


### PR DESCRIPTION
## Summary

This is a **pilot / RFC**, not a request for immediate merge. It explores what a C# track for this repo could look like, using the exercise the labs already teach first (`01-build-agent-portal-and-vscode`) as the proving ground.

- Adds `Labfiles/01-build-agent-portal-and-vscode/CSharp/` alongside the existing `Python/` folder.
- The console client connects to the `it-support-agent` created in the Foundry portal (same exercise steps as the Python version — no code changes needed there) and chats with it, downloading any Code Interpreter-generated files/charts.
- Built with the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) (`Microsoft.Agents.AI.Foundry`) rather than a raw `azure-ai-projects` + OpenAI Responses API call, since that's the framework the newer `07-agent-framework`/`08-agent-orchestration` Python labs already use — this keeps the concepts consistent if a C# track were to grow across exercises later.
- `AgentAdministrationClient.GetAgentAsync(name)` + `AsAIAgent(...)` retrieves the *existing* portal-defined agent (its tools/instructions stay owned by the Foundry portal, matching how the Python sample works), `AgentSession` handles multi-turn chat, and `ContainerClient.DownloadContainerFileAsync` mirrors the Python script's container-file-citation handling for saving generated charts.
- **Now wired into `Instructions/Exercises/01-build-agent-portal-and-vscode.md`**: after the repo-clone step, the doc forks into parallel `### Python` / `### C#` subsections (this Jekyll theme has no tab/pivot component, so it's plain markdown headings rather than a true tabbed UI), converging back for the shared, language-agnostic "Test the client application" and "Cleanup" sections. `Program.cs` ships as a complete, ready-to-run implementation rather than a fill-in-the-blank template — the doc's C# section walks through what it does instead of asking students to paste 150+ lines, so the file in the repo stays the single source of truth instead of a copy embedded in the markdown drifting out of sync.
- Added a `.NET 8 SDK` prerequisite alongside Python 3.13 in the Prerequisites section.

## Caveats

- `Microsoft.Agents.AI.Foundry` is still prerelease (pinned to `1.16.0-preview.260730.1`); the API may change before GA.
- Only this one exercise is ported, as a proof of concept — happy to extend to more exercises if this direction is welcome.
- No built-in tab/pivot support exists in this repo's Jekyll theme, so the language split in the doc is two sequential `###` sections rather than an interactive tab switcher. Open to a different presentation if maintainers prefer one.

## Test plan
- [x] `dotnet build` succeeds (net8.0, zero warnings/errors)
- [x] Doc heading structure double-checked (H2 section → H3 language → H4 configure/run, converging back to shared H2 sections)
- [x] Manual run against a live Foundry project (not yet verified end-to-end against a real agent — build/compile-verified only)