### PR TITLE
Fix stale azure-ai-projects pin and default TPM guidance in labs 02/04/06

### DIFF
--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -71,7 +71,7 @@ At the core of any generative AI project, there’s at least one generative AI m
    - **Deployment name**: Enter a name like "gpt-5"
    - **Deployment type**: Select **Global Standard** (or **Standard** if Global Standard is not available)
    - **Model version**: Leave as default
-   - **Tokens per minute**: Leave as default
+   - **Tokens per minute**: Raise the Tokens per Minute limit to 150000 or higher.
 
 1. Select **Deploy to Microsoft Foundry** in the bottom-left corner.
 

--- a/Labfiles/02-agent-custom-tools/Python/requirements.txt
+++ b/Labfiles/02-agent-custom-tools/Python/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 azure-identity
-azure-ai-projects==2.0.0b4
+azure-ai-projects==2.3.0
 openai

--- a/Labfiles/04-integrate-agent-with-foundry-iq/Python/requirements.txt
+++ b/Labfiles/04-integrate-agent-with-foundry-iq/Python/requirements.txt
@@ -1,3 +1,3 @@
-azure-ai-projects==2.0.0b4
+azure-ai-projects==2.3.0
 azure-identity
 python-dotenv

--- a/Labfiles/06-build-workflow-ms-foundry/Python/requirements.txt
+++ b/Labfiles/06-build-workflow-ms-foundry/Python/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 azure-identity
-azure-ai-projects==2.0.0b4
+azure-ai-projects==2.3.0
 aiohttp


### PR DESCRIPTION
# Module: 02, 04, 06
## Lab/Demo: 02-agent-custom-tools, 04-integrate-agent-with-foundry-iq, 06-build-workflow-ms-foundry

Fixes a live 404 in lab 02 (and the same latent issue in 04/06) plus a reliable 429 in lab 02.

Changes proposed in this pull request:

- Bump `azure-ai-projects` from the stale `2.0.0b4` pin to `2.3.0` in `Labfiles/02-agent-custom-tools/Python/requirements.txt`, `Labfiles/04-integrate-agent-with-foundry-iq/Python/requirements.txt`, and `Labfiles/06-build-workflow-ms-foundry/Python/requirements.txt`
- Update `Instructions/Exercises/02-agent-custom-tools.md`'s model deployment step to raise **Tokens per minute** to 150000+ instead of leaving it at the default

## Details

**SDK pin**: `2.0.0b4` predates the Foundry agent-versioning API surface (`PromptAgentDefinition`, `agents.create_version`, etc.) that these labs' own starter code already calls. Against a live "New Foundry" project, `agents.create_version` returns an empty-body 404 with this pin — the route itself isn't resolving correctly, not a bad request. `Labfiles/03-mcp-integration/Python/requirements.txt` is already pinned to `azure-ai-projects==2.3.0`, so this looks like a fix that landed for lab 03 but wasn't backported to 02/04/06, which share the same starter-code pattern.

Verified locally end-to-end for lab 02: reproduced the 404 with `2.0.0b4`, confirmed `create_version`/`delete_version`/`PromptAgentDefinition`/`FunctionTool` all still resolve correctly after bumping to `2.3.0`, and successfully ran the lab against a live Foundry project after the change (agent created, function-tool calls handled, conversation worked end-to-end).

Labs 04 and 06 have the identical stale pin but create their agents through the portal UI rather than the SDK's `create_version` path in their documented steps, so I didn't reproduce the 404 for those specifically — bumping the pin brings them in line with 02/03 regardless, since nothing in either lab's code depends on the older API surface.

**TPM default**: with the default (low) Tokens-Per-Minute setting, lab 02's per-turn traffic pattern (an initial `responses.create` call, then a second call to submit function-tool outputs) reliably triggers `RateLimitError: 429 rate_limit_exceeded` during normal interactive use — not an edge case, just normal lab usage. `Labfiles/03-mcp-integration`'s corresponding doc step already says "Raise the Tokens Per Minute limit to 150000 or higher"; lab 02's said "Leave as default." Brought it in line with lab 03's wording. Labs 04 and 06 don't have an equivalent "Deploy a model" step with a Tokens-per-minute field to fix (their agents are created through the portal UI without exposing that setting), so no doc change was needed there.

## Test plan
- [x] Reproduced the 404 on `agents.create_version` against a live project with `azure-ai-projects==2.0.0b4`
- [x] Confirmed the API surface (`create_version`, `delete_version`, `PromptAgentDefinition`, `FunctionTool`) is unchanged in `2.3.0`
- [x] Ran lab 02 end-to-end against a live Foundry project after the fix — agent creation, function-tool calls, and multi-turn conversation all worked
- [x] Reproduced and diagnosed the 429 during the same live run; confirmed it's TPM-quota related, not a code issue