### PR TITLE
[Pilot] C# client for 02-agent-custom-tools using Microsoft Agent Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,13 @@ Thumbs.db
 # Azure
 .azure/
 
+# .NET
+bin/
+obj/
+*.user
+.vs/
+
 # Output files
 analysis_results.json
 output.txt
+agent_outputs/

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -24,7 +24,7 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) or later installed, **or** the [.NET 8 SDK](https://dotnet.microsoft.com/download) or later if you're following the C# version of the client application
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
 > \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
@@ -101,6 +101,10 @@ For this exercise, you'll use starter code that will help you connect to your Fo
 
 1. Once the repository opens, select **File > Open Folder** and navigate to `mslearn-ai-agents/Labfiles/02-agent-custom-tools`, then choose **Select Folder**.
 
+This exercise provides starter code for both Python and C#. Follow the **Python** section below to build the agent step by step, or skip to the **C#** section further down if you're using C#.
+
+### Python
+
 1. In the Explorer pane, expand the **Python** folder to view the code files for this exercise.
 
 1. Right-click on the **requirements.txt** file and select **Open in Integrated Terminal**.
@@ -115,7 +119,7 @@ For this exercise, you'll use starter code that will help you connect to your Fo
 
 1. Open the **.env** file, replace the **your_project_endpoint** placeholder with the endpoint for your project (copied from the project deployment resource in the Foundry Toolkit VS Code extension) and ensure that the MODEL_DEPLOYMENT_NAME variable is set to your model deployment name. Use **Ctrl+S** to save the file after making these changes.
 
-Now you're ready to create an AI agent that uses MCP server tools to access external data sources and APIs.
+Now you're ready to create an AI agent that uses custom function tools to complete tasks.
 
 ## Create a function for the agent to use
 
@@ -462,6 +466,65 @@ Now that you've created the agent with the function tools, you can send messages
 1. Enter `quit` to exit the application.
 
     You can also use `deactivate` to exit the Python virtual environment in the terminal.
+
+### C#
+
+> **Tip**: This C# client uses the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) (`Microsoft.Agents.AI.Foundry`) instead of hand-written `azure-ai-projects` calls. The package is still prerelease, so APIs may change before general availability.
+
+1. In the Explorer pane, expand the **CSharp** folder to view the code files for this exercise.
+
+1. Open the **Functions.cs** file and review the code. It contains C# ports of the same three functions defined in `functions.py`: `NextVisibleEvent`, `CalculateObservationCost`, and `GenerateObservationReport`. Each method has `[Description]` attributes on the method and its parameters, which the Microsoft Agent Framework uses to generate the tool's JSON schema automatically -- unlike the Python sample, there's no hand-written schema to keep in sync with the function signature.
+
+1. Open the **Program.cs** file and review the code. Unlike the Python starter files, `Program.cs` and `Functions.cs` already contain a complete implementation. `Program.cs`:
+
+    - Wraps each method in `Functions.cs` as a tool with `AIFunctionFactory.Create(...)`
+    - Creates an agent in a single call with `AIProjectClient.AsAIAgent(model, instructions, name, tools)` -- combining what the Python sample does across defining each `FunctionTool`'s JSON schema and calling `agents.create_version(...)`
+    - Creates an `AgentSession` to keep the conversation's context across turns, then loops on console input, calling `agent.RunAsync(userInput, session)` for each message
+
+    Notice there's no code here that inspects `response.output` for `function_call` items, dispatches to the matching function, or resends results as `function_call_output` -- the Microsoft Agent Framework handles that loop internally. It also doesn't call an equivalent of `agents.delete_version(...)` at the end, since this pattern doesn't persist an agent resource on the server to begin with.
+
+#### Configure environment and run the application
+
+1. In the Explorer pane, you'll see a `.env.example` file already present in the folder.
+
+1. Duplicate the `.env.example` file, and rename it to `.env`.
+
+1. In the `.env` file, replace the placeholders with your project endpoint and model deployment name:
+
+    ```
+   PROJECT_ENDPOINT=<your_project_endpoint>
+   MODEL_DEPLOYMENT_NAME=<your_model_deployment_name>
+    ```
+
+1. Save the `.env` file (**Ctrl+S** or **File > Save**).
+
+1. Open a terminal in VS Code (**Terminal > New Terminal**) and navigate to the working directory.
+
+1. Sign in to Azure so the application can authenticate:
+
+    ```bash
+   az login
+    ```
+
+1. Run the application (this restores the required NuGet packages automatically on first run):
+
+    ```bash
+   dotnet run
+    ```
+
+1. When prompted, try the same prompts as the Python version above, for example:
+
+    ```
+   Find me the next event I can see from South America and give me the cost for 5 hours of premium telescope time at normal priority.
+    ```
+
+    ```
+   Generate that information in a report for Bellows College.
+    ```
+
+    The generated report is saved to the working directory, matching the Python sample's behavior.
+
+1. Enter `quit` to exit the application.
 
 ## Clean up
 

--- a/Labfiles/02-agent-custom-tools/CSharp/.env.example
+++ b/Labfiles/02-agent-custom-tools/CSharp/.env.example
@@ -1,0 +1,11 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# Get this from the Foundry project
+# In VS Code, you can try Foundry Toolkit > right-click your active project > Copy Endpoint
+# If that option isn't available, copy the endpoint from the Microsoft Foundry portal project overview page
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (e.g. gpt-5)
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here

--- a/Labfiles/02-agent-custom-tools/CSharp/AstronomyAgentClient.csproj
+++ b/Labfiles/02-agent-custom-tools/CSharp/AstronomyAgentClient.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.16.0-preview.260730.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="data\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/Labfiles/02-agent-custom-tools/CSharp/Functions.cs
+++ b/Labfiles/02-agent-custom-tools/CSharp/Functions.cs
@@ -1,0 +1,172 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+// Local function tools for the astronomy agent. C# port of functions.py -- each method here
+// maps 1:1 to a Python function of the same name. [Description] attributes are what let
+// AIFunctionFactory.Create(...) generate the tool's JSON schema automatically from the method
+// signature (see Program.cs), instead of hand-writing the schema like the Python sample does.
+static class Functions
+{
+    private static readonly List<(string Name, string Type, int SortKey, string DateText, HashSet<string> Locations)> Events = LoadEvents("data/events.txt");
+    private static readonly Dictionary<string, double> TelescopeRates = LoadRates("data/telescope_rates.txt");
+    private static readonly Dictionary<string, double> PriorityMultipliers = LoadRates("data/priority_multipliers.txt");
+
+    [Description("Get the next visible astronomical event for a given location.")]
+    public static string NextVisibleEvent(
+        [Description("Continent to find the next visible event in (e.g. 'north_america', 'south_america', 'australia')")] string location)
+    {
+        int today = int.Parse(DateTime.Now.ToString("MMdd"));
+        string loc = location.ToLowerInvariant().Replace(" ", "_");
+
+        foreach (var (name, type, sortKey, dateText, locations) in Events)
+        {
+            if (locations.Contains(loc) && sortKey >= today)
+            {
+                return JsonSerializer.Serialize(new JsonObject
+                {
+                    ["event"] = name,
+                    ["type"] = type,
+                    ["date"] = dateText,
+                    ["visible_from"] = new JsonArray(locations.OrderBy(l => l).Select(l => (JsonNode)l).ToArray()),
+                });
+            }
+        }
+
+        return JsonSerializer.Serialize(new JsonObject { ["message"] = $"No upcoming events found for {location}." });
+    }
+
+    [Description("Calculate the cost of an observation based on the telescope tier, number of hours, and priority level.")]
+    public static string CalculateObservationCost(
+        [Description("The tier of the telescope (e.g. 'standard', 'advanced', 'premium')")] string telescopeTier,
+        [Description("The number of hours for the observation")] double hours,
+        [Description("The priority level of the observation (e.g. 'low', 'normal', 'high')")] string priority)
+    {
+        string tier = telescopeTier.ToLowerInvariant();
+        string pri = priority.ToLowerInvariant();
+
+        if (!TelescopeRates.TryGetValue(tier, out double hourlyRate))
+        {
+            return JsonSerializer.Serialize(new JsonObject { ["error"] = $"Unknown telescope tier '{telescopeTier}'. Choose from: {string.Join(", ", TelescopeRates.Keys)}" });
+        }
+
+        if (!PriorityMultipliers.TryGetValue(pri, out double multiplier))
+        {
+            return JsonSerializer.Serialize(new JsonObject { ["error"] = $"Unknown priority '{priority}'. Choose from: {string.Join(", ", PriorityMultipliers.Keys)}" });
+        }
+
+        if (hours <= 0)
+        {
+            return JsonSerializer.Serialize(new JsonObject { ["error"] = "Hours must be greater than zero." });
+        }
+
+        double baseCost = hourlyRate * hours;
+        double totalCost = baseCost * multiplier;
+
+        return JsonSerializer.Serialize(new JsonObject
+        {
+            ["telescope_tier"] = tier,
+            ["hours"] = hours,
+            ["hourly_rate"] = hourlyRate,
+            ["priority"] = pri,
+            ["priority_multiplier"] = multiplier,
+            ["base_cost"] = baseCost,
+            ["total_cost"] = totalCost,
+        });
+    }
+
+    [Description("Generate a report summarizing an astronomical observation.")]
+    public static string GenerateObservationReport(
+        [Description("The name of the astronomical event being observed")] string eventName,
+        [Description("The location of the observer")] string location,
+        [Description("The tier of the telescope used for the observation (e.g. 'standard', 'advanced', 'premium')")] string telescopeTier,
+        [Description("The number of hours the telescope was used for the observation")] double hours,
+        [Description("The priority level of the observation (e.g. 'low', 'normal', 'high')")] string priority,
+        [Description("The name of the person who conducted the observation")] string observerName)
+    {
+        JsonNode costResult = JsonNode.Parse(CalculateObservationCost(telescopeTier, hours, priority))!;
+        if (costResult["error"] is not null)
+        {
+            return costResult.ToJsonString();
+        }
+
+        JsonNode eventResult = JsonNode.Parse(NextVisibleEvent(location))!;
+
+        DateTime now = DateTime.Now;
+        string timestamp = now.ToString("yyyy-MM-dd HH:mm");
+        string filename = $"report_{eventName.Replace(' ', '_').ToLowerInvariant()}_{now:yyyy-MM-dd_HHmm}.txt";
+
+        double hourlyRate = (double)costResult["hourly_rate"]!;
+        double baseCost = (double)costResult["base_cost"]!;
+        double totalCost = (double)costResult["total_cost"]!;
+
+        string report = $"""
+            ======================================
+              CONTOSO OBSERVATORIES - SESSION REPORT
+            ======================================
+            Date:           {timestamp}
+            Observer:       {observerName}
+            Event:          {eventName}
+            Location:       {location}
+
+            NEXT VISIBLE EVENT
+              Event:        {(string?)eventResult["event"] ?? "N/A"}
+              Date:         {(string?)eventResult["date"] ?? "N/A"}
+
+            TELESCOPE BOOKING
+              Tier:         {(string?)costResult["telescope_tier"]}
+              Hours:        {(double)costResult["hours"]!}
+              Hourly Rate:  ${hourlyRate:F2}
+              Priority:     {(string?)costResult["priority"]}
+              Multiplier:   {(double)costResult["priority_multiplier"]!}x
+
+            COST SUMMARY
+              Base Cost:    ${baseCost:F2}
+              Total Cost:   ${totalCost:F2}
+            ======================================
+
+            """;
+
+        File.WriteAllText(filename, report);
+
+        return JsonSerializer.Serialize(new JsonObject { ["status"] = "Report generated", ["file"] = filename });
+    }
+
+    private static List<(string, string, int, string, HashSet<string>)> LoadEvents(string path)
+    {
+        var events = new List<(string, string, int, string, HashSet<string>)>();
+
+        foreach (string line in File.ReadAllLines(path))
+        {
+            string[] parts = line.Trim().Split('|');
+            if (parts.Length != 4)
+            {
+                continue;
+            }
+
+            string[] monthDay = parts[2].Split('-');
+            int sortKey = int.Parse(monthDay[0]) * 100 + int.Parse(monthDay[1]);
+            var locations = parts[3].Split(';').ToHashSet();
+
+            events.Add((parts[0], parts[1], sortKey, parts[2], locations));
+        }
+
+        return events.OrderBy(e => e.Item3).ToList();
+    }
+
+    private static Dictionary<string, double> LoadRates(string path)
+    {
+        var rates = new Dictionary<string, double>();
+
+        foreach (string line in File.ReadAllLines(path))
+        {
+            string[] parts = line.Trim().Split('|');
+            if (parts.Length == 2)
+            {
+                rates[parts[0]] = double.Parse(parts[1]);
+            }
+        }
+
+        return rates;
+    }
+}

--- a/Labfiles/02-agent-custom-tools/CSharp/Program.cs
+++ b/Labfiles/02-agent-custom-tools/CSharp/Program.cs
@@ -1,0 +1,111 @@
+// Astronomy agent client -- C# / Microsoft Agent Framework port of the Python agent.py sample.
+// Defines an agent with custom function tools (see Functions.cs) and chats with it from the
+// console. Unlike the Python sample, the Agent Framework generates each tool's JSON schema
+// from the C# method signature and [Description] attributes, and handles the function-call /
+// function-result loop automatically -- there's no manual "walk response.output, dispatch by
+// name, resend as function_call_output" loop here.
+
+using Azure.AI.Projects;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+LoadDotEnv();
+
+string? projectEndpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
+string? modelDeployment = Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT_NAME");
+
+if (string.IsNullOrWhiteSpace(projectEndpoint) || projectEndpoint == "your_project_endpoint_here")
+{
+    Console.WriteLine("Error: PROJECT_ENDPOINT environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+if (string.IsNullOrWhiteSpace(modelDeployment))
+{
+    Console.WriteLine("Error: MODEL_DEPLOYMENT_NAME environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+// AzureCliCredential (rather than DefaultAzureCredential) talks to the "az login" session
+// directly. DefaultAzureCredential also tries ManagedIdentityCredential first, which can throw
+// (instead of just being "unavailable") on machines without IMDS -- e.g. WSL -- aborting the
+// credential chain before it ever reaches AzureCliCredential.
+AIProjectClient projectClient = new(new Uri(projectEndpoint), new AzureCliCredential());
+
+// Wrap each local method as a tool. AIFunctionFactory reads the method signature and
+// [Description] attributes to build the tool's JSON schema -- no hand-written schema needed.
+AITool[] tools =
+[
+    AIFunctionFactory.Create(Functions.NextVisibleEvent),
+    AIFunctionFactory.Create(Functions.CalculateObservationCost),
+    AIFunctionFactory.Create(Functions.GenerateObservationReport),
+];
+
+AIAgent agent = projectClient.AsAIAgent(
+    modelDeployment,
+    instructions: """
+        You are an astronomy observations assistant that helps users find
+        information about astronomical events and calculate telescope rental costs.
+        Use the available tools to assist users with their inquiries.
+        """,
+    name: "astronomy-agent",
+    tools: tools);
+
+AgentSession session = await agent.CreateSessionAsync();
+
+while (true)
+{
+    Console.Write("Enter a prompt for the astronomy agent. Use 'quit' to exit.\nUSER: ");
+    string userInput = (Console.ReadLine() ?? string.Empty).Trim();
+
+    if (userInput.Equals("quit", StringComparison.OrdinalIgnoreCase))
+    {
+        Console.WriteLine("Exiting chat.");
+        break;
+    }
+
+    if (userInput.Length == 0)
+    {
+        continue;
+    }
+
+    AgentResponse response = await agent.RunAsync(userInput, session);
+    Console.WriteLine($"AGENT: {response.Text}");
+}
+
+// Minimal ".env" loader so this project can reuse the same .env file format as
+// the Python sample, without adding a NuGet dependency just for that.
+static void LoadDotEnv()
+{
+    string envPath = Path.Combine(Directory.GetCurrentDirectory(), ".env");
+    if (!File.Exists(envPath))
+    {
+        return;
+    }
+
+    foreach (string rawLine in File.ReadAllLines(envPath))
+    {
+        string line = rawLine.Trim();
+        if (line.Length == 0 || line.StartsWith('#'))
+        {
+            continue;
+        }
+
+        int separatorIndex = line.IndexOf('=');
+        if (separatorIndex <= 0)
+        {
+            continue;
+        }
+
+        string key = line[..separatorIndex].Trim();
+        string value = line[(separatorIndex + 1)..].Trim().Trim('"');
+
+        if (Environment.GetEnvironmentVariable(key) is null)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/Labfiles/02-agent-custom-tools/CSharp/README.md
+++ b/Labfiles/02-agent-custom-tools/CSharp/README.md
@@ -1,0 +1,62 @@
+# Astronomy agent client (C# / Microsoft Agent Framework)
+
+This is a C# port of the [`Python/agent.py`](../Python/agent.py) client from this exercise, built with the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) instead of hand-written `azure-ai-projects` calls. It creates an astronomy assistant agent with three custom function tools (see [`Functions.cs`](Functions.cs), ported from [`Python/functions.py`](../Python/functions.py)) and chats with it from the console.
+
+> **Status**: pilot / community contribution. `Microsoft.Agents.AI.Foundry` is still prerelease, so APIs may change before GA.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download) or later
+- A Foundry project with a deployed model, per [Create a Foundry project with the Foundry Toolkit for VS Code extension](../../../Instructions/Exercises/02-agent-custom-tools.md#create-a-foundry-project-with-the-foundry-toolkit-for-vs-code-extension) and [Deploy a model](../../../Instructions/Exercises/02-agent-custom-tools.md#deploy-a-model)
+- The [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli), signed in with `az login`
+
+## Setup
+
+1. Duplicate `.env.example` and rename it to `.env`.
+
+2. In `.env`, replace the placeholders with your project endpoint and model deployment name:
+
+    ```
+   PROJECT_ENDPOINT=<your_project_endpoint>
+   MODEL_DEPLOYMENT_NAME=<your_model_deployment_name>
+    ```
+
+3. Sign in to Azure so `AzureCliCredential` can authenticate:
+
+    ```bash
+   az login
+    ```
+
+4. Restore and run:
+
+    ```bash
+   dotnet run
+    ```
+
+## Try it
+
+```
+What's the next visible event in Europe?
+```
+
+```
+How much would 3 hours on an advanced telescope with high priority cost?
+```
+
+```
+Generate a report for observing the Geminids Meteor Shower from Europe on a premium telescope, 2 hours, normal priority, for observer Alex Chen.
+```
+
+The generated report is written to the current directory, matching the Python sample's behavior. Type `quit` to exit.
+
+## How it maps to the Python sample
+
+| Python (`agent.py` / `functions.py`) | C# (`Program.cs` / `Functions.cs`) |
+| --- | --- |
+| Hand-written JSON schema for each `FunctionTool` | `[Description]` attributes + `AIFunctionFactory.Create(...)`, which reads the method signature via reflection |
+| `project_client.agents.create_version(...)` (persists a versioned agent server-side) | `AIProjectClient.AsAIAgent(model, instructions, name, tools)` (a code-owned, ephemeral agent -- no server-side agent resource) |
+| Manually walking `response.output` for `function_call` items, dispatching by name, and resending results as `function_call_output` | `agent.RunAsync(...)` -- the framework invokes the matching local method and continues automatically |
+| Manually created `conversation` + `previous_response_id` chaining | `AgentSession` from `agent.CreateSessionAsync()` |
+| `project_client.agents.delete_version(...)` cleanup at the end | Not needed -- nothing is persisted server-side |
+
+See [Function Tools](https://learn.microsoft.com/agent-framework/tools/function-tools) and [Microsoft Foundry provider docs](https://learn.microsoft.com/agent-framework/agents/providers/microsoft-foundry) for more on the patterns used here.

--- a/Labfiles/02-agent-custom-tools/CSharp/data/events.txt
+++ b/Labfiles/02-agent-custom-tools/CSharp/data/events.txt
@@ -1,0 +1,9 @@
+Quadrantids Meteor Shower|meteor_shower|01-03|north_america;europe;asia
+Annular Solar Eclipse|eclipse|02-17|south_america;africa;antarctica
+Total Lunar Eclipse|eclipse|03-03|north_america;europe;africa
+Lyrids Meteor Shower|meteor_shower|04-22|north_america;europe;asia
+Jupiter-Venus Conjunction|conjunction|05-01|north_america;south_america;europe;asia;africa;australia
+Saturn-Mars Conjunction|conjunction|07-10|north_america;south_america;europe;asia;africa;australia
+Partial Solar Eclipse|eclipse|08-12|europe;africa
+Perseids Meteor Shower|meteor_shower|08-12|north_america;europe;asia
+Geminids Meteor Shower|meteor_shower|12-14|north_america;south_america;europe;asia;africa;australia

--- a/Labfiles/02-agent-custom-tools/CSharp/data/priority_multipliers.txt
+++ b/Labfiles/02-agent-custom-tools/CSharp/data/priority_multipliers.txt
@@ -1,0 +1,4 @@
+low|1.00
+normal|1.25
+high|1.75
+urgent|2.50

--- a/Labfiles/02-agent-custom-tools/CSharp/data/telescope_rates.txt
+++ b/Labfiles/02-agent-custom-tools/CSharp/data/telescope_rates.txt
@@ -1,0 +1,3 @@
+standard|50.00
+advanced|120.00
+premium|300.00


### PR DESCRIPTION
## Summary

Second pilot in the same vein as #220 -- a C# port of `02-agent-custom-tools`, chosen next because it exercises a different capability than lab 01 did: client-defined **function tools**, rather than portal-configured hosted tools (file search / code interpreter).

- Adds `Labfiles/02-agent-custom-tools/CSharp/` alongside `Python/`: `Functions.cs` (three local function tools, ported 1:1 from `functions.py`) and `Program.cs` (the astronomy agent client).
- `[Description]` attributes on each method/parameter + `AIFunctionFactory.Create(...)` generate each tool's JSON schema straight from the C# method signature -- replacing the hand-written `FunctionTool(name=..., parameters={...json schema...})` dictionaries in `agent.py`.
- `AIProjectClient.AsAIAgent(model, instructions, name, tools)` creates the agent in one call, replacing the separate `FunctionTool` definitions + `PromptAgentDefinition` + `agents.create_version(...)` steps. This is the *ephemeral* "Responses Agent" pattern (code-owned, no server-side agent resource), not the versioned/persisted pattern lab 01 used to reference a portal-created agent -- it's the better match here since lab 02's agent and its tools are entirely defined in code, not in the portal.
- `agent.RunAsync(...)` handles the function-call / function-result loop internally -- no manual walk of `response.output` for `function_call` items, no manual `FunctionCallOutput` resend, no `previous_response_id` chaining. Also no equivalent of `agents.delete_version(...)` cleanup, since nothing is persisted server-side to begin with.
- Wired into `Instructions/Exercises/02-agent-custom-tools.md`: a Python/C# fork after the shared repo-clone step, `.NET 8 SDK` added as an alternate prerequisite, and (incidental, one-line) a copy-paste leftover fixed -- the doc said "...agent that uses MCP server tools..." in a lab that's about custom function tools, not MCP.
- `.gitignore` gets the same `bin/`/`obj/`/`.vs/`/`agent_outputs/` entries added in the lab 01 branch (#220) -- needed independently here since this branch was cut from `main` before that fix merged; harmless if both land (worst case a trivial merge conflict on `.gitignore`).

## Verification

- `dotnet build`: 0 warnings, 0 errors.
- Cross-checked `Functions.cs` against the actual `functions.py` for the same inputs (event lookup for a location with/without an upcoming event, cost calculation including both error paths, and report generation) -- outputs matched exactly.
- **Not yet run end-to-end against a live agent** -- only compile- and logic-verified, same caveat as #220 initially had.

## Caveats

- `Microsoft.Agents.AI.Foundry` is still prerelease (pinned to `1.16.0-preview.260730.1`).
- Same "no real tab widget in this Jekyll theme" caveat as #220 -- the language split in the doc is sequential `###` sections, not an interactive switcher.

## Test plan
- [x] `dotnet build` succeeds (net8.0, zero warnings/errors)
- [x] `Functions.cs` output cross-checked against `functions.py` for matching inputs
- [x] Manual run against a live Foundry project (not yet verified)