### PR TITLE
[Pilot] C# clients for 03-mcp-integration using Microsoft Agent Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,13 @@ Thumbs.db
 # Azure
 .azure/
 
+# .NET
+bin/
+obj/
+*.user
+.vs/
+
 # Output files
 analysis_results.json
 output.txt
+agent_outputs/

--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -22,7 +22,7 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) or later installed, **or** the [.NET 8 SDK](https://dotnet.microsoft.com/download) or later if you're following the C# version of the client application
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
 > \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.12.
@@ -96,6 +96,10 @@ For this exercise, you'll use starter code that will help you connect to your Fo
 1. When prompted, select **Open** to open the cloned repository in VS Code.
 
 1. Once the repository opens, select **File > Open Folder** and navigate to `mslearn-ai-agents/Labfiles/03-mcp-integration`, then choose **Select Folder**.
+
+This exercise provides starter code for both Python and C#. Follow the **Python** sections below to build the agents step by step, or skip to the **C#** section near the end if you're using C#.
+
+### Python
 
 1. In the Explorer pane, expand the **Python** folder to view the code files for this exercise.
 
@@ -535,6 +539,70 @@ In this task, you'll connect the MCP server tools to your agent so that it can c
 1. Enter `quit` to exit the application.
 
     You can also use `deactivate` to exit the Python virtual environment in the terminal.
+
+### C#
+
+> **Tip**: This C# client uses the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) (`Microsoft.Agents.AI.Foundry`) instead of hand-written `azure-ai-projects` calls. The package is still prerelease, so APIs may change before general availability.
+
+The C# version splits across three projects in the **CSharp** folder, matching the three Python files: **Agent** (equivalent to `agent.py`), **InventoryServer** (equivalent to `server.py`), and **InventoryClient** (equivalent to `client.py`). All three already contain a complete implementation -- there's no incremental "find the comment, add this code" flow like the Python steps above, so this section just walks through what each one does and how to run it.
+
+#### Connect to the remote MCP server (Agent)
+
+1. In the Explorer pane, expand the **CSharp** folder, then the **Agent** folder.
+
+1. Open **Program.cs** and review the code. Instead of `MCPTool(server_label=..., server_url=..., require_approval="always")`, it creates a `HostedMcpServerTool` with `ApprovalMode = HostedMcpServerToolApprovalMode.AlwaysRequire`, and passes it to `AIProjectClient.AsAIAgent(...)` as a tool. Just like the Python sample, Foundry calls the remote MCP server directly -- this is a *hosted* MCP tool, not a local one.
+
+1. Notice the approval loop: instead of manually walking `response.output` for `mcp_approval_request` items and resending `McpApprovalResponse`s, the code reads `ToolApprovalRequestContent` items off the response and calls `request.CreateResponse(approved: true)` for each one, looping with `agent.RunAsync(...)` until none remain -- the same automatic-approval behavior as the Python sample.
+
+1. In the Explorer pane, duplicate the **.env.example** file in the **Agent** folder and rename it to **.env**. Fill in `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` as you did for the Python `.env` file.
+
+1. Open a terminal in the **Agent** folder and sign in to Azure:
+
+    ```bash
+   az login
+    ```
+
+1. Run the application:
+
+    ```bash
+   dotnet run
+    ```
+
+    You should see output similar to the Python version -- the agent using the remote MCP server to answer the fixed prompt about creating an Azure Container App with a managed identity.
+
+#### Create and connect to a custom MCP server (InventoryServer and InventoryClient)
+
+1. In the Explorer pane, expand the **InventoryServer** folder and open **InventoryTools.cs**. This is the C# equivalent of `server.py`: `[McpServerToolType]` marks the class as a tool container, and `[McpServerTool]` marks `GetInventoryLevels` and `GetWeeklySales` as discoverable tools -- the same role `@mcp.tool()` plays in the Python version. Open **Program.cs** to see the few lines of hosting setup (`AddMcpServer().WithStdioServerTransport().WithTools<InventoryTools>()`) that start the server over stdio, replacing `FastMCP` and `mcp.run(...)`.
+
+1. Expand the **InventoryClient** folder and open **Program.cs**. Compare this with `client.py`:
+    - `McpClient.CreateAsync(new StdioClientTransport(...))` starts `InventoryServer` as a subprocess and connects to it, the same role `StdioServerParameters` and `stdio_client(...)` play in Python
+    - `mcpTools.Cast<AITool>()` hands the discovered tools straight to `AIProjectClient.AsAIAgent(...)` -- there's no equivalent of `make_tool_func`, the hand-written `FunctionTool` JSON schemas, or the manual `function_call` dispatch loop, because `McpClientTool` already implements `AITool`
+
+1. In the **InventoryClient** folder, duplicate **.env.example** and rename it to **.env**. Fill in `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`. **InventoryServer** doesn't need its own `.env` -- it has no Azure dependency at all.
+
+1. Open a terminal in the **InventoryClient** folder and sign in to Azure:
+
+    ```bash
+   az login
+    ```
+
+1. Run the client (this automatically starts **InventoryServer** as a subprocess -- you don't need to run it separately):
+
+    ```bash
+   dotnet run
+    ```
+
+1. Try the same prompts as the Python version, for example:
+
+    ```
+   Show me the current inventory levels for all products.
+    ```
+
+    ```
+   Are there any products that should be restocked?
+    ```
+
+1. Enter `quit` to exit the application.
 
 ## Clean up
 

--- a/Labfiles/03-mcp-integration/CSharp/Agent/.env.example
+++ b/Labfiles/03-mcp-integration/CSharp/Agent/.env.example
@@ -1,0 +1,11 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# Get this from the Foundry project
+# In VS Code, you can try Foundry Toolkit > right-click your active project > Copy Endpoint
+# If that option isn't available, copy the endpoint from the Microsoft Foundry portal project overview page
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (e.g. gpt-5)
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here

--- a/Labfiles/03-mcp-integration/CSharp/Agent/Agent.csproj
+++ b/Labfiles/03-mcp-integration/CSharp/Agent/Agent.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.16.0-preview.260730.1" />
+  </ItemGroup>
+
+</Project>

--- a/Labfiles/03-mcp-integration/CSharp/Agent/Program.cs
+++ b/Labfiles/03-mcp-integration/CSharp/Agent/Program.cs
@@ -1,0 +1,113 @@
+// Remote MCP server client -- C# / Microsoft Agent Framework port of the Python agent.py sample.
+// Connects an agent to the Microsoft Learn Docs remote MCP server (a *hosted* MCP tool: Foundry
+// itself calls the remote server, not this client) and automatically approves each tool call the
+// agent wants to make, matching agent.py's require_approval="always" + auto-approve loop.
+
+using Azure.AI.Projects;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+LoadDotEnv();
+
+string? projectEndpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
+string? modelDeployment = Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT_NAME");
+
+if (string.IsNullOrWhiteSpace(projectEndpoint) || projectEndpoint == "your_project_endpoint_here")
+{
+    Console.WriteLine("Error: PROJECT_ENDPOINT environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+if (string.IsNullOrWhiteSpace(modelDeployment))
+{
+    Console.WriteLine("Error: MODEL_DEPLOYMENT_NAME environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+// AzureCliCredential talks to the "az login" session directly. DefaultAzureCredential also tries
+// ManagedIdentityCredential first, which can throw (instead of just being "unavailable") on
+// machines without IMDS -- e.g. WSL -- aborting the credential chain before it ever reaches
+// AzureCliCredential.
+AIProjectClient projectClient = new(new Uri(projectEndpoint), new AzureCliCredential());
+
+// This connects to the Microsoft Learn Docs remote MCP server -- a cloud-hosted service that
+// enables clients to access trusted and up-to-date information directly from Microsoft's
+// official documentation. Because Foundry calls this server directly (a "hosted" MCP tool),
+// there's no local MCP client/session here -- compare with InventoryClient, which uses a *local*
+// MCP tool instead.
+var mcpTool = new HostedMcpServerTool(serverName: "api-specs", serverAddress: "https://learn.microsoft.com/api/mcp")
+{
+    ApprovalMode = HostedMcpServerToolApprovalMode.AlwaysRequire,
+};
+
+AIAgent agent = projectClient.AsAIAgent(
+    modelDeployment,
+    instructions: "You are a helpful agent that can use MCP tools to assist users. Use the available MCP tools to answer questions and perform tasks.",
+    name: "MyAgent",
+    tools: [mcpTool]);
+
+Console.WriteLine($"Agent created (name: {agent.Name})");
+
+AgentSession session = await agent.CreateSessionAsync();
+
+AgentResponse response = await agent.RunAsync(
+    "Give me the Azure CLI commands to create an Azure Container App with a managed identity.",
+    session);
+
+// The agent may issue several tool calls, each needing its own approval, so we loop until
+// there are none left -- mirroring the Python sample's "while True" approval loop.
+List<ToolApprovalRequestContent> approvalRequests = response.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>().ToList();
+
+while (approvalRequests.Count > 0)
+{
+    // Automatically approve every MCP request to allow the agent to proceed.
+    List<ChatMessage> approvals = approvalRequests
+        .Select(request => new ChatMessage(ChatRole.User, [request.CreateResponse(approved: true)]))
+        .ToList();
+
+    response = await agent.RunAsync(approvals, session);
+    approvalRequests = response.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>().ToList();
+}
+
+Console.WriteLine($"\nAgent response: {response.Text}");
+
+// No cleanup step here -- AsAIAgent(model, instructions, name, tools) doesn't persist a
+// server-side agent resource the way the Python sample's agents.create_version(...) does, so
+// there's nothing in the Foundry project to delete (see the CSharp/README.md for details).
+
+// Minimal ".env" loader so this project can reuse the same .env file format as
+// the Python sample, without adding a NuGet dependency just for that.
+static void LoadDotEnv()
+{
+    string envPath = Path.Combine(Directory.GetCurrentDirectory(), ".env");
+    if (!File.Exists(envPath))
+    {
+        return;
+    }
+
+    foreach (string rawLine in File.ReadAllLines(envPath))
+    {
+        string line = rawLine.Trim();
+        if (line.Length == 0 || line.StartsWith('#'))
+        {
+            continue;
+        }
+
+        int separatorIndex = line.IndexOf('=');
+        if (separatorIndex <= 0)
+        {
+            continue;
+        }
+
+        string key = line[..separatorIndex].Trim();
+        string value = line[(separatorIndex + 1)..].Trim().Trim('"');
+
+        if (Environment.GetEnvironmentVariable(key) is null)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/Labfiles/03-mcp-integration/CSharp/InventoryClient/.env.example
+++ b/Labfiles/03-mcp-integration/CSharp/InventoryClient/.env.example
@@ -1,0 +1,11 @@
+# Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Microsoft Foundry Project Endpoint
+# Get this from the Foundry project
+# In VS Code, you can try Foundry Toolkit > right-click your active project > Copy Endpoint
+# If that option isn't available, copy the endpoint from the Microsoft Foundry portal project overview page
+PROJECT_ENDPOINT=your_project_endpoint_here
+
+# The name of your deployed model (e.g. gpt-5)
+MODEL_DEPLOYMENT_NAME=your_model_deployment_name_here

--- a/Labfiles/03-mcp-integration/CSharp/InventoryClient/InventoryClient.csproj
+++ b/Labfiles/03-mcp-integration/CSharp/InventoryClient/InventoryClient.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.16.0-preview.260730.1" />
+    <PackageReference Include="ModelContextProtocol" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Labfiles/03-mcp-integration/CSharp/InventoryClient/Program.cs
+++ b/Labfiles/03-mcp-integration/CSharp/InventoryClient/Program.cs
@@ -1,0 +1,123 @@
+// Local MCP client -- C# / Microsoft Agent Framework port of the Python client.py sample.
+// Spawns InventoryServer as a subprocess over stdio, discovers its tools, and hands them
+// straight to an agent as local MCP tools.
+//
+// Compare with Agent/Program.cs: that project uses a *hosted* MCP tool (Foundry calls the
+// remote server directly). Here, this client owns the MCP session and the Agent Framework
+// invokes each tool call locally -- there's no manual "wrap each tool in a function, build a
+// FunctionTool JSON schema, walk response.output for function_call items" like client.py does;
+// McpClientTool already implements AITool, so the discovered tools can be passed to the agent
+// as-is.
+
+using Azure.AI.Projects;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Client;
+
+LoadDotEnv();
+
+string? projectEndpoint = Environment.GetEnvironmentVariable("PROJECT_ENDPOINT");
+string? modelDeployment = Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT_NAME");
+
+if (string.IsNullOrWhiteSpace(projectEndpoint) || projectEndpoint == "your_project_endpoint_here")
+{
+    Console.WriteLine("Error: PROJECT_ENDPOINT environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+if (string.IsNullOrWhiteSpace(modelDeployment))
+{
+    Console.WriteLine("Error: MODEL_DEPLOYMENT_NAME environment variable not set");
+    Console.WriteLine("Please set it in your .env file or environment");
+    return;
+}
+
+// Start the MCP server. In a standard production setup the server would run separately from
+// the client, but for this lab the client is responsible for starting it, using stdio as a
+// lightweight communication channel -- same tradeoff client.py makes with StdioServerParameters.
+await using McpClient mcpClient = await McpClient.CreateAsync(new StdioClientTransport(new()
+{
+    Name = "Inventory",
+    Command = "dotnet",
+    Arguments = ["run", "--project", "../InventoryServer"],
+}));
+
+// List available tools
+IList<McpClientTool> mcpTools = await mcpClient.ListToolsAsync();
+Console.WriteLine($"\nConnected to server with tools: {string.Join(", ", mcpTools.Select(t => t.Name))}");
+
+// AzureCliCredential talks to the "az login" session directly. DefaultAzureCredential also tries
+// ManagedIdentityCredential first, which can throw (instead of just being "unavailable") on
+// machines without IMDS -- e.g. WSL -- aborting the credential chain before it ever reaches
+// AzureCliCredential.
+AIProjectClient projectClient = new(new Uri(projectEndpoint), new AzureCliCredential());
+
+// McpClientTool already implements AITool, so the tools discovered from the MCP session can be
+// handed to the agent directly -- no per-tool JSON schema or dispatch function needed.
+AIAgent agent = projectClient.AsAIAgent(
+    modelDeployment,
+    instructions: """
+        You are an inventory assistant. Here are some general guidelines:
+        - Recommend restock if item inventory < 10 and weekly sales > 15
+        - Recommend clearance if item inventory > 20 and weekly sales < 5
+        """,
+    name: "inventory-agent",
+    tools: [.. mcpTools.Cast<AITool>()]);
+
+AgentSession session = await agent.CreateSessionAsync();
+
+while (true)
+{
+    Console.Write("Enter a prompt for the inventory agent. Use 'quit' to exit.\nUSER: ");
+    string userInput = (Console.ReadLine() ?? string.Empty).Trim();
+
+    if (userInput.Equals("quit", StringComparison.OrdinalIgnoreCase))
+    {
+        Console.WriteLine("Exiting chat.");
+        break;
+    }
+
+    if (userInput.Length == 0)
+    {
+        continue;
+    }
+
+    AgentResponse response = await agent.RunAsync(userInput, session);
+    Console.WriteLine($"Agent response: {response.Text}");
+}
+
+// Minimal ".env" loader so this project can reuse the same .env file format as
+// the Python sample, without adding a NuGet dependency just for that.
+static void LoadDotEnv()
+{
+    string envPath = Path.Combine(Directory.GetCurrentDirectory(), ".env");
+    if (!File.Exists(envPath))
+    {
+        return;
+    }
+
+    foreach (string rawLine in File.ReadAllLines(envPath))
+    {
+        string line = rawLine.Trim();
+        if (line.Length == 0 || line.StartsWith('#'))
+        {
+            continue;
+        }
+
+        int separatorIndex = line.IndexOf('=');
+        if (separatorIndex <= 0)
+        {
+            continue;
+        }
+
+        string key = line[..separatorIndex].Trim();
+        string value = line[(separatorIndex + 1)..].Trim().Trim('"');
+
+        if (Environment.GetEnvironmentVariable(key) is null)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/Labfiles/03-mcp-integration/CSharp/InventoryServer/InventoryServer.csproj
+++ b/Labfiles/03-mcp-integration/CSharp/InventoryServer/InventoryServer.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+  </ItemGroup>
+
+</Project>

--- a/Labfiles/03-mcp-integration/CSharp/InventoryServer/InventoryTools.cs
+++ b/Labfiles/03-mcp-integration/CSharp/InventoryServer/InventoryTools.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+
+namespace InventoryServer;
+
+// C# port of the tools defined in server.py. [McpServerToolType] marks this class as a
+// container for tools; [McpServerTool] marks each method as one, discoverable the same way
+// functions.py's functions become discoverable when decorated with @mcp.tool().
+[McpServerToolType]
+public sealed class InventoryTools
+{
+    [McpServerTool, Description("Returns current inventory for all products.")]
+    public static string GetInventoryLevels() => JsonSerializer.Serialize(new Dictionary<string, int>
+    {
+        ["Moisturizer"] = 6,
+        ["Shampoo"] = 8,
+        ["Body Spray"] = 28,
+        ["Hair Gel"] = 5,
+        ["Lip Balm"] = 12,
+        ["Skin Serum"] = 9,
+        ["Cleanser"] = 30,
+        ["Conditioner"] = 3,
+        ["Setting Powder"] = 17,
+        ["Dry Shampoo"] = 45,
+    });
+
+    [McpServerTool, Description("Returns number of units sold last week.")]
+    public static string GetWeeklySales() => JsonSerializer.Serialize(new Dictionary<string, int>
+    {
+        ["Moisturizer"] = 22,
+        ["Shampoo"] = 18,
+        ["Body Spray"] = 3,
+        ["Hair Gel"] = 2,
+        ["Lip Balm"] = 14,
+        ["Skin Serum"] = 19,
+        ["Cleanser"] = 4,
+        ["Conditioner"] = 1,
+        ["Setting Powder"] = 13,
+        ["Dry Shampoo"] = 17,
+    });
+}

--- a/Labfiles/03-mcp-integration/CSharp/InventoryServer/Program.cs
+++ b/Labfiles/03-mcp-integration/CSharp/InventoryServer/Program.cs
@@ -1,0 +1,20 @@
+// Custom MCP server -- C# port of server.py. Hosts the same two tools (inventory levels, weekly
+// sales) over stdio, using the official ModelContextProtocol SDK instead of Python's FastMCP.
+// Run standalone to test manually, or let InventoryClient spawn it automatically.
+
+using InventoryServer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddMcpServer()
+    .WithStdioServerTransport()
+    .WithTools<InventoryTools>();
+
+// stdout is reserved for the MCP protocol -- route logs to stderr, same reason server.py
+// passes show_banner=False to mcp.run().
+builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+await builder.Build().RunAsync();

--- a/Labfiles/03-mcp-integration/CSharp/README.md
+++ b/Labfiles/03-mcp-integration/CSharp/README.md
@@ -1,0 +1,66 @@
+# MCP integration clients (C# / Microsoft Agent Framework)
+
+C# ports of the Python samples in this exercise, built with the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) instead of hand-written `azure-ai-projects` calls. There are three projects, matching the three Python files:
+
+| Project | Python equivalent | What it does |
+| --- | --- | --- |
+| [`Agent/`](Agent) | [`agent.py`](../Python/agent.py) | Connects an agent to the remote Microsoft Learn Docs MCP server (a **hosted** MCP tool -- Foundry calls the remote server directly) and auto-approves each tool call |
+| [`InventoryServer/`](InventoryServer) | [`server.py`](../Python/server.py) | A custom MCP server exposing inventory/sales tools over stdio |
+| [`InventoryClient/`](InventoryClient) | [`client.py`](../Python/client.py) | Spawns `InventoryServer`, discovers its tools, and hands them to an agent as **local** MCP tools |
+
+> **Status**: pilot / community contribution. `Microsoft.Agents.AI.Foundry` is still prerelease, so APIs may change before GA.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download) or later
+- A Foundry project with a deployed model, per [Create a Foundry project with the Foundry Toolkit for VS Code extension](../../../Instructions/Exercises/03-mcp-integration.md#create-a-foundry-project-with-the-foundry-toolkit-for-vs-code-extension) and [Deploy a model](../../../Instructions/Exercises/03-mcp-integration.md#deploy-a-model)
+- The [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli), signed in with `az login`
+
+## Running the remote MCP server sample
+
+1. In `Agent/`, duplicate `.env.example` as `.env` and fill in `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`.
+2. `az login`
+3. From `Agent/`, run:
+
+    ```bash
+   dotnet run
+    ```
+
+   It sends one fixed prompt (matching `agent.py`), auto-approves the MCP tool calls it triggers, and prints the response.
+
+## Running the custom MCP server + client sample
+
+1. In `InventoryClient/`, duplicate `.env.example` as `.env` and fill in `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`. `InventoryServer` doesn't need its own `.env` -- it has no Azure dependency at all, only `InventoryClient` does.
+2. `az login`
+3. From `InventoryClient/`, run:
+
+    ```bash
+   dotnet run
+    ```
+
+   This spawns `InventoryServer` as a subprocess automatically (via `dotnet run --project ../InventoryServer`) -- you don't need to start it separately. Try prompts like:
+
+    ```
+   Show me the current inventory levels for all products.
+    ```
+
+    ```
+   Are there any products that should be restocked?
+    ```
+
+   Type `quit` to exit.
+
+   You can also run `InventoryServer` on its own (`dotnet run` from that folder) to sanity-check it starts without errors, though it won't print anything useful to a terminal since it's speaking the MCP protocol over stdio.
+
+## How it maps to the Python sample
+
+| Python | C# |
+| --- | --- |
+| `MCPTool(server_label=..., server_url=..., require_approval="always")` | `new HostedMcpServerTool(serverName:, serverAddress:) { ApprovalMode = HostedMcpServerToolApprovalMode.AlwaysRequire }` |
+| Manually walking `response.output` for `mcp_approval_request` items and resending `McpApprovalResponse`s | `response.Messages...OfType<ToolApprovalRequestContent>()` + `request.CreateResponse(approved: true)`, resent via `agent.RunAsync(approvals, session)` |
+| `FastMCP` + `@mcp.tool()` | `[McpServerToolType]` on the class, `[McpServerTool]` on each method (official [ModelContextProtocol](https://www.nuget.org/packages/ModelContextProtocol) SDK) |
+| `StdioServerParameters(command="python", args=["server.py"])` + `stdio_client(...)` | `McpClient.CreateAsync(new StdioClientTransport(new() { Command = "dotnet", Arguments = ["run", "--project", "../InventoryServer"] }))` |
+| Manually wrapping each MCP tool in a Python function, hand-writing a `FunctionTool` JSON schema for it, and dispatching `function_call` items by name | `mcpTools.Cast<AITool>()` -- `McpClientTool` already implements `AITool`, so the discovered tools go straight to the agent |
+| `project_client.agents.create_version(...)` (persists a versioned agent server-side) | `AIProjectClient.AsAIAgent(model, instructions, name, tools)` (a code-owned, ephemeral agent -- no server-side agent resource, so no `delete_version` cleanup either) |
+
+See [Hosted MCP Tools](https://learn.microsoft.com/agent-framework/tools/hosted-mcp-tools), [Local MCP Tools](https://learn.microsoft.com/agent-framework/tools/local-mcp-tools), and the [ModelContextProtocol C# SDK](https://github.com/modelcontextprotocol/csharp-sdk) for more on the patterns used here.


### PR DESCRIPTION
## Summary

Third pilot in the same series as #220 and #222 -- a C# port of `03-mcp-integration`, which exercises two more distinct capabilities: **hosted** MCP tools (server-calls-server, with an approval flow) and **local** MCP tools (client owns the MCP session, spawning its own server).

Adds `Labfiles/03-mcp-integration/CSharp/` with three projects, matching the three Python files:

- **`Agent/`** (matches `agent.py`): connects to the remote Microsoft Learn Docs MCP server as a *hosted* MCP tool via `HostedMcpServerTool` with `ApprovalMode = HostedMcpServerToolApprovalMode.AlwaysRequire`. The approval loop reads `ToolApprovalRequestContent` items off the response and calls `request.CreateResponse(approved: true)` for each, looping via `agent.RunAsync(...)` until none remain -- replacing the manual `mcp_approval_request` / `McpApprovalResponse` walk in `agent.py`.
- **`InventoryServer/`** (matches `server.py`): a custom MCP server built with the official [ModelContextProtocol](https://github.com/modelcontextprotocol/csharp-sdk) SDK -- `[McpServerToolType]` on the class, `[McpServerTool]` on each method, hosted via `AddMcpServer().WithStdioServerTransport()` -- instead of `FastMCP`. Exposes the same two tools (`get_inventory_levels`, `get_weekly_sales`).
- **`InventoryClient/`** (matches `client.py`): spawns `InventoryServer` as a subprocess via `StdioClientTransport` (`dotnet run --project ../InventoryServer`, mirroring `StdioServerParameters(command="python", args=["server.py"])`), discovers its tools, and passes them to `AIProjectClient.AsAIAgent(...)` directly via `mcpTools.Cast<AITool>()`. `McpClientTool` already implements `AITool`, so there's no equivalent of `client.py`'s `make_tool_func` wrapping, hand-written `FunctionTool` JSON schemas, or manual `function_call` dispatch loop.

Also wires a Python/C# fork into `Instructions/Exercises/03-mcp-integration.md` (after the shared repo-clone step, before the shared Clean up section), adds `.NET 8 SDK` as an alternate prerequisite, and extends `.gitignore` for `bin`/`obj`/`.vs`/`agent_outputs` (same fix as the lab 01 and 02 branches, needed independently here since this branch was cut from `main` before those merged).

## Verification

- `dotnet build` on all three projects: 0 warnings, 0 errors.
- **End-to-end tested the MCP transport itself**: ran `InventoryClient` with placeholder Azure credentials and confirmed it successfully spawned `InventoryServer` as a subprocess, completed the MCP handshake, and listed its tools -- `get_inventory_levels, get_weekly_sales`, matching the Python server's tool names exactly (the SDK's default name conversion from `GetInventoryLevels` matches FastMCP's snake_case convention). Only the actual live agent conversation (Azure auth + model calls) is unverified, same caveat as #220/#222.

## Caveats

- `Microsoft.Agents.AI.Foundry` is still prerelease (pinned to `1.16.0-preview.260730.1`).
- Same "no real tab widget in this Jekyll theme" caveat as the other two pilots -- the language split in the doc is sequential `###`/`####` sections, not an interactive switcher.

## Test plan
- [x] `dotnet build` succeeds on all three projects (net8.0, zero warnings/errors)
- [x] MCP stdio handshake verified end-to-end: `InventoryClient` spawns `InventoryServer` and lists its tools correctly
- [ ] Manual run against a live Foundry project / remote MCP server (not yet verified)