### PR TITLE
Fix check_env.py working-directory and python-dotenv dependency bugs in Labs A/B/C

### DIFF
--- a/Instructions/Exercises/A0-getting-started.md
+++ b/Instructions/Exercises/A0-getting-started.md
@@ -84,8 +84,8 @@ creates the Foundry resource, a project, and a model deployment for you.
 
     > **Note**: This provisions the resources but does **not** create the grounded portal
     > agent — Task 1 does that. If you're starting at Task 3, run
-    > `python setup/bootstrap_agent.py` after `azd up` to create it. When you're done with
-    > the lab, run `azd down` to delete everything it created.
+    > `python ../setup/bootstrap_agent.py` from the `Python` folder after `azd up` to create
+    > it. When you're done with the lab, run `azd down` to delete everything it created.
 
 ## Get the starter code
 
@@ -112,14 +112,19 @@ creates the Foundry resource, a project, and a model deployment for you.
 ## Check you're ready for a task
 
 Each task needs specific values in your `.env`. Before starting a task, run the preflight
-check from the `Labfiles/A-build-and-extend-ai-agents` folder — it reads your `.env` and
+check from the `Python` folder you opened in VS Code — it reads your `.env` and
 tells you what (if anything) is missing:
 
 ```
-python setup/check_env.py --task 2
+python ../setup/check_env.py --task 2
 ```
 
-Swap `2` for the task number you're about to start. That's it — head to any task:
+Swap `2` for the task number you're about to start.
+
+> **Tip**: The preflight check uses only the Python standard library, so it's safe to run
+> before `pip install` and without the virtual environment active.
+
+That's it — head to any task:
 
 | Task | Page |
 | --- | --- |

--- a/Instructions/Exercises/A2-connect-a-remote-mcp-server.md
+++ b/Instructions/Exercises/A2-connect-a-remote-mcp-server.md
@@ -16,10 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project and the starter code. If you
 > haven't already, complete [Getting started](A0-getting-started.md) to create your project,
 > clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
-> Then, from the `Labfiles/A-build-and-extend-ai-agents` folder, verify you're ready:
+> Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 2
+python ../setup/check_env.py --task 2
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Instructions/Exercises/A3-call-your-agent-from-a-client-app.md
+++ b/Instructions/Exercises/A3-call-your-agent-from-a-client-app.md
@@ -18,17 +18,17 @@ lab:
 > clone the code, and set `PROJECT_ENDPOINT` in `Python/.env`.
 
 This task drives a **grounded agent**. The quickest way to get one is to create it in code —
-from the `Labfiles/A-build-and-extend-ai-agents` folder, run:
+from the `Python` folder you opened in VS Code, run:
 
 ```
-python setup/bootstrap_agent.py
+python ../setup/bootstrap_agent.py
 ```
 
 That creates and grounds `tailwind-agent` — including the **Code Interpreter** tool with the
 sales data already attached — and writes `AGENT_NAME` into your `.env`. Then verify you're ready:
 
 ```
-python setup/check_env.py --task 3
+python ../setup/check_env.py --task 3
 ```
 
 > **Already built the agent in [Task 1](A1-create-and-ground-an-agent.md)?** Use it instead
@@ -48,7 +48,7 @@ not the interface.
 
 **Set up:**
 
-If you ran `python setup/bootstrap_agent.py` above, your agent, its **Code Interpreter** tool,
+If you ran `python ../setup/bootstrap_agent.py` above, your agent, its **Code Interpreter** tool,
 and `AGENT_NAME` are already configured — activate your virtual environment
 (`.\labenv\Scripts\Activate.ps1`) and skip to **Try it first**.
 

--- a/Instructions/Exercises/A4-add-custom-function-tools.md
+++ b/Instructions/Exercises/A4-add-custom-function-tools.md
@@ -16,10 +16,11 @@ lab:
 > **Set up (start here):** This task needs a Foundry project and the starter code. If you
 > haven't already, complete [Getting started](A0-getting-started.md) to create your project,
 > clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. The
-> helper file `functions.py` is already in the starter folder. Then verify you're ready:
+> helper file `functions.py` is already in the starter folder. Then, from the `Python` folder
+> you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 4
+python ../setup/check_env.py --task 4
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Instructions/Exercises/A5-capstone-build-your-own-mcp-server.md
+++ b/Instructions/Exercises/A5-capstone-build-your-own-mcp-server.md
@@ -17,10 +17,11 @@ lab:
 > starter code. If you haven't already, complete [Getting started](A0-getting-started.md) to
 > create your project, clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`
 > in `Python/.env`. It reuses `functions.py` from [Task 4](A4-add-custom-function-tools.md) —
-> already in the starter folder, so you don't need to have finished Task 4. Then verify:
+> already in the starter folder, so you don't need to have finished Task 4. Then, from the
+> `Python` folder you opened in VS Code, verify:
 
 ```
-python setup/check_env.py --task 5
+python ../setup/check_env.py --task 5
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Instructions/Exercises/A6-promote-your-assistant-to-a-hosted-agent.md
+++ b/Instructions/Exercises/A6-promote-your-assistant-to-a-hosted-agent.md
@@ -16,10 +16,11 @@ lab:
 > **Set up (start here):** This task deploys code, so it needs a Foundry project, a deployed
 > model, and the **Azure Developer CLI (`azd`)**. If you haven't already, complete
 > [Getting started](A0-getting-started.md) to create your project and set `PROJECT_ENDPOINT`
-> and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. Then verify:
+> and `MODEL_DEPLOYMENT_NAME` in `Python/.env`. Then, from the `Python` folder you opened in
+> VS Code, verify:
 
 ```
-python setup/check_env.py --task 6
+python ../setup/check_env.py --task 6
 ```
 
 > You also need **`azd` 1.25.3 or later** and the Foundry extension. Install it once with:

--- a/Instructions/Exercises/B0-getting-started.md
+++ b/Instructions/Exercises/B0-getting-started.md
@@ -88,8 +88,8 @@ creates the Foundry resource, a project, and a model deployment for you.
 
     > **Note**: This provisions the resources but does **not** create the grounded knowledge
     > agent — Task 1 does that in the portal. If you want a grounded agent in code instead, run
-    > `python setup/bootstrap_agent.py` after `azd up`. When you're done with the lab, run
-    > `azd down` to delete everything it created.
+    > `python ../setup/bootstrap_agent.py` from the `Python` folder after `azd up`. When you're
+    > done with the lab, run `azd down` to delete everything it created.
 
 ## Get the starter code
 
@@ -116,14 +116,19 @@ creates the Foundry resource, a project, and a model deployment for you.
 ## Check you're ready for a task
 
 Each task needs specific values in your `.env`. Before starting a task, run the preflight
-check from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365` folder — it reads
+check from the `Python` folder you opened in VS Code — it reads
 your `.env` and tells you what (if anything) is missing:
 
 ```
-python setup/check_env.py --task 1
+python ../setup/check_env.py --task 1
 ```
 
-Swap `1` for the task number you're about to start. That's it — head to any task:
+Swap `1` for the task number you're about to start.
+
+> **Tip**: The preflight check uses only the Python standard library, so it's safe to run
+> before `pip install` and without the virtual environment active.
+
+That's it — head to any task:
 
 | Task | Page |
 | --- | --- |

--- a/Instructions/Exercises/B1-create-a-foundry-iq-knowledge-agent.md
+++ b/Instructions/Exercises/B1-create-a-foundry-iq-knowledge-agent.md
@@ -16,11 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project (with a deployed model) and the
 > starter code. If you haven't already, complete [Getting started](B0-getting-started.md) to
 > create your project, clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME`
-> in `Python/.env`. Then, from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365`
-> folder, verify you're ready:
+> in `Python/.env`. Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 1
+python ../setup/check_env.py --task 1
 ```
 
 > **Continuing from a previous task?** If your project, virtual environment, and `.env` are
@@ -398,7 +397,7 @@ python knowledge_chat_app.py
 A browser opens at `http://localhost:7860` with the **Tailwind Traders Staff Knowledge Assistant**. This variant **auto-approves** the Foundry IQ knowledge tool so the chat stays smooth. Ask it the same questions as above. Close the tab and press **Ctrl+C** to stop it.
 
 > **Fast-forward**: If you'd rather ground an agent in code instead of the portal, run
-> `python setup/bootstrap_agent.py` from the `Python` folder. It creates
+> `python ../setup/bootstrap_agent.py` from the `Python` folder. It creates
 > `tailwind-knowledge-agent`, grounds it on the six knowledge docs with File Search, and writes
 > `AGENT_NAME` to `.env`. The client code you run against it is identical.
 

--- a/Instructions/Exercises/B2-publish-to-microsoft-teams.md
+++ b/Instructions/Exercises/B2-publish-to-microsoft-teams.md
@@ -16,8 +16,8 @@ lab:
 > **Set up (start here):** This task publishes the grounded `tailwind-knowledge-agent` from
 > [Task 1](B1-create-a-foundry-iq-knowledge-agent.md). If you don't have that agent yet, complete
 > Task 1 first (or, for the quickest path, create and ground it in code with
-> `python setup/bootstrap_agent.py` from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365`
-> folder). You also need a **Microsoft 365 account with Teams access**. This task is completed
+> `python ../setup/bootstrap_agent.py` from the `Python` folder you opened in VS Code). You
+> also need a **Microsoft 365 account with Teams access**. This task is completed
 > entirely in the portal and Teams — no local code or `.env` file is required.
 
 > **Continuing from a previous task?** If you just finished Task 1 and your

--- a/Instructions/Exercises/B3-publish-to-microsoft-365-copilot.md
+++ b/Instructions/Exercises/B3-publish-to-microsoft-365-copilot.md
@@ -15,8 +15,8 @@ lab:
 
 > **Set up (start here):** This task publishes the grounded `tailwind-knowledge-agent` from
 > [Task 1](B1-create-a-foundry-iq-knowledge-agent.md). If you don't have that agent yet, complete
-> Task 1 first (or create and ground it in code with `python setup/bootstrap_agent.py` from the
-> `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365` folder). This task is completed
+> Task 1 first (or create and ground it in code with `python ../setup/bootstrap_agent.py` from
+> the `Python` folder you opened in VS Code). This task is completed
 > entirely in the portal and Copilot — no local code or `.env` file is required.
 
 > **Note**: This task requires a **Microsoft 365 Copilot license**. If you don't have one, you can

--- a/Instructions/Exercises/B4-work-iq-workplace-intelligence.md
+++ b/Instructions/Exercises/B4-work-iq-workplace-intelligence.md
@@ -16,11 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project (with a deployed model) and the
 > starter code. If you haven't already, complete [Getting started](B0-getting-started.md) to
 > create your project, clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in
-> `Python/.env`. Then, from the `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365`
-> folder, verify you're ready:
+> `Python/.env`. Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 4
+python ../setup/check_env.py --task 4
 ```
 
 > **Note**: This is an **optional/advanced** task that requires a **Microsoft 365 Copilot

--- a/Instructions/Exercises/C0-getting-started.md
+++ b/Instructions/Exercises/C0-getting-started.md
@@ -111,14 +111,19 @@ creates the Foundry resource, a project, and a model deployment for you.
 ## Check you're ready for a task
 
 Each task needs specific values in your `.env`. Before starting a task, run the preflight
-check from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder — it reads
+check from the `Python` folder you opened in VS Code — it reads
 your `.env` and tells you what (if anything) is missing:
 
 ```
-python setup/check_env.py --task 1
+python ../setup/check_env.py --task 1
 ```
 
-Swap `1` for the task number you're about to start. That's it — head to any task:
+Swap `1` for the task number you're about to start.
+
+> **Tip**: The preflight check uses only the Python standard library, so it's safe to run
+> before `pip install` and without the virtual environment active.
+
+That's it — head to any task:
 
 | Task | Page |
 | --- | --- |

--- a/Instructions/Exercises/C1-create-an-agent-with-a-tool.md
+++ b/Instructions/Exercises/C1-create-an-agent-with-a-tool.md
@@ -16,10 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project and the starter code. If you
 > haven't already, complete [Getting started](C0-getting-started.md) to create your project,
 > clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
-> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+> Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 1
+python ../setup/check_env.py --task 1
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Instructions/Exercises/C2-orchestrate-multiple-agents.md
+++ b/Instructions/Exercises/C2-orchestrate-multiple-agents.md
@@ -16,10 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project and the starter code. If you
 > haven't already, complete [Getting started](C0-getting-started.md) to create your project,
 > clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
-> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+> Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 2
+python ../setup/check_env.py --task 2
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Instructions/Exercises/C3-connect-remote-agents-with-a2a.md
+++ b/Instructions/Exercises/C3-connect-remote-agents-with-a2a.md
@@ -16,10 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project and the starter code. If you
 > haven't already, complete [Getting started](C0-getting-started.md) to create your project,
 > clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
-> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+> Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 3
+python ../setup/check_env.py --task 3
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Instructions/Exercises/C4-classify-and-route-a-ticket.md
+++ b/Instructions/Exercises/C4-classify-and-route-a-ticket.md
@@ -16,10 +16,10 @@ lab:
 > **Set up (start here):** This task needs a Foundry project and the starter code. If you
 > haven't already, complete [Getting started](C0-getting-started.md) to create your project,
 > clone the code, and set `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `Python/.env`.
-> Then, from the `Labfiles/C-build-multi-agent-solutions-with-agent-framework` folder, verify you're ready:
+> Then, from the `Python` folder you opened in VS Code, verify you're ready:
 
 ```
-python setup/check_env.py --task 4
+python ../setup/check_env.py --task 4
 ```
 
 > **Continuing from a previous task?** If you just finished an earlier task in the same

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/README.md
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/README.md
@@ -47,13 +47,15 @@ This lab can be completed end to end **or one task at a time**. Two things make 
   needs and how to fast-forward.
 - **Setup scripts** in `Labfiles/A-build-and-extend-ai-agents/setup/`:
   - `check_env.py --task N` — preflight-checks that `.env` has the keys task *N* needs.
+    Run it as `python ../setup/check_env.py --task N`.
   - `bootstrap_agent.py` — **fast-forwards Task 1 in code**: creates and grounds
     `tailwind-agent` (File Search on `Store_Policy.txt` + Code Interpreter on `weekly_sales.csv`)
     and writes `AGENT_NAME` to `.env`, so learners can start at **Task 3** without the portal.
     Idempotent; pass `--force` to recreate.
 
-Both scripts run from the **starter** `Python/` folder and use the shared virtual environment
-and `.env`.
+Both scripts run from the **starter** `Python/` folder (`Labfiles/A-build-and-extend-ai-agents/Python`,
+not `Solution/Python/`) and use the shared virtual environment and `.env`. That's why the paths
+above are `../setup/...` — `setup/` is a sibling of the starter `Python/` folder.
 
 ### Optional: provision infrastructure with azd
 
@@ -95,7 +97,7 @@ traceback prints in the terminal**.
 ### 3. Create the portal agent (Task 1 — required for Task 3)
 The Task 3 client loads an agent **by name** that you create in the portal:
 1. In the Foundry portal, create an agent named **`tailwind-agent`**.
-2. Ground it: upload **`Store_Policy.txt`** (from `Python/`) and give it instructions to
+2. Ground it: upload **`Store_Policy.txt`** (from `Solution/Python/`) and give it instructions to
    answer from store policy.
 3. For Task 3's chart demo, add the **Code interpreter** tool and upload **`weekly_sales.csv`**
    (from the same folder). Save the agent.
@@ -103,11 +105,12 @@ The Task 3 client loads an agent **by name** that you create in the portal:
 > Tasks 4 and 5 create their own agents in code (`trip-planner-agent`, `tailwind-assistant`)
 > and delete them on exit — no portal work needed for those.
 
-> **Shortcut**: instead of the portal steps above, run `python setup/bootstrap_agent.py` from
-> the `Python/` folder to create and ground `tailwind-agent` in code and write `AGENT_NAME`.
+> **Shortcut**: instead of the portal steps above, run `python ../setup/bootstrap_agent.py`
+> from the **starter** `Python/` folder (not `Solution/Python/`) to create and ground
+> `tailwind-agent` in code and write `AGENT_NAME`.
 
 ### 4. Set up the environment once (shared by all tasks)
-From the `Python/` folder:
+From this folder (`Solution/Python/`):
 ```
 python -m venv labenv
 .\labenv\Scripts\Activate.ps1        # Windows PowerShell
@@ -119,7 +122,7 @@ Then copy `.env.example` to `.env` and fill in the values (all tasks read the sa
 - `AGENT_NAME=tailwind-agent` — used by Task 3
 
 ### 5. Run each task
-All commands run from the single `Python/` folder:
+All commands run from the single `Solution/Python/` folder:
 
 | Task | Command | What you get |
 |------|---------|--------------|
@@ -140,5 +143,5 @@ agent" section in the exercise instructions.
 
 ## Quick sanity checks that DON'T need Azure
 - `python -m py_compile <file>` — all solution files compile.
-- From `Python/`: `python -c "import functions; print(functions.calculate_rental_cost('premium', 5, 'priority'))"`
+- From `Solution/Python/`: `python -c "import functions; print(functions.calculate_rental_cost('premium', 5, 'priority'))"`
   should show a total cost of **$1,875** (premium $300/day × 5 × priority 1.25).

--- a/Labfiles/A-build-and-extend-ai-agents/setup/bootstrap_agent.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/bootstrap_agent.py
@@ -3,9 +3,12 @@ Fast-forward setup for the Tailwind Traders lab.
 
 Task 3 needs the grounded agent you would normally build by hand in Task 1
 (and extend at the start of Task 3). If you're starting at Task 3 on its own,
-run this once to create that agent for you:
+run this once to create that agent for you.
 
-    python setup/bootstrap_agent.py
+Run it from the lab's starter code folder — Labfiles/A-build-and-extend-ai-agents/Python,
+the folder you open in VS Code — with the lab virtual environment active:
+
+    python ../setup/bootstrap_agent.py
 
 It reproduces, in code, exactly what Tasks 1 and 3 have you do in the portal:
 
@@ -142,7 +145,7 @@ def main():
         project_client.get_openai_client() as openai_client,
     ):
         if agent_exists(project_client) and not args.force:
-            print(f"\nAgent '{AGENT_NAME}' already exists — nothing to do.")
+            print(f"\nAgent '{AGENT_NAME}' already exists - nothing to do.")
             print("Re-run with --force to add a new grounded version.")
             set_env_value("AGENT_NAME", AGENT_NAME)
             print(f"Ensured AGENT_NAME={AGENT_NAME} in {ENV_PATH}")

--- a/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
@@ -269,8 +269,14 @@ def _scan_for_close(text, quote):
         # statement. end still says where parsing resumes.
         return contents, True, end, False
 
-    recovered, closed, end = _read_quoted(text, quote, escape_aware=False)
-    return recovered, closed, end, False
+    # Recovery. python-dotenv's value pattern failed to match, and it then
+    # resynchronises on the LAST occurrence of the quote character rather than
+    # the first, so everything up to that point is lost. Measured: keys after
+    # that final occurrence survive, and if there are none, nothing does.
+    last = text.rfind(quote, 1)
+    if last == -1:
+        return "", False, len(text), False
+    return text[1:last], True, last + 1, False
 
 
 def _read_quoted(text, quote, escape_aware):

--- a/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
@@ -39,44 +39,29 @@ from pathlib import Path
 def read_env_file(env_path):
     """Parse a .env file into a dict, using only the standard library.
 
-    Matches python-dotenv's dotenv_values() for every well-formed .env these
-    labs use: comments, blank lines, 'export KEY=value' (space or tab), single-
+    Matches python-dotenv's dotenv_values() for every .env shape these labs can
+    encounter: comments, blank lines, 'export KEY=value' (space or tab), single-
     and double-quoted values, escape sequences inside double quotes, inline
-    comments after a value, and bare keys (value None). Returns an empty dict
-    if the file cannot be read.
+    comments, values quoted across several lines, and bare keys (value None).
 
     Matching python-dotenv matters because the lab apps load .env with
-    python-dotenv: whatever it returns is what the app actually sees, so the
-    preflight has to agree with it rather than be a "better" parser.
+    python-dotenv. Whatever it returns is what the app actually sees, so the
+    preflight has to agree with it rather than be a "better" parser -- a parser
+    that is more forgiving than the runtime reports keys as present that the
+    app cannot read.
 
-    Malformed files are handled by find_env_problems() instead -- see the note
-    there for why this function does not try to imitate python-dotenv's
-    behaviour on broken input.
+    Returns an empty dict if the file cannot be read.
     """
     values, _ = _parse(env_path)
     return values
 
 
 def find_env_problems(env_path):
-    """Return a list of (summary, advice) for defects that break the lab apps.
+    """Return a list of (summary, advice) for defects that always break the app.
 
-    Some .env defects do not make a key "missing" so much as make the file
-    unusable in ways the learner cannot see. For those we refuse to give a
-    per-key verdict at all: reporting "[OK] PROJECT_ENDPOINT" for a file the
-    app cannot read would be a false positive, and reporting unrelated keys as
-    MISSING would send the learner hunting the wrong problem. Instead we name
-    the defect, explain the cause, and exit non-zero.
-
-    Detected:
-
-    * UTF-8 BOM. python-dotenv does not strip it, so it becomes part of the
-      first setting's NAME and the app's os.getenv() for that setting returns
-      None even though the file looks correct.
-    * Unterminated quote. python-dotenv treats the opening quote as the start
-      of a multi-line value. What that costs depends on the rest of the file:
-      with no later quote it drops just that entry, but if a quote appears
-      further down it swallows everything in between, silently wiping settings
-      that are themselves written correctly.
+    Only a BOM qualifies: it always corrupts the name of the first setting, so
+    the file cannot work no matter which task the learner is starting. Other
+    malformations are impact-dependent and come back from find_env_notes().
     """
     problems = []
     if _has_bom(env_path):
@@ -89,19 +74,52 @@ def find_env_problems(env_path):
             "    indicator in the status bar, choose 'Save with Encoding', then\n"
             "    'UTF-8' (not 'UTF-8 with BOM').",
         ))
-
-    _, open_quote_line = _parse(env_path)
-    if open_quote_line is not None:
-        number, text = open_quote_line
-        problems.append((
-            f"unterminated quote on line {number} of .env",
-            f"That line is:  {text}\n"
-            "    It opens a quote that is never closed. The lab apps then treat\n"
-            "    everything after it as part of that one value, which can silently\n"
-            "    wipe out settings further down the file. Close the quote, or\n"
-            "    remove both quotes -- values in .env do not need them.",
-        ))
     return problems
+
+
+def find_env_notes(env_path):
+    """Return a list of (summary, advice) for malformed lines in the .env.
+
+    These are reported but not automatically fatal. A stray quote only matters
+    if it actually costs the learner a setting the task needs: an unterminated
+    quote with nothing after it to swallow leaves a working file, and failing
+    that would be its own false alarm. The caller decides, by checking whether
+    the keys the task needs came through.
+
+    Detection reads the file directly rather than inferring from parser output,
+    because python-dotenv reports malformed statements to stderr and simply
+    omits them from its result -- the app just sees a setting vanish with no
+    indication of why.
+    """
+    notes = []
+    _, defects = _parse(env_path)
+    for kind, number, text in defects:
+        if kind == "unterminated":
+            notes.append((
+                f"unterminated quote on line {number} of .env",
+                f"That line is:  {text}\n"
+                "    It opens a quote that is never closed, so the lab apps drop\n"
+                "    that setting entirely. Close the quote, or remove both quotes\n"
+                "    -- values in .env do not need them.",
+            ))
+        elif kind == "swallowed":
+            notes.append((
+                f"quote opened on line {number} of .env is closed much later",
+                f"That line is:  {text}\n"
+                "    Everything up to the next quote further down the file becomes\n"
+                "    part of this one value, so the settings in between are lost\n"
+                "    even though they look correct. Close the quote on this line,\n"
+                "    or remove both quotes.",
+            ))
+        elif kind == "trailing":
+            notes.append((
+                f"unexpected text after the quoted value on line {number} of .env",
+                f"That line is:  {text}\n"
+                "    python-dotenv cannot parse the line, so the lab apps drop that\n"
+                "    setting. Keep the value inside one pair of quotes, and put\n"
+                "    nothing after the closing quote except a # comment.",
+            ))
+    return notes
 
 
 def _has_bom(env_path):
@@ -113,22 +131,45 @@ def _has_bom(env_path):
         return False
 
 
-def _parse(env_path):
-    """Return (values, first_unterminated_quote) for a .env file.
+def _looks_like_assignment(line):
+    """True for a line shaped like KEY=..., used to spot swallowed settings."""
+    head = line.strip().partition("=")
+    if not head[1]:
+        return False
+    name = head[0].strip()
+    if name.startswith("export "):
+        name = name[len("export "):].strip()
+    return bool(name) and name.replace("_", "").isalnum()
 
-    first_unterminated_quote is None, or (line_number, stripped_line).
+
+def _parse(env_path):
+    """Return (values, defects).
+
+    defects is a list of (kind, line_number, line_text) where kind is one of
+    "unterminated", "swallowed" or "trailing".
+
+    Quoted values are resolved with a lookahead that only advances when a
+    closing quote is actually found, which is what python-dotenv does: a quote
+    closed on a later line is a legitimate multi-line value, while a quote that
+    is never closed makes python-dotenv discard that statement and resume at
+    the next line.
     """
     values = {}
-    bad_quote = None
+    defects = []
     try:
         # utf-8-sig strips a BOM so the remaining keys are reported accurately.
         # The BOM itself is surfaced separately by find_env_problems().
         text = Path(env_path).read_text(encoding="utf-8-sig")
     except OSError:
-        return values, bad_quote
+        return values, defects
 
-    for number, raw_line in enumerate(text.splitlines(), start=1):
-        line = raw_line.strip()
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        number = index + 1
+        line = lines[index].strip()
+        index += 1
+
         if not line or line.startswith("#"):
             continue
         if line.startswith("export ") or line.startswith("export\t"):
@@ -143,48 +184,122 @@ def _parse(env_path):
             continue
 
         value = value.strip()
-        if value[:1] in ("'", '"'):
-            inner, closed = _read_quoted(value, value[0])
-            if not closed:
-                if bad_quote is None:
-                    bad_quote = (number, line)
-                continue
-            # Anything after the closing quote (such as ' # comment') is dropped.
-            value = inner
-        else:
+        if value[:1] not in ("'", '"'):
             for comment_marker in (" #", "\t#"):
                 value = value.split(comment_marker, 1)[0]
-            value = value.strip()
-        values[key] = value
+            values[key] = value.strip()
+            continue
 
-    return values, bad_quote
+        quote = value[0]
+        # Join the rest of the file so a value may close on a later line.
+        rest = "\n".join([value] + lines[index:])
+        inner, closed, end, usable = _scan_for_close(rest, quote)
+        if not closed:
+            defects.append(("unterminated", number, line))
+            continue
+
+        consumed = rest.count("\n", 0, end)
+        if not usable:
+            # python-dotenv cannot parse the statement and drops it. If the
+            # quote also spanned lines, report it as a swallow: the settings it
+            # ate are the part the learner can actually see and act on.
+            defects.append(("swallowed" if consumed else "trailing", number, line))
+            index += consumed
+            continue
+
+        if consumed:
+            swallowed = lines[index:index + consumed]
+            if any(_looks_like_assignment(item) for item in swallowed):
+                defects.append(("swallowed", number, line))
+            index += consumed
+
+        values[key] = inner
+
+    return values, defects
 
 
-# Escape sequences python-dotenv expands inside double-quoted values.
-_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", "'": "'", '"': '"'}
+# Escape sequences python-dotenv decodes, per quote character. Double quotes
+# take the full set; single quotes decode only the delimiter and a literal
+# backslash, so '\n' inside single quotes stays as a backslash and an n.
+# Anything not listed keeps its backslash.
+_ESCAPES = {
+    '"': {
+        "a": "\a",
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        '"': '"',
+        "'": "'",
+        "\\": "\\",
+    },
+    "'": {"'": "'", "\\": "\\"},
+}
 
 
-def _read_quoted(value, quote):
-    """Return (contents, closed) for a value that starts with a quote character.
+def _scan_for_close(text, quote):
+    """Find where a quoted value ends, the way python-dotenv does.
 
-    A '#' inside the quotes is data, not a comment. Inside double quotes,
-    backslash escapes are expanded in a single pass, so an escaped quote does
-    not end the value and a literal backslash is never re-interpreted.
+    Returns (contents, closed, end_index, usable). usable is False when
+    python-dotenv could not parse the statement and dropped it, in which case
+    end_index still says where parsing resumes.
+
+    Two passes, matching python-dotenv:
+
+    1. Escape-aware, using the escape set for whichever character opened the
+       value (see _ESCAPES). A backslash-escaped quote is skipped rather than
+       treated as the close. If this closes with nothing but whitespace or a
+       comment after it, the value is good.
+    2. Raw, only if the first pass finds no close anywhere. Nothing is exempt
+       here: a matching character inside a comment, inside a differently quoted
+       value, or in an unquoted value all close the run.
+
+    A close found by pass 2, or a pass-1 close followed by text python-dotenv
+    cannot parse, means the statement is unparseable: its key is dropped and
+    parsing resumes after the close that was found.
+    """
+    contents, closed, end = _read_quoted(text, quote, escape_aware=True)
+    if closed:
+        tail = text[end:].split("\n", 1)[0].strip()
+        if not tail or tail.startswith("#"):
+            return contents, True, end, True
+        # Closed, but python-dotenv cannot parse what follows, so it drops the
+        # statement. end still says where parsing resumes.
+        return contents, True, end, False
+
+    recovered, closed, end = _read_quoted(text, quote, escape_aware=False)
+    return recovered, closed, end, False
+
+
+def _read_quoted(text, quote, escape_aware):
+    """Return (contents, closed, end_index) for text starting with a quote.
+
+    end_index is the position just past the closing quote. A '#' inside the
+    quotes is data, not a comment.
+
+    When escape_aware, backslash escapes are expanded in a single pass, so an
+    escaped quote does not end the run and a literal backslash is never
+    re-interpreted. The caller decides when that applies: parsing a value
+    honours escapes in double quotes only, while recovering from an unclosed
+    quote honours them for either character.
     """
     chars = []
     index = 1
-    while index < len(value):
-        char = value[index]
-        if char == "\\" and quote == '"' and index + 1 < len(value):
-            following = value[index + 1]
-            chars.append(_ESCAPES.get(following, "\\" + following))
+    while index < len(text):
+        char = text[index]
+        if escape_aware and char == "\\" and index + 1 < len(text):
+            following = text[index + 1]
+            decoded = _ESCAPES.get(quote, {})
+            chars.append(decoded.get(following, "\\" + following))
             index += 2
             continue
         if char == quote:
-            return "".join(chars), True
+            return "".join(chars), True, index + 1
         chars.append(char)
         index += 1
-    return "".join(chars), False
+    return "".join(chars), False, index
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {
@@ -274,11 +389,11 @@ def is_set(values, key):
 
 
 
-def report_problems(problems):
+def report_items(heading, items):
     """Print each .env defect and how to fix it."""
     print()
-    print("Fix your .env before starting this task:")
-    for summary, advice in problems:
+    print(heading)
+    for summary, advice in items:
         print(f"\n  {summary}\n    {advice}")
 
 def main():
@@ -298,6 +413,7 @@ def main():
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
     problems = find_env_problems(env_path) if env_path.exists() else []
+    notes = find_env_notes(env_path) if env_path.exists() else []
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
@@ -309,17 +425,21 @@ def main():
         if problems:
             for summary, _ in problems:
                 print(f"\n  [PROBLEM] {summary}")
-            report_problems(problems)
+            report_items("Fix your .env before starting a code task:", problems)
             return 1
+        if notes:
+            for summary, _ in notes:
+                print(f"\n  [NOTE] {summary}")
+            report_items("This task does not need .env, but note:", notes)
         return 0
 
-    # A malformed .env is reported on its own. Listing keys as OK/MISSING
-    # alongside it would either claim a broken file is fine, or point the
-    # learner at keys that are only "missing" because of the real defect.
+    # A BOM always corrupts the first setting's name, so the file cannot work
+    # whatever the task needs. Report it on its own: listing keys as OK/MISSING
+    # alongside it would either bless a broken file or point at the wrong thing.
     if problems:
         for summary, _ in problems:
             print(f"  [PROBLEM] {summary}")
-        report_problems(problems)
+        report_items("Fix your .env before starting this task:", problems)
         return 1
 
     missing = [key for key in required if not is_set(values, key)]
@@ -327,8 +447,19 @@ def main():
     for key in required:
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
+    for summary, _ in notes:
+        print(f"  [NOTE] {summary}")
 
+    # A malformed line only matters if it actually cost this task a setting.
+    # A stray quote with nothing after it to swallow leaves a working file, and
+    # failing that would be a false alarm in the other direction.
     if not missing:
+        if notes:
+            report_items(
+                "One line in your .env is malformed, but nothing this task "
+                "needs is affected:",
+                notes,
+            )
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
@@ -337,6 +468,8 @@ def main():
     print("Set the following before starting this task:")
     for key in missing:
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    if notes:
+        report_items("This may be why -- your .env has a malformed line:", notes)
     return 1
 
 

--- a/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
@@ -39,19 +39,95 @@ from pathlib import Path
 def read_env_file(env_path):
     """Parse a .env file into a dict, using only the standard library.
 
-    Mirrors python-dotenv's dotenv_values() for the syntax these labs use:
-    comments, blank lines, 'export KEY=value', single- and double-quoted values,
-    inline comments after unquoted values, and bare keys (value None). Reads as
-    utf-8-sig so a Notepad-saved .env carrying a UTF-8 BOM still resolves its
-    first key. Returns an empty dict if the file cannot be read.
+    Matches python-dotenv's dotenv_values() for every well-formed .env these
+    labs use: comments, blank lines, 'export KEY=value' (space or tab), single-
+    and double-quoted values, escape sequences inside double quotes, inline
+    comments after a value, and bare keys (value None). Returns an empty dict
+    if the file cannot be read.
+
+    Matching python-dotenv matters because the lab apps load .env with
+    python-dotenv: whatever it returns is what the app actually sees, so the
+    preflight has to agree with it rather than be a "better" parser.
+
+    Malformed files are handled by find_env_problems() instead -- see the note
+    there for why this function does not try to imitate python-dotenv's
+    behaviour on broken input.
+    """
+    values, _ = _parse(env_path)
+    return values
+
+
+def find_env_problems(env_path):
+    """Return a list of (summary, advice) for defects that break the lab apps.
+
+    Some .env defects do not make a key "missing" so much as make the file
+    unusable in ways the learner cannot see. For those we refuse to give a
+    per-key verdict at all: reporting "[OK] PROJECT_ENDPOINT" for a file the
+    app cannot read would be a false positive, and reporting unrelated keys as
+    MISSING would send the learner hunting the wrong problem. Instead we name
+    the defect, explain the cause, and exit non-zero.
+
+    Detected:
+
+    * UTF-8 BOM. python-dotenv does not strip it, so it becomes part of the
+      first setting's NAME and the app's os.getenv() for that setting returns
+      None even though the file looks correct.
+    * Unterminated quote. python-dotenv treats the opening quote as the start
+      of a multi-line value. What that costs depends on the rest of the file:
+      with no later quote it drops just that entry, but if a quote appears
+      further down it swallows everything in between, silently wiping settings
+      that are themselves written correctly.
+    """
+    problems = []
+    if _has_bom(env_path):
+        problems.append((
+            ".env starts with a UTF-8 BOM",
+            "Your .env was saved as 'UTF-8 with BOM' (Notepad does this by\n"
+            "    default). The BOM becomes part of the first setting's name, so the\n"
+            "    lab apps read that setting as empty even though the file looks\n"
+            "    correct. Re-save as plain UTF-8: in VS Code click the encoding\n"
+            "    indicator in the status bar, choose 'Save with Encoding', then\n"
+            "    'UTF-8' (not 'UTF-8 with BOM').",
+        ))
+
+    _, open_quote_line = _parse(env_path)
+    if open_quote_line is not None:
+        number, text = open_quote_line
+        problems.append((
+            f"unterminated quote on line {number} of .env",
+            f"That line is:  {text}\n"
+            "    It opens a quote that is never closed. The lab apps then treat\n"
+            "    everything after it as part of that one value, which can silently\n"
+            "    wipe out settings further down the file. Close the quote, or\n"
+            "    remove both quotes -- values in .env do not need them.",
+        ))
+    return problems
+
+
+def _has_bom(env_path):
+    """True if the file starts with a UTF-8 BOM."""
+    try:
+        with open(env_path, "rb") as handle:
+            return handle.read(3) == b"\xef\xbb\xbf"
+    except OSError:
+        return False
+
+
+def _parse(env_path):
+    """Return (values, first_unterminated_quote) for a .env file.
+
+    first_unterminated_quote is None, or (line_number, stripped_line).
     """
     values = {}
+    bad_quote = None
     try:
+        # utf-8-sig strips a BOM so the remaining keys are reported accurately.
+        # The BOM itself is surfaced separately by find_env_problems().
         text = Path(env_path).read_text(encoding="utf-8-sig")
     except OSError:
-        return values
+        return values, bad_quote
 
-    for raw_line in text.splitlines():
+    for number, raw_line in enumerate(text.splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
@@ -68,10 +144,10 @@ def read_env_file(env_path):
 
         value = value.strip()
         if value[:1] in ("'", '"'):
-            quote = value[0]
-            inner, closed = _read_quoted(value, quote)
+            inner, closed = _read_quoted(value, value[0])
             if not closed:
-                # Unterminated quote: python-dotenv discards the whole entry.
+                if bad_quote is None:
+                    bad_quote = (number, line)
                 continue
             # Anything after the closing quote (such as ' # comment') is dropped.
             value = inner
@@ -81,21 +157,27 @@ def read_env_file(env_path):
             value = value.strip()
         values[key] = value
 
-    return values
+    return values, bad_quote
+
+
+# Escape sequences python-dotenv expands inside double-quoted values.
+_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", "'": "'", '"': '"'}
 
 
 def _read_quoted(value, quote):
     """Return (contents, closed) for a value that starts with a quote character.
 
-    A '#' inside the quotes is data, not a comment. Backslash escapes are
-    honored inside double quotes, matching python-dotenv.
+    A '#' inside the quotes is data, not a comment. Inside double quotes,
+    backslash escapes are expanded in a single pass, so an escaped quote does
+    not end the value and a literal backslash is never re-interpreted.
     """
     chars = []
     index = 1
     while index < len(value):
         char = value[index]
         if char == "\\" and quote == '"' and index + 1 < len(value):
-            chars.append(value[index + 1])
+            following = value[index + 1]
+            chars.append(_ESCAPES.get(following, "\\" + following))
             index += 2
             continue
         if char == quote:
@@ -114,16 +196,32 @@ TASK_REQUIREMENTS = {
     6: ["PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME"],
 }
 
-# Placeholder text shipped in .env.example — present but not yet filled in.
-PLACEHOLDERS = {
-    "",
-    "your-project-endpoint",
-    "your-model-deployment-name",
-    "your-agent-name",
-    "<your-project-endpoint>",
-    "<your-model-deployment-name>",
-    "<your-agent-name>",
-}
+def looks_like_placeholder(value):
+    """True if the value is still example text rather than a real setting.
+
+    Matched by shape rather than an exact list. The shipped .env.example files
+    have used both 'your-project-endpoint' and 'your_project_endpoint_here',
+    and an exact list silently rots the moment one of them changes -- which is
+    exactly what happened: a learner could copy .env.example verbatim, change
+    nothing, and be told they were ready to start.
+
+    Anything empty, wrapped in angle brackets, or whose first word is "your"
+    counts as unfilled. Real defaults these labs ship (tailwind-agent,
+    tailwind-knowledge-agent, localhost, port numbers) do not match.
+
+    This deliberately errs toward "not filled in": a real value beginning with
+    the word "your" would be flagged, but none of these keys takes one (they
+    hold a URL, a model deployment name, a slug or a port). Being told to
+    double-check a key you did set is recoverable; being told you are ready
+    when you are not is the failure this whole script exists to prevent.
+    """
+    text = value.strip()
+    if not text:
+        return True
+    if text.startswith("<") and text.endswith(">"):
+        return True
+    words = text.replace("-", " ").replace("_", " ").lower().split()
+    return bool(words) and words[0] == "your"
 
 # How to fix each key, shown only when it's missing.
 FIX_HINTS = {
@@ -172,9 +270,16 @@ def load_values(env_path):
 
 def is_set(values, key):
     """A key counts as set if it's present and not a leftover placeholder."""
-    value = (values.get(key) or "").strip()
-    return bool(value) and value not in PLACEHOLDERS
+    return not looks_like_placeholder(values.get(key) or "")
 
+
+
+def report_problems(problems):
+    """Print each .env defect and how to fix it."""
+    print()
+    print("Fix your .env before starting this task:")
+    for summary, advice in problems:
+        print(f"\n  {summary}\n    {advice}")
 
 def main():
     parser = argparse.ArgumentParser(
@@ -192,6 +297,7 @@ def main():
     env_path = find_env_file()
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
+    problems = find_env_problems(env_path) if env_path.exists() else []
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
@@ -200,7 +306,21 @@ def main():
     if not required:
         print("Task 1 is completed entirely in the Foundry portal - no .env needed.")
         print("When you're ready for a code task, run this again with --task 2 (or higher).")
+        if problems:
+            for summary, _ in problems:
+                print(f"\n  [PROBLEM] {summary}")
+            report_problems(problems)
+            return 1
         return 0
+
+    # A malformed .env is reported on its own. Listing keys as OK/MISSING
+    # alongside it would either claim a broken file is fine, or point the
+    # learner at keys that are only "missing" because of the real defect.
+    if problems:
+        for summary, _ in problems:
+            print(f"  [PROBLEM] {summary}")
+        report_problems(problems)
+        return 1
 
     missing = [key for key in required if not is_set(values, key)]
 

--- a/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
@@ -2,9 +2,16 @@
 Preflight check for the Tailwind Traders lab.
 
 Each task in this lab can be completed on its own. Before you start a task,
-run this script to confirm your .env file has everything that task needs:
+run this script to confirm your .env file has everything that task needs.
 
-    python setup/check_env.py --task 3
+Run it from the lab's starter code folder — Labfiles/A-build-and-extend-ai-agents/Python,
+the folder you open in VS Code, where your virtual environment and .env live:
+
+    python ../setup/check_env.py --task 3
+
+This script uses only the Python standard library, so it works before you run
+'pip install' and without the lab virtual environment active. Keep it that way:
+it is the one script learners are most likely to run in a bare environment.
 
 It never changes anything — it only reads your .env and tells you what (if
 anything) is missing, so you can fix it before running the task.
@@ -23,7 +30,53 @@ import argparse
 import os
 from pathlib import Path
 
-from dotenv import dotenv_values
+# Keep this script dependency-free. It is a *preflight* check, so it runs before
+# 'pip install' and often on a bare system Python with no virtual environment
+# active. Importing anything outside the standard library (python-dotenv
+# included) would make it fail at exactly the moment it is most needed.
+
+
+def read_env_file(env_path):
+    """Parse a .env file into a dict, using only the standard library.
+
+    Mirrors python-dotenv's dotenv_values() for the syntax these labs use:
+    comments, blank lines, 'export KEY=value', single- and double-quoted values,
+    inline comments after unquoted values, and bare keys (value None). Reads as
+    utf-8-sig so a Notepad-saved .env carrying a UTF-8 BOM still resolves its
+    first key. Returns an empty dict if the file cannot be read.
+    """
+    values = {}
+    try:
+        text = Path(env_path).read_text(encoding="utf-8-sig")
+    except OSError:
+        return values
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export ") or line.startswith("export\t"):
+            line = line[len("export"):].lstrip()
+
+        key, separator, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        if not separator:
+            values[key] = None
+            continue
+
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            # Quoted: a '#' inside the quotes is data, not a comment.
+            value = value[1:-1]
+        else:
+            for comment_marker in (" #", "\t#"):
+                value = value.split(comment_marker, 1)[0]
+            value = value.strip()
+        values[key] = value
+
+    return values
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {
@@ -60,7 +113,7 @@ FIX_HINTS = {
     "AGENT_NAME": (
         "Task 3 needs the grounded portal agent from Task 1. Either complete Task 1 in "
         "the portal and set AGENT_NAME=tailwind-agent, or fast-forward past Task 1 by "
-        "running: python setup/bootstrap_agent.py"
+        "running, from the Python folder: python ../setup/bootstrap_agent.py"
     ),
 }
 
@@ -84,7 +137,7 @@ def load_values(env_path):
     """Merge real environment variables over .env file values (env wins)."""
     values = {}
     if env_path.exists():
-        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+        values.update({k: v for k, v in read_env_file(env_path).items() if v is not None})
     for key in ("PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME", "AGENT_NAME"):
         if os.environ.get(key):
             values[key] = os.environ[key]

--- a/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/check_env.py
@@ -67,9 +67,14 @@ def read_env_file(env_path):
             continue
 
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            # Quoted: a '#' inside the quotes is data, not a comment.
-            value = value[1:-1]
+        if value[:1] in ("'", '"'):
+            quote = value[0]
+            inner, closed = _read_quoted(value, quote)
+            if not closed:
+                # Unterminated quote: python-dotenv discards the whole entry.
+                continue
+            # Anything after the closing quote (such as ' # comment') is dropped.
+            value = inner
         else:
             for comment_marker in (" #", "\t#"):
                 value = value.split(comment_marker, 1)[0]
@@ -77,6 +82,27 @@ def read_env_file(env_path):
         values[key] = value
 
     return values
+
+
+def _read_quoted(value, quote):
+    """Return (contents, closed) for a value that starts with a quote character.
+
+    A '#' inside the quotes is data, not a comment. Backslash escapes are
+    honored inside double quotes, matching python-dotenv.
+    """
+    chars = []
+    index = 1
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and quote == '"' and index + 1 < len(value):
+            chars.append(value[index + 1])
+            index += 2
+            continue
+        if char == quote:
+            return "".join(chars), True
+        chars.append(char)
+        index += 1
+    return "".join(chars), False
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {

--- a/Labfiles/A-build-and-extend-ai-agents/setup/write_env.ps1
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/write_env.ps1
@@ -33,4 +33,4 @@ Set-EnvValue 'PROJECT_ENDPOINT' $env:PROJECT_ENDPOINT
 Set-EnvValue 'MODEL_DEPLOYMENT_NAME' $env:MODEL_DEPLOYMENT_NAME
 
 Write-Host "Updated $envPath with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
-Write-Host "Task 3 also needs a grounded agent: run 'python setup/bootstrap_agent.py' to create it."
+Write-Host "Task 3 also needs a grounded agent: from the Python folder, run 'python ../setup/bootstrap_agent.py' to create it."

--- a/Labfiles/A-build-and-extend-ai-agents/setup/write_env.sh
+++ b/Labfiles/A-build-and-extend-ai-agents/setup/write_env.sh
@@ -34,4 +34,4 @@ set_env_value "PROJECT_ENDPOINT" "$PROJECT_ENDPOINT"
 set_env_value "MODEL_DEPLOYMENT_NAME" "$MODEL_DEPLOYMENT_NAME"
 
 echo "Updated $env_path with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
-echo "Task 3 also needs a grounded agent: run 'python setup/bootstrap_agent.py' to create it."
+echo "Task 3 also needs a grounded agent: from the Python folder, run 'python ../setup/bootstrap_agent.py' to create it."

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/README.md
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/README.md
@@ -34,13 +34,16 @@ This lab can be completed end to end **or one task at a time**. Two things make 
   needs and how to fast-forward.
 - **Setup scripts** in `Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/`:
   - `check_env.py --task N` — preflight-checks that `.env` has the keys task *N* needs.
+    Run it as `python ../setup/check_env.py --task N`.
   - `bootstrap_agent.py` — **fast-forwards the Task 1 grounding step in code**: creates and
     grounds `tailwind-knowledge-agent` (File Search over the `data/` knowledge base) and writes
     `AGENT_NAME` to `.env`, so learners can start against a working agent without the portal.
     Idempotent; pass `--force` to recreate.
 
-Both scripts run from the **starter** `Python/` folder and use the shared virtual environment
-and `.env`.
+Both scripts run from the **starter** `Python/` folder
+(`Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python`, not `Solution/Python/`)
+and use the shared virtual environment and `.env`. That's why the paths above are
+`../setup/...` — `setup/` is a sibling of the starter `Python/` folder.
 
 > **Note**: Task 1 in the portal grounds the agent with **Foundry IQ** (a knowledge source with
 > agentic retrieval and an approval step). `bootstrap_agent.py` uses the simpler **File Search**
@@ -87,12 +90,13 @@ The Task 1 clients load an agent **by name** that you create in the portal:
 2. Add a **Foundry IQ knowledge source** and index the Tailwind Traders docs from `Python/data/`.
 3. Give it instructions to answer store staff questions from the knowledge base. Save the agent.
 
-> **Shortcut**: instead of the portal grounding above, run `python setup/bootstrap_agent.py` from
-> the `Python/` folder to create and ground `tailwind-knowledge-agent` in code (File Search) and
+> **Shortcut**: instead of the portal grounding above, run `python ../setup/bootstrap_agent.py`
+> from the **starter** `Python/` folder (not `Solution/Python/`) to create and ground
+> `tailwind-knowledge-agent` in code (File Search) and
 > write `AGENT_NAME`.
 
 ### 4. Set up the environment once (shared by all code tasks)
-From the `Python/` folder:
+From this folder (`Solution/Python/`):
 ```
 python -m venv labenv
 .\labenv\Scripts\Activate.ps1        # Windows PowerShell
@@ -104,7 +108,7 @@ Then copy `.env.example` to `.env` and fill in the values (all tasks read the sa
 - `AGENT_NAME=tailwind-knowledge-agent` — used by the Task 1 code clients
 
 ### 5. Run each task
-Code tasks run from the single `Python/` folder:
+Code tasks run from the single `Solution/Python/` folder:
 
 | Task | Command | What you get |
 |------|---------|--------------|

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/bootstrap_agent.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/bootstrap_agent.py
@@ -3,9 +3,13 @@ Fast-forward setup for the Tailwind Traders enterprise-knowledge lab.
 
 Task 1 has you build an enterprise-knowledge agent and ground it on the Tailwind
 Traders knowledge base. If you'd rather jump straight to connecting from code (or
-to an optional task), run this once to create a grounded agent for you:
+to an optional task), run this once to create a grounded agent for you.
 
-    python setup/bootstrap_agent.py
+Run it from the lab's starter code folder —
+Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python, the folder you
+open in VS Code — with the lab virtual environment active:
+
+    python ../setup/bootstrap_agent.py
 
 It reproduces, in code, the grounding step Task 1 has you do in the portal:
 

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
@@ -2,9 +2,17 @@
 Preflight check for the Tailwind Traders enterprise-knowledge lab.
 
 Each task in this lab can be completed on its own. Before you start a task,
-run this script to confirm your .env file has everything that task needs:
+run this script to confirm your .env file has everything that task needs.
 
-    python setup/check_env.py --task 4
+Run it from the lab's starter code folder —
+Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python, the folder
+you open in VS Code, where your virtual environment and .env live:
+
+    python ../setup/check_env.py --task 4
+
+This script uses only the Python standard library, so it works before you run
+'pip install' and without the lab virtual environment active. Keep it that way:
+it is the one script learners are most likely to run in a bare environment.
 
 It never changes anything — it only reads your .env and tells you what (if
 anything) is missing, so you can fix it before running the task.
@@ -21,7 +29,53 @@ import argparse
 import os
 from pathlib import Path
 
-from dotenv import dotenv_values
+# Keep this script dependency-free. It is a *preflight* check, so it runs before
+# 'pip install' and often on a bare system Python with no virtual environment
+# active. Importing anything outside the standard library (python-dotenv
+# included) would make it fail at exactly the moment it is most needed.
+
+
+def read_env_file(env_path):
+    """Parse a .env file into a dict, using only the standard library.
+
+    Mirrors python-dotenv's dotenv_values() for the syntax these labs use:
+    comments, blank lines, 'export KEY=value', single- and double-quoted values,
+    inline comments after unquoted values, and bare keys (value None). Reads as
+    utf-8-sig so a Notepad-saved .env carrying a UTF-8 BOM still resolves its
+    first key. Returns an empty dict if the file cannot be read.
+    """
+    values = {}
+    try:
+        text = Path(env_path).read_text(encoding="utf-8-sig")
+    except OSError:
+        return values
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export ") or line.startswith("export\t"):
+            line = line[len("export"):].lstrip()
+
+        key, separator, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        if not separator:
+            values[key] = None
+            continue
+
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            # Quoted: a '#' inside the quotes is data, not a comment.
+            value = value[1:-1]
+        else:
+            for comment_marker in (" #", "\t#"):
+                value = value.split(comment_marker, 1)[0]
+            value = value.strip()
+        values[key] = value
+
+    return values
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {
@@ -58,7 +112,7 @@ FIX_HINTS = {
     "AGENT_NAME": (
         "Task 1 needs the Foundry IQ enterprise-knowledge agent. Either build it in the "
         "portal and set AGENT_NAME=tailwind-knowledge-agent, or fast-forward the grounding "
-        "step by running: python setup/bootstrap_agent.py"
+        "step by running, from the Python folder: python ../setup/bootstrap_agent.py"
     ),
 }
 
@@ -82,7 +136,7 @@ def load_values(env_path):
     """Merge real environment variables over .env file values (env wins)."""
     values = {}
     if env_path.exists():
-        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+        values.update({k: v for k, v in read_env_file(env_path).items() if v is not None})
     for key in ("PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME", "AGENT_NAME"):
         if os.environ.get(key):
             values[key] = os.environ[key]

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
@@ -66,9 +66,14 @@ def read_env_file(env_path):
             continue
 
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            # Quoted: a '#' inside the quotes is data, not a comment.
-            value = value[1:-1]
+        if value[:1] in ("'", '"'):
+            quote = value[0]
+            inner, closed = _read_quoted(value, quote)
+            if not closed:
+                # Unterminated quote: python-dotenv discards the whole entry.
+                continue
+            # Anything after the closing quote (such as ' # comment') is dropped.
+            value = inner
         else:
             for comment_marker in (" #", "\t#"):
                 value = value.split(comment_marker, 1)[0]
@@ -76,6 +81,27 @@ def read_env_file(env_path):
         values[key] = value
 
     return values
+
+
+def _read_quoted(value, quote):
+    """Return (contents, closed) for a value that starts with a quote character.
+
+    A '#' inside the quotes is data, not a comment. Backslash escapes are
+    honored inside double quotes, matching python-dotenv.
+    """
+    chars = []
+    index = 1
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and quote == '"' and index + 1 < len(value):
+            chars.append(value[index + 1])
+            index += 2
+            continue
+        if char == quote:
+            return "".join(chars), True
+        chars.append(char)
+        index += 1
+    return "".join(chars), False
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
@@ -38,19 +38,95 @@ from pathlib import Path
 def read_env_file(env_path):
     """Parse a .env file into a dict, using only the standard library.
 
-    Mirrors python-dotenv's dotenv_values() for the syntax these labs use:
-    comments, blank lines, 'export KEY=value', single- and double-quoted values,
-    inline comments after unquoted values, and bare keys (value None). Reads as
-    utf-8-sig so a Notepad-saved .env carrying a UTF-8 BOM still resolves its
-    first key. Returns an empty dict if the file cannot be read.
+    Matches python-dotenv's dotenv_values() for every well-formed .env these
+    labs use: comments, blank lines, 'export KEY=value' (space or tab), single-
+    and double-quoted values, escape sequences inside double quotes, inline
+    comments after a value, and bare keys (value None). Returns an empty dict
+    if the file cannot be read.
+
+    Matching python-dotenv matters because the lab apps load .env with
+    python-dotenv: whatever it returns is what the app actually sees, so the
+    preflight has to agree with it rather than be a "better" parser.
+
+    Malformed files are handled by find_env_problems() instead -- see the note
+    there for why this function does not try to imitate python-dotenv's
+    behaviour on broken input.
+    """
+    values, _ = _parse(env_path)
+    return values
+
+
+def find_env_problems(env_path):
+    """Return a list of (summary, advice) for defects that break the lab apps.
+
+    Some .env defects do not make a key "missing" so much as make the file
+    unusable in ways the learner cannot see. For those we refuse to give a
+    per-key verdict at all: reporting "[OK] PROJECT_ENDPOINT" for a file the
+    app cannot read would be a false positive, and reporting unrelated keys as
+    MISSING would send the learner hunting the wrong problem. Instead we name
+    the defect, explain the cause, and exit non-zero.
+
+    Detected:
+
+    * UTF-8 BOM. python-dotenv does not strip it, so it becomes part of the
+      first setting's NAME and the app's os.getenv() for that setting returns
+      None even though the file looks correct.
+    * Unterminated quote. python-dotenv treats the opening quote as the start
+      of a multi-line value. What that costs depends on the rest of the file:
+      with no later quote it drops just that entry, but if a quote appears
+      further down it swallows everything in between, silently wiping settings
+      that are themselves written correctly.
+    """
+    problems = []
+    if _has_bom(env_path):
+        problems.append((
+            ".env starts with a UTF-8 BOM",
+            "Your .env was saved as 'UTF-8 with BOM' (Notepad does this by\n"
+            "    default). The BOM becomes part of the first setting's name, so the\n"
+            "    lab apps read that setting as empty even though the file looks\n"
+            "    correct. Re-save as plain UTF-8: in VS Code click the encoding\n"
+            "    indicator in the status bar, choose 'Save with Encoding', then\n"
+            "    'UTF-8' (not 'UTF-8 with BOM').",
+        ))
+
+    _, open_quote_line = _parse(env_path)
+    if open_quote_line is not None:
+        number, text = open_quote_line
+        problems.append((
+            f"unterminated quote on line {number} of .env",
+            f"That line is:  {text}\n"
+            "    It opens a quote that is never closed. The lab apps then treat\n"
+            "    everything after it as part of that one value, which can silently\n"
+            "    wipe out settings further down the file. Close the quote, or\n"
+            "    remove both quotes -- values in .env do not need them.",
+        ))
+    return problems
+
+
+def _has_bom(env_path):
+    """True if the file starts with a UTF-8 BOM."""
+    try:
+        with open(env_path, "rb") as handle:
+            return handle.read(3) == b"\xef\xbb\xbf"
+    except OSError:
+        return False
+
+
+def _parse(env_path):
+    """Return (values, first_unterminated_quote) for a .env file.
+
+    first_unterminated_quote is None, or (line_number, stripped_line).
     """
     values = {}
+    bad_quote = None
     try:
+        # utf-8-sig strips a BOM so the remaining keys are reported accurately.
+        # The BOM itself is surfaced separately by find_env_problems().
         text = Path(env_path).read_text(encoding="utf-8-sig")
     except OSError:
-        return values
+        return values, bad_quote
 
-    for raw_line in text.splitlines():
+    for number, raw_line in enumerate(text.splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
@@ -67,10 +143,10 @@ def read_env_file(env_path):
 
         value = value.strip()
         if value[:1] in ("'", '"'):
-            quote = value[0]
-            inner, closed = _read_quoted(value, quote)
+            inner, closed = _read_quoted(value, value[0])
             if not closed:
-                # Unterminated quote: python-dotenv discards the whole entry.
+                if bad_quote is None:
+                    bad_quote = (number, line)
                 continue
             # Anything after the closing quote (such as ' # comment') is dropped.
             value = inner
@@ -80,21 +156,27 @@ def read_env_file(env_path):
             value = value.strip()
         values[key] = value
 
-    return values
+    return values, bad_quote
+
+
+# Escape sequences python-dotenv expands inside double-quoted values.
+_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", "'": "'", '"': '"'}
 
 
 def _read_quoted(value, quote):
     """Return (contents, closed) for a value that starts with a quote character.
 
-    A '#' inside the quotes is data, not a comment. Backslash escapes are
-    honored inside double quotes, matching python-dotenv.
+    A '#' inside the quotes is data, not a comment. Inside double quotes,
+    backslash escapes are expanded in a single pass, so an escaped quote does
+    not end the value and a literal backslash is never re-interpreted.
     """
     chars = []
     index = 1
     while index < len(value):
         char = value[index]
         if char == "\\" and quote == '"' and index + 1 < len(value):
-            chars.append(value[index + 1])
+            following = value[index + 1]
+            chars.append(_ESCAPES.get(following, "\\" + following))
             index += 2
             continue
         if char == quote:
@@ -111,18 +193,32 @@ TASK_REQUIREMENTS = {
     4: ["PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME"],
 }
 
-# Placeholder text shipped in .env.example — present but not yet filled in.
-PLACEHOLDERS = {
-    "",
-    "your_project_endpoint_here",
-    "your_model_deployment_name_here",
-    "your-project-endpoint",
-    "your-model-deployment-name",
-    "your-agent-name",
-    "<your-project-endpoint>",
-    "<your-model-deployment-name>",
-    "<your-agent-name>",
-}
+def looks_like_placeholder(value):
+    """True if the value is still example text rather than a real setting.
+
+    Matched by shape rather than an exact list. The shipped .env.example files
+    have used both 'your-project-endpoint' and 'your_project_endpoint_here',
+    and an exact list silently rots the moment one of them changes -- which is
+    exactly what happened: a learner could copy .env.example verbatim, change
+    nothing, and be told they were ready to start.
+
+    Anything empty, wrapped in angle brackets, or whose first word is "your"
+    counts as unfilled. Real defaults these labs ship (tailwind-agent,
+    tailwind-knowledge-agent, localhost, port numbers) do not match.
+
+    This deliberately errs toward "not filled in": a real value beginning with
+    the word "your" would be flagged, but none of these keys takes one (they
+    hold a URL, a model deployment name, a slug or a port). Being told to
+    double-check a key you did set is recoverable; being told you are ready
+    when you are not is the failure this whole script exists to prevent.
+    """
+    text = value.strip()
+    if not text:
+        return True
+    if text.startswith("<") and text.endswith(">"):
+        return True
+    words = text.replace("-", " ").replace("_", " ").lower().split()
+    return bool(words) and words[0] == "your"
 
 # How to fix each key, shown only when it's missing.
 FIX_HINTS = {
@@ -171,9 +267,16 @@ def load_values(env_path):
 
 def is_set(values, key):
     """A key counts as set if it's present and not a leftover placeholder."""
-    value = (values.get(key) or "").strip()
-    return bool(value) and value not in PLACEHOLDERS
+    return not looks_like_placeholder(values.get(key) or "")
 
+
+
+def report_problems(problems):
+    """Print each .env defect and how to fix it."""
+    print()
+    print("Fix your .env before starting this task:")
+    for summary, advice in problems:
+        print(f"\n  {summary}\n    {advice}")
 
 def main():
     parser = argparse.ArgumentParser(
@@ -191,6 +294,7 @@ def main():
     env_path = find_env_file()
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
+    problems = find_env_problems(env_path) if env_path.exists() else []
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
@@ -199,7 +303,21 @@ def main():
     if not required:
         print(f"Task {args.task} is completed entirely in the portal - no .env needed.")
         print("When you're ready for a code task, run this again with --task 1 or --task 4.")
+        if problems:
+            for summary, _ in problems:
+                print(f"\n  [PROBLEM] {summary}")
+            report_problems(problems)
+            return 1
         return 0
+
+    # A malformed .env is reported on its own. Listing keys as OK/MISSING
+    # alongside it would either claim a broken file is fine, or point the
+    # learner at keys that are only "missing" because of the real defect.
+    if problems:
+        for summary, _ in problems:
+            print(f"  [PROBLEM] {summary}")
+        report_problems(problems)
+        return 1
 
     missing = [key for key in required if not is_set(values, key)]
 

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
@@ -38,44 +38,29 @@ from pathlib import Path
 def read_env_file(env_path):
     """Parse a .env file into a dict, using only the standard library.
 
-    Matches python-dotenv's dotenv_values() for every well-formed .env these
-    labs use: comments, blank lines, 'export KEY=value' (space or tab), single-
+    Matches python-dotenv's dotenv_values() for every .env shape these labs can
+    encounter: comments, blank lines, 'export KEY=value' (space or tab), single-
     and double-quoted values, escape sequences inside double quotes, inline
-    comments after a value, and bare keys (value None). Returns an empty dict
-    if the file cannot be read.
+    comments, values quoted across several lines, and bare keys (value None).
 
     Matching python-dotenv matters because the lab apps load .env with
-    python-dotenv: whatever it returns is what the app actually sees, so the
-    preflight has to agree with it rather than be a "better" parser.
+    python-dotenv. Whatever it returns is what the app actually sees, so the
+    preflight has to agree with it rather than be a "better" parser -- a parser
+    that is more forgiving than the runtime reports keys as present that the
+    app cannot read.
 
-    Malformed files are handled by find_env_problems() instead -- see the note
-    there for why this function does not try to imitate python-dotenv's
-    behaviour on broken input.
+    Returns an empty dict if the file cannot be read.
     """
     values, _ = _parse(env_path)
     return values
 
 
 def find_env_problems(env_path):
-    """Return a list of (summary, advice) for defects that break the lab apps.
+    """Return a list of (summary, advice) for defects that always break the app.
 
-    Some .env defects do not make a key "missing" so much as make the file
-    unusable in ways the learner cannot see. For those we refuse to give a
-    per-key verdict at all: reporting "[OK] PROJECT_ENDPOINT" for a file the
-    app cannot read would be a false positive, and reporting unrelated keys as
-    MISSING would send the learner hunting the wrong problem. Instead we name
-    the defect, explain the cause, and exit non-zero.
-
-    Detected:
-
-    * UTF-8 BOM. python-dotenv does not strip it, so it becomes part of the
-      first setting's NAME and the app's os.getenv() for that setting returns
-      None even though the file looks correct.
-    * Unterminated quote. python-dotenv treats the opening quote as the start
-      of a multi-line value. What that costs depends on the rest of the file:
-      with no later quote it drops just that entry, but if a quote appears
-      further down it swallows everything in between, silently wiping settings
-      that are themselves written correctly.
+    Only a BOM qualifies: it always corrupts the name of the first setting, so
+    the file cannot work no matter which task the learner is starting. Other
+    malformations are impact-dependent and come back from find_env_notes().
     """
     problems = []
     if _has_bom(env_path):
@@ -88,19 +73,52 @@ def find_env_problems(env_path):
             "    indicator in the status bar, choose 'Save with Encoding', then\n"
             "    'UTF-8' (not 'UTF-8 with BOM').",
         ))
-
-    _, open_quote_line = _parse(env_path)
-    if open_quote_line is not None:
-        number, text = open_quote_line
-        problems.append((
-            f"unterminated quote on line {number} of .env",
-            f"That line is:  {text}\n"
-            "    It opens a quote that is never closed. The lab apps then treat\n"
-            "    everything after it as part of that one value, which can silently\n"
-            "    wipe out settings further down the file. Close the quote, or\n"
-            "    remove both quotes -- values in .env do not need them.",
-        ))
     return problems
+
+
+def find_env_notes(env_path):
+    """Return a list of (summary, advice) for malformed lines in the .env.
+
+    These are reported but not automatically fatal. A stray quote only matters
+    if it actually costs the learner a setting the task needs: an unterminated
+    quote with nothing after it to swallow leaves a working file, and failing
+    that would be its own false alarm. The caller decides, by checking whether
+    the keys the task needs came through.
+
+    Detection reads the file directly rather than inferring from parser output,
+    because python-dotenv reports malformed statements to stderr and simply
+    omits them from its result -- the app just sees a setting vanish with no
+    indication of why.
+    """
+    notes = []
+    _, defects = _parse(env_path)
+    for kind, number, text in defects:
+        if kind == "unterminated":
+            notes.append((
+                f"unterminated quote on line {number} of .env",
+                f"That line is:  {text}\n"
+                "    It opens a quote that is never closed, so the lab apps drop\n"
+                "    that setting entirely. Close the quote, or remove both quotes\n"
+                "    -- values in .env do not need them.",
+            ))
+        elif kind == "swallowed":
+            notes.append((
+                f"quote opened on line {number} of .env is closed much later",
+                f"That line is:  {text}\n"
+                "    Everything up to the next quote further down the file becomes\n"
+                "    part of this one value, so the settings in between are lost\n"
+                "    even though they look correct. Close the quote on this line,\n"
+                "    or remove both quotes.",
+            ))
+        elif kind == "trailing":
+            notes.append((
+                f"unexpected text after the quoted value on line {number} of .env",
+                f"That line is:  {text}\n"
+                "    python-dotenv cannot parse the line, so the lab apps drop that\n"
+                "    setting. Keep the value inside one pair of quotes, and put\n"
+                "    nothing after the closing quote except a # comment.",
+            ))
+    return notes
 
 
 def _has_bom(env_path):
@@ -112,22 +130,45 @@ def _has_bom(env_path):
         return False
 
 
-def _parse(env_path):
-    """Return (values, first_unterminated_quote) for a .env file.
+def _looks_like_assignment(line):
+    """True for a line shaped like KEY=..., used to spot swallowed settings."""
+    head = line.strip().partition("=")
+    if not head[1]:
+        return False
+    name = head[0].strip()
+    if name.startswith("export "):
+        name = name[len("export "):].strip()
+    return bool(name) and name.replace("_", "").isalnum()
 
-    first_unterminated_quote is None, or (line_number, stripped_line).
+
+def _parse(env_path):
+    """Return (values, defects).
+
+    defects is a list of (kind, line_number, line_text) where kind is one of
+    "unterminated", "swallowed" or "trailing".
+
+    Quoted values are resolved with a lookahead that only advances when a
+    closing quote is actually found, which is what python-dotenv does: a quote
+    closed on a later line is a legitimate multi-line value, while a quote that
+    is never closed makes python-dotenv discard that statement and resume at
+    the next line.
     """
     values = {}
-    bad_quote = None
+    defects = []
     try:
         # utf-8-sig strips a BOM so the remaining keys are reported accurately.
         # The BOM itself is surfaced separately by find_env_problems().
         text = Path(env_path).read_text(encoding="utf-8-sig")
     except OSError:
-        return values, bad_quote
+        return values, defects
 
-    for number, raw_line in enumerate(text.splitlines(), start=1):
-        line = raw_line.strip()
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        number = index + 1
+        line = lines[index].strip()
+        index += 1
+
         if not line or line.startswith("#"):
             continue
         if line.startswith("export ") or line.startswith("export\t"):
@@ -142,48 +183,122 @@ def _parse(env_path):
             continue
 
         value = value.strip()
-        if value[:1] in ("'", '"'):
-            inner, closed = _read_quoted(value, value[0])
-            if not closed:
-                if bad_quote is None:
-                    bad_quote = (number, line)
-                continue
-            # Anything after the closing quote (such as ' # comment') is dropped.
-            value = inner
-        else:
+        if value[:1] not in ("'", '"'):
             for comment_marker in (" #", "\t#"):
                 value = value.split(comment_marker, 1)[0]
-            value = value.strip()
-        values[key] = value
+            values[key] = value.strip()
+            continue
 
-    return values, bad_quote
+        quote = value[0]
+        # Join the rest of the file so a value may close on a later line.
+        rest = "\n".join([value] + lines[index:])
+        inner, closed, end, usable = _scan_for_close(rest, quote)
+        if not closed:
+            defects.append(("unterminated", number, line))
+            continue
+
+        consumed = rest.count("\n", 0, end)
+        if not usable:
+            # python-dotenv cannot parse the statement and drops it. If the
+            # quote also spanned lines, report it as a swallow: the settings it
+            # ate are the part the learner can actually see and act on.
+            defects.append(("swallowed" if consumed else "trailing", number, line))
+            index += consumed
+            continue
+
+        if consumed:
+            swallowed = lines[index:index + consumed]
+            if any(_looks_like_assignment(item) for item in swallowed):
+                defects.append(("swallowed", number, line))
+            index += consumed
+
+        values[key] = inner
+
+    return values, defects
 
 
-# Escape sequences python-dotenv expands inside double-quoted values.
-_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", "'": "'", '"': '"'}
+# Escape sequences python-dotenv decodes, per quote character. Double quotes
+# take the full set; single quotes decode only the delimiter and a literal
+# backslash, so '\n' inside single quotes stays as a backslash and an n.
+# Anything not listed keeps its backslash.
+_ESCAPES = {
+    '"': {
+        "a": "\a",
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        '"': '"',
+        "'": "'",
+        "\\": "\\",
+    },
+    "'": {"'": "'", "\\": "\\"},
+}
 
 
-def _read_quoted(value, quote):
-    """Return (contents, closed) for a value that starts with a quote character.
+def _scan_for_close(text, quote):
+    """Find where a quoted value ends, the way python-dotenv does.
 
-    A '#' inside the quotes is data, not a comment. Inside double quotes,
-    backslash escapes are expanded in a single pass, so an escaped quote does
-    not end the value and a literal backslash is never re-interpreted.
+    Returns (contents, closed, end_index, usable). usable is False when
+    python-dotenv could not parse the statement and dropped it, in which case
+    end_index still says where parsing resumes.
+
+    Two passes, matching python-dotenv:
+
+    1. Escape-aware, using the escape set for whichever character opened the
+       value (see _ESCAPES). A backslash-escaped quote is skipped rather than
+       treated as the close. If this closes with nothing but whitespace or a
+       comment after it, the value is good.
+    2. Raw, only if the first pass finds no close anywhere. Nothing is exempt
+       here: a matching character inside a comment, inside a differently quoted
+       value, or in an unquoted value all close the run.
+
+    A close found by pass 2, or a pass-1 close followed by text python-dotenv
+    cannot parse, means the statement is unparseable: its key is dropped and
+    parsing resumes after the close that was found.
+    """
+    contents, closed, end = _read_quoted(text, quote, escape_aware=True)
+    if closed:
+        tail = text[end:].split("\n", 1)[0].strip()
+        if not tail or tail.startswith("#"):
+            return contents, True, end, True
+        # Closed, but python-dotenv cannot parse what follows, so it drops the
+        # statement. end still says where parsing resumes.
+        return contents, True, end, False
+
+    recovered, closed, end = _read_quoted(text, quote, escape_aware=False)
+    return recovered, closed, end, False
+
+
+def _read_quoted(text, quote, escape_aware):
+    """Return (contents, closed, end_index) for text starting with a quote.
+
+    end_index is the position just past the closing quote. A '#' inside the
+    quotes is data, not a comment.
+
+    When escape_aware, backslash escapes are expanded in a single pass, so an
+    escaped quote does not end the run and a literal backslash is never
+    re-interpreted. The caller decides when that applies: parsing a value
+    honours escapes in double quotes only, while recovering from an unclosed
+    quote honours them for either character.
     """
     chars = []
     index = 1
-    while index < len(value):
-        char = value[index]
-        if char == "\\" and quote == '"' and index + 1 < len(value):
-            following = value[index + 1]
-            chars.append(_ESCAPES.get(following, "\\" + following))
+    while index < len(text):
+        char = text[index]
+        if escape_aware and char == "\\" and index + 1 < len(text):
+            following = text[index + 1]
+            decoded = _ESCAPES.get(quote, {})
+            chars.append(decoded.get(following, "\\" + following))
             index += 2
             continue
         if char == quote:
-            return "".join(chars), True
+            return "".join(chars), True, index + 1
         chars.append(char)
         index += 1
-    return "".join(chars), False
+    return "".join(chars), False, index
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {
@@ -271,11 +386,11 @@ def is_set(values, key):
 
 
 
-def report_problems(problems):
+def report_items(heading, items):
     """Print each .env defect and how to fix it."""
     print()
-    print("Fix your .env before starting this task:")
-    for summary, advice in problems:
+    print(heading)
+    for summary, advice in items:
         print(f"\n  {summary}\n    {advice}")
 
 def main():
@@ -295,6 +410,7 @@ def main():
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
     problems = find_env_problems(env_path) if env_path.exists() else []
+    notes = find_env_notes(env_path) if env_path.exists() else []
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
@@ -306,17 +422,21 @@ def main():
         if problems:
             for summary, _ in problems:
                 print(f"\n  [PROBLEM] {summary}")
-            report_problems(problems)
+            report_items("Fix your .env before starting a code task:", problems)
             return 1
+        if notes:
+            for summary, _ in notes:
+                print(f"\n  [NOTE] {summary}")
+            report_items("This task does not need .env, but note:", notes)
         return 0
 
-    # A malformed .env is reported on its own. Listing keys as OK/MISSING
-    # alongside it would either claim a broken file is fine, or point the
-    # learner at keys that are only "missing" because of the real defect.
+    # A BOM always corrupts the first setting's name, so the file cannot work
+    # whatever the task needs. Report it on its own: listing keys as OK/MISSING
+    # alongside it would either bless a broken file or point at the wrong thing.
     if problems:
         for summary, _ in problems:
             print(f"  [PROBLEM] {summary}")
-        report_problems(problems)
+        report_items("Fix your .env before starting this task:", problems)
         return 1
 
     missing = [key for key in required if not is_set(values, key)]
@@ -324,8 +444,19 @@ def main():
     for key in required:
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
+    for summary, _ in notes:
+        print(f"  [NOTE] {summary}")
 
+    # A malformed line only matters if it actually cost this task a setting.
+    # A stray quote with nothing after it to swallow leaves a working file, and
+    # failing that would be a false alarm in the other direction.
     if not missing:
+        if notes:
+            report_items(
+                "One line in your .env is malformed, but nothing this task "
+                "needs is affected:",
+                notes,
+            )
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
@@ -334,6 +465,8 @@ def main():
     print("Set the following before starting this task:")
     for key in missing:
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    if notes:
+        report_items("This may be why -- your .env has a malformed line:", notes)
     return 1
 
 

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/check_env.py
@@ -268,8 +268,14 @@ def _scan_for_close(text, quote):
         # statement. end still says where parsing resumes.
         return contents, True, end, False
 
-    recovered, closed, end = _read_quoted(text, quote, escape_aware=False)
-    return recovered, closed, end, False
+    # Recovery. python-dotenv's value pattern failed to match, and it then
+    # resynchronises on the LAST occurrence of the quote character rather than
+    # the first, so everything up to that point is lost. Measured: keys after
+    # that final occurrence survive, and if there are none, nothing does.
+    last = text.rfind(quote, 1)
+    if last == -1:
+        return "", False, len(text), False
+    return text[1:last], True, last + 1, False
 
 
 def _read_quoted(text, quote, escape_aware):

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.ps1
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.ps1
@@ -33,4 +33,4 @@ Set-EnvValue 'PROJECT_ENDPOINT' $env:PROJECT_ENDPOINT
 Set-EnvValue 'MODEL_DEPLOYMENT_NAME' $env:MODEL_DEPLOYMENT_NAME
 
 Write-Host "Updated $envPath with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
-Write-Host "Task 1 also needs a grounded agent: run 'python setup/bootstrap_agent.py' to create it."
+Write-Host "Task 1 also needs a grounded agent: from the Python folder, run 'python ../setup/bootstrap_agent.py' to create it."

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.sh
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/write_env.sh
@@ -34,4 +34,4 @@ set_env_value "PROJECT_ENDPOINT" "$PROJECT_ENDPOINT"
 set_env_value "MODEL_DEPLOYMENT_NAME" "$MODEL_DEPLOYMENT_NAME"
 
 echo "Updated $env_path with your provisioned PROJECT_ENDPOINT and MODEL_DEPLOYMENT_NAME."
-echo "Task 1 also needs a grounded agent: run 'python setup/bootstrap_agent.py' to create it."
+echo "Task 1 also needs a grounded agent: from the Python folder, run 'python ../setup/bootstrap_agent.py' to create it."

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/README.md
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/README.md
@@ -39,9 +39,12 @@ This lab can be completed end to end **or one task at a time**. Two things make 
   needs and how to fast-forward.
 - **Setup scripts** in `Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/`:
   - `check_env.py --task N` — preflight-checks that `.env` has the keys task *N* needs.
+    Run it as `python ../setup/check_env.py --task N`.
 
-Both scripts run from the **starter** `Python/` folder and use the shared virtual environment
-and `.env`.
+The script runs from the **starter** `Python/` folder
+(`Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python`, not `Solution/Python/`)
+and uses the shared virtual environment and `.env`. That's why the path above is
+`../setup/...` — `setup/` is a sibling of the starter `Python/` folder.
 
 ### Optional: provision infrastructure with azd
 
@@ -80,7 +83,7 @@ Sign in with the same account that has access to the project. Every task authent
 fails at run time.
 
 ### 3. Set up the environment once (shared by all tasks)
-From the `Python/` folder:
+From this folder (`Solution/Python/`):
 ```
 python -m venv labenv
 .\labenv\Scripts\Activate.ps1        # Windows PowerShell
@@ -93,7 +96,7 @@ Then copy `.env.example` to `.env` and fill in the values (all tasks read the sa
   (these ship pre-filled in `.env.example`)
 
 ### 4. Run each task
-All commands run from the single `Python/` folder:
+All commands run from the single `Solution/Python/` folder:
 
 | Task | Command | What you get |
 |------|---------|--------------|
@@ -110,5 +113,5 @@ Press Ctrl+C in the `run_all.py` terminal to stop every server.
 
 ## Quick sanity checks that DON'T need Azure
 - `python -m py_compile <file>` — all solution files compile.
-- From `Python/`: `python -c "print(open('data.txt').read())"` prints the Tailwind Traders
+- From `Solution/Python/`: `python -c "print(open('data.txt').read())"` prints the Tailwind Traders
   guided-trip expense data that Task 1's agent reads.

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
@@ -40,19 +40,95 @@ from pathlib import Path
 def read_env_file(env_path):
     """Parse a .env file into a dict, using only the standard library.
 
-    Mirrors python-dotenv's dotenv_values() for the syntax these labs use:
-    comments, blank lines, 'export KEY=value', single- and double-quoted values,
-    inline comments after unquoted values, and bare keys (value None). Reads as
-    utf-8-sig so a Notepad-saved .env carrying a UTF-8 BOM still resolves its
-    first key. Returns an empty dict if the file cannot be read.
+    Matches python-dotenv's dotenv_values() for every well-formed .env these
+    labs use: comments, blank lines, 'export KEY=value' (space or tab), single-
+    and double-quoted values, escape sequences inside double quotes, inline
+    comments after a value, and bare keys (value None). Returns an empty dict
+    if the file cannot be read.
+
+    Matching python-dotenv matters because the lab apps load .env with
+    python-dotenv: whatever it returns is what the app actually sees, so the
+    preflight has to agree with it rather than be a "better" parser.
+
+    Malformed files are handled by find_env_problems() instead -- see the note
+    there for why this function does not try to imitate python-dotenv's
+    behaviour on broken input.
+    """
+    values, _ = _parse(env_path)
+    return values
+
+
+def find_env_problems(env_path):
+    """Return a list of (summary, advice) for defects that break the lab apps.
+
+    Some .env defects do not make a key "missing" so much as make the file
+    unusable in ways the learner cannot see. For those we refuse to give a
+    per-key verdict at all: reporting "[OK] PROJECT_ENDPOINT" for a file the
+    app cannot read would be a false positive, and reporting unrelated keys as
+    MISSING would send the learner hunting the wrong problem. Instead we name
+    the defect, explain the cause, and exit non-zero.
+
+    Detected:
+
+    * UTF-8 BOM. python-dotenv does not strip it, so it becomes part of the
+      first setting's NAME and the app's os.getenv() for that setting returns
+      None even though the file looks correct.
+    * Unterminated quote. python-dotenv treats the opening quote as the start
+      of a multi-line value. What that costs depends on the rest of the file:
+      with no later quote it drops just that entry, but if a quote appears
+      further down it swallows everything in between, silently wiping settings
+      that are themselves written correctly.
+    """
+    problems = []
+    if _has_bom(env_path):
+        problems.append((
+            ".env starts with a UTF-8 BOM",
+            "Your .env was saved as 'UTF-8 with BOM' (Notepad does this by\n"
+            "    default). The BOM becomes part of the first setting's name, so the\n"
+            "    lab apps read that setting as empty even though the file looks\n"
+            "    correct. Re-save as plain UTF-8: in VS Code click the encoding\n"
+            "    indicator in the status bar, choose 'Save with Encoding', then\n"
+            "    'UTF-8' (not 'UTF-8 with BOM').",
+        ))
+
+    _, open_quote_line = _parse(env_path)
+    if open_quote_line is not None:
+        number, text = open_quote_line
+        problems.append((
+            f"unterminated quote on line {number} of .env",
+            f"That line is:  {text}\n"
+            "    It opens a quote that is never closed. The lab apps then treat\n"
+            "    everything after it as part of that one value, which can silently\n"
+            "    wipe out settings further down the file. Close the quote, or\n"
+            "    remove both quotes -- values in .env do not need them.",
+        ))
+    return problems
+
+
+def _has_bom(env_path):
+    """True if the file starts with a UTF-8 BOM."""
+    try:
+        with open(env_path, "rb") as handle:
+            return handle.read(3) == b"\xef\xbb\xbf"
+    except OSError:
+        return False
+
+
+def _parse(env_path):
+    """Return (values, first_unterminated_quote) for a .env file.
+
+    first_unterminated_quote is None, or (line_number, stripped_line).
     """
     values = {}
+    bad_quote = None
     try:
+        # utf-8-sig strips a BOM so the remaining keys are reported accurately.
+        # The BOM itself is surfaced separately by find_env_problems().
         text = Path(env_path).read_text(encoding="utf-8-sig")
     except OSError:
-        return values
+        return values, bad_quote
 
-    for raw_line in text.splitlines():
+    for number, raw_line in enumerate(text.splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
@@ -69,10 +145,10 @@ def read_env_file(env_path):
 
         value = value.strip()
         if value[:1] in ("'", '"'):
-            quote = value[0]
-            inner, closed = _read_quoted(value, quote)
+            inner, closed = _read_quoted(value, value[0])
             if not closed:
-                # Unterminated quote: python-dotenv discards the whole entry.
+                if bad_quote is None:
+                    bad_quote = (number, line)
                 continue
             # Anything after the closing quote (such as ' # comment') is dropped.
             value = inner
@@ -82,21 +158,27 @@ def read_env_file(env_path):
             value = value.strip()
         values[key] = value
 
-    return values
+    return values, bad_quote
+
+
+# Escape sequences python-dotenv expands inside double-quoted values.
+_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", "'": "'", '"': '"'}
 
 
 def _read_quoted(value, quote):
     """Return (contents, closed) for a value that starts with a quote character.
 
-    A '#' inside the quotes is data, not a comment. Backslash escapes are
-    honored inside double quotes, matching python-dotenv.
+    A '#' inside the quotes is data, not a comment. Inside double quotes,
+    backslash escapes are expanded in a single pass, so an escaped quote does
+    not end the value and a literal backslash is never re-interpreted.
     """
     chars = []
     index = 1
     while index < len(value):
         char = value[index]
         if char == "\\" and quote == '"' and index + 1 < len(value):
-            chars.append(value[index + 1])
+            following = value[index + 1]
+            chars.append(_ESCAPES.get(following, "\\" + following))
             index += 2
             continue
         if char == quote:
@@ -130,16 +212,32 @@ ALL_KEYS = [
     "ROUTING_AGENT_PORT",
 ]
 
-# Placeholder text shipped in .env.example — present but not yet filled in.
-PLACEHOLDERS = {
-    "",
-    "your_project_endpoint_here",
-    "your_model_deployment_name_here",
-    "your-project-endpoint",
-    "your-model-deployment-name",
-    "<your-project-endpoint>",
-    "<your-model-deployment-name>",
-}
+def looks_like_placeholder(value):
+    """True if the value is still example text rather than a real setting.
+
+    Matched by shape rather than an exact list. The shipped .env.example files
+    have used both 'your-project-endpoint' and 'your_project_endpoint_here',
+    and an exact list silently rots the moment one of them changes -- which is
+    exactly what happened: a learner could copy .env.example verbatim, change
+    nothing, and be told they were ready to start.
+
+    Anything empty, wrapped in angle brackets, or whose first word is "your"
+    counts as unfilled. Real defaults these labs ship (tailwind-agent,
+    tailwind-knowledge-agent, localhost, port numbers) do not match.
+
+    This deliberately errs toward "not filled in": a real value beginning with
+    the word "your" would be flagged, but none of these keys takes one (they
+    hold a URL, a model deployment name, a slug or a port). Being told to
+    double-check a key you did set is recoverable; being told you are ready
+    when you are not is the failure this whole script exists to prevent.
+    """
+    text = value.strip()
+    if not text:
+        return True
+    if text.startswith("<") and text.endswith(">"):
+        return True
+    words = text.replace("-", " ").replace("_", " ").lower().split()
+    return bool(words) and words[0] == "your"
 
 # How to fix each key, shown only when it's missing.
 FIX_HINTS = {
@@ -199,9 +297,16 @@ def load_values(env_path):
 
 def is_set(values, key):
     """A key counts as set if it's present and not a leftover placeholder."""
-    value = (values.get(key) or "").strip()
-    return bool(value) and value not in PLACEHOLDERS
+    return not looks_like_placeholder(values.get(key) or "")
 
+
+
+def report_problems(problems):
+    """Print each .env defect and how to fix it."""
+    print()
+    print("Fix your .env before starting this task:")
+    for summary, advice in problems:
+        print(f"\n  {summary}\n    {advice}")
 
 def main():
     parser = argparse.ArgumentParser(
@@ -219,10 +324,20 @@ def main():
     env_path = find_env_file()
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
+    problems = find_env_problems(env_path) if env_path.exists() else []
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
     print()
+
+    # A malformed .env is reported on its own. Listing keys as OK/MISSING
+    # alongside it would either claim a broken file is fine, or point the
+    # learner at keys that are only "missing" because of the real defect.
+    if problems:
+        for summary, _ in problems:
+            print(f"  [PROBLEM] {summary}")
+        report_problems(problems)
+        return 1
 
     missing = [key for key in required if not is_set(values, key)]
 

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
@@ -40,44 +40,29 @@ from pathlib import Path
 def read_env_file(env_path):
     """Parse a .env file into a dict, using only the standard library.
 
-    Matches python-dotenv's dotenv_values() for every well-formed .env these
-    labs use: comments, blank lines, 'export KEY=value' (space or tab), single-
+    Matches python-dotenv's dotenv_values() for every .env shape these labs can
+    encounter: comments, blank lines, 'export KEY=value' (space or tab), single-
     and double-quoted values, escape sequences inside double quotes, inline
-    comments after a value, and bare keys (value None). Returns an empty dict
-    if the file cannot be read.
+    comments, values quoted across several lines, and bare keys (value None).
 
     Matching python-dotenv matters because the lab apps load .env with
-    python-dotenv: whatever it returns is what the app actually sees, so the
-    preflight has to agree with it rather than be a "better" parser.
+    python-dotenv. Whatever it returns is what the app actually sees, so the
+    preflight has to agree with it rather than be a "better" parser -- a parser
+    that is more forgiving than the runtime reports keys as present that the
+    app cannot read.
 
-    Malformed files are handled by find_env_problems() instead -- see the note
-    there for why this function does not try to imitate python-dotenv's
-    behaviour on broken input.
+    Returns an empty dict if the file cannot be read.
     """
     values, _ = _parse(env_path)
     return values
 
 
 def find_env_problems(env_path):
-    """Return a list of (summary, advice) for defects that break the lab apps.
+    """Return a list of (summary, advice) for defects that always break the app.
 
-    Some .env defects do not make a key "missing" so much as make the file
-    unusable in ways the learner cannot see. For those we refuse to give a
-    per-key verdict at all: reporting "[OK] PROJECT_ENDPOINT" for a file the
-    app cannot read would be a false positive, and reporting unrelated keys as
-    MISSING would send the learner hunting the wrong problem. Instead we name
-    the defect, explain the cause, and exit non-zero.
-
-    Detected:
-
-    * UTF-8 BOM. python-dotenv does not strip it, so it becomes part of the
-      first setting's NAME and the app's os.getenv() for that setting returns
-      None even though the file looks correct.
-    * Unterminated quote. python-dotenv treats the opening quote as the start
-      of a multi-line value. What that costs depends on the rest of the file:
-      with no later quote it drops just that entry, but if a quote appears
-      further down it swallows everything in between, silently wiping settings
-      that are themselves written correctly.
+    Only a BOM qualifies: it always corrupts the name of the first setting, so
+    the file cannot work no matter which task the learner is starting. Other
+    malformations are impact-dependent and come back from find_env_notes().
     """
     problems = []
     if _has_bom(env_path):
@@ -90,19 +75,52 @@ def find_env_problems(env_path):
             "    indicator in the status bar, choose 'Save with Encoding', then\n"
             "    'UTF-8' (not 'UTF-8 with BOM').",
         ))
-
-    _, open_quote_line = _parse(env_path)
-    if open_quote_line is not None:
-        number, text = open_quote_line
-        problems.append((
-            f"unterminated quote on line {number} of .env",
-            f"That line is:  {text}\n"
-            "    It opens a quote that is never closed. The lab apps then treat\n"
-            "    everything after it as part of that one value, which can silently\n"
-            "    wipe out settings further down the file. Close the quote, or\n"
-            "    remove both quotes -- values in .env do not need them.",
-        ))
     return problems
+
+
+def find_env_notes(env_path):
+    """Return a list of (summary, advice) for malformed lines in the .env.
+
+    These are reported but not automatically fatal. A stray quote only matters
+    if it actually costs the learner a setting the task needs: an unterminated
+    quote with nothing after it to swallow leaves a working file, and failing
+    that would be its own false alarm. The caller decides, by checking whether
+    the keys the task needs came through.
+
+    Detection reads the file directly rather than inferring from parser output,
+    because python-dotenv reports malformed statements to stderr and simply
+    omits them from its result -- the app just sees a setting vanish with no
+    indication of why.
+    """
+    notes = []
+    _, defects = _parse(env_path)
+    for kind, number, text in defects:
+        if kind == "unterminated":
+            notes.append((
+                f"unterminated quote on line {number} of .env",
+                f"That line is:  {text}\n"
+                "    It opens a quote that is never closed, so the lab apps drop\n"
+                "    that setting entirely. Close the quote, or remove both quotes\n"
+                "    -- values in .env do not need them.",
+            ))
+        elif kind == "swallowed":
+            notes.append((
+                f"quote opened on line {number} of .env is closed much later",
+                f"That line is:  {text}\n"
+                "    Everything up to the next quote further down the file becomes\n"
+                "    part of this one value, so the settings in between are lost\n"
+                "    even though they look correct. Close the quote on this line,\n"
+                "    or remove both quotes.",
+            ))
+        elif kind == "trailing":
+            notes.append((
+                f"unexpected text after the quoted value on line {number} of .env",
+                f"That line is:  {text}\n"
+                "    python-dotenv cannot parse the line, so the lab apps drop that\n"
+                "    setting. Keep the value inside one pair of quotes, and put\n"
+                "    nothing after the closing quote except a # comment.",
+            ))
+    return notes
 
 
 def _has_bom(env_path):
@@ -114,22 +132,45 @@ def _has_bom(env_path):
         return False
 
 
-def _parse(env_path):
-    """Return (values, first_unterminated_quote) for a .env file.
+def _looks_like_assignment(line):
+    """True for a line shaped like KEY=..., used to spot swallowed settings."""
+    head = line.strip().partition("=")
+    if not head[1]:
+        return False
+    name = head[0].strip()
+    if name.startswith("export "):
+        name = name[len("export "):].strip()
+    return bool(name) and name.replace("_", "").isalnum()
 
-    first_unterminated_quote is None, or (line_number, stripped_line).
+
+def _parse(env_path):
+    """Return (values, defects).
+
+    defects is a list of (kind, line_number, line_text) where kind is one of
+    "unterminated", "swallowed" or "trailing".
+
+    Quoted values are resolved with a lookahead that only advances when a
+    closing quote is actually found, which is what python-dotenv does: a quote
+    closed on a later line is a legitimate multi-line value, while a quote that
+    is never closed makes python-dotenv discard that statement and resume at
+    the next line.
     """
     values = {}
-    bad_quote = None
+    defects = []
     try:
         # utf-8-sig strips a BOM so the remaining keys are reported accurately.
         # The BOM itself is surfaced separately by find_env_problems().
         text = Path(env_path).read_text(encoding="utf-8-sig")
     except OSError:
-        return values, bad_quote
+        return values, defects
 
-    for number, raw_line in enumerate(text.splitlines(), start=1):
-        line = raw_line.strip()
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        number = index + 1
+        line = lines[index].strip()
+        index += 1
+
         if not line or line.startswith("#"):
             continue
         if line.startswith("export ") or line.startswith("export\t"):
@@ -144,48 +185,122 @@ def _parse(env_path):
             continue
 
         value = value.strip()
-        if value[:1] in ("'", '"'):
-            inner, closed = _read_quoted(value, value[0])
-            if not closed:
-                if bad_quote is None:
-                    bad_quote = (number, line)
-                continue
-            # Anything after the closing quote (such as ' # comment') is dropped.
-            value = inner
-        else:
+        if value[:1] not in ("'", '"'):
             for comment_marker in (" #", "\t#"):
                 value = value.split(comment_marker, 1)[0]
-            value = value.strip()
-        values[key] = value
+            values[key] = value.strip()
+            continue
 
-    return values, bad_quote
+        quote = value[0]
+        # Join the rest of the file so a value may close on a later line.
+        rest = "\n".join([value] + lines[index:])
+        inner, closed, end, usable = _scan_for_close(rest, quote)
+        if not closed:
+            defects.append(("unterminated", number, line))
+            continue
+
+        consumed = rest.count("\n", 0, end)
+        if not usable:
+            # python-dotenv cannot parse the statement and drops it. If the
+            # quote also spanned lines, report it as a swallow: the settings it
+            # ate are the part the learner can actually see and act on.
+            defects.append(("swallowed" if consumed else "trailing", number, line))
+            index += consumed
+            continue
+
+        if consumed:
+            swallowed = lines[index:index + consumed]
+            if any(_looks_like_assignment(item) for item in swallowed):
+                defects.append(("swallowed", number, line))
+            index += consumed
+
+        values[key] = inner
+
+    return values, defects
 
 
-# Escape sequences python-dotenv expands inside double-quoted values.
-_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", "'": "'", '"': '"'}
+# Escape sequences python-dotenv decodes, per quote character. Double quotes
+# take the full set; single quotes decode only the delimiter and a literal
+# backslash, so '\n' inside single quotes stays as a backslash and an n.
+# Anything not listed keeps its backslash.
+_ESCAPES = {
+    '"': {
+        "a": "\a",
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        '"': '"',
+        "'": "'",
+        "\\": "\\",
+    },
+    "'": {"'": "'", "\\": "\\"},
+}
 
 
-def _read_quoted(value, quote):
-    """Return (contents, closed) for a value that starts with a quote character.
+def _scan_for_close(text, quote):
+    """Find where a quoted value ends, the way python-dotenv does.
 
-    A '#' inside the quotes is data, not a comment. Inside double quotes,
-    backslash escapes are expanded in a single pass, so an escaped quote does
-    not end the value and a literal backslash is never re-interpreted.
+    Returns (contents, closed, end_index, usable). usable is False when
+    python-dotenv could not parse the statement and dropped it, in which case
+    end_index still says where parsing resumes.
+
+    Two passes, matching python-dotenv:
+
+    1. Escape-aware, using the escape set for whichever character opened the
+       value (see _ESCAPES). A backslash-escaped quote is skipped rather than
+       treated as the close. If this closes with nothing but whitespace or a
+       comment after it, the value is good.
+    2. Raw, only if the first pass finds no close anywhere. Nothing is exempt
+       here: a matching character inside a comment, inside a differently quoted
+       value, or in an unquoted value all close the run.
+
+    A close found by pass 2, or a pass-1 close followed by text python-dotenv
+    cannot parse, means the statement is unparseable: its key is dropped and
+    parsing resumes after the close that was found.
+    """
+    contents, closed, end = _read_quoted(text, quote, escape_aware=True)
+    if closed:
+        tail = text[end:].split("\n", 1)[0].strip()
+        if not tail or tail.startswith("#"):
+            return contents, True, end, True
+        # Closed, but python-dotenv cannot parse what follows, so it drops the
+        # statement. end still says where parsing resumes.
+        return contents, True, end, False
+
+    recovered, closed, end = _read_quoted(text, quote, escape_aware=False)
+    return recovered, closed, end, False
+
+
+def _read_quoted(text, quote, escape_aware):
+    """Return (contents, closed, end_index) for text starting with a quote.
+
+    end_index is the position just past the closing quote. A '#' inside the
+    quotes is data, not a comment.
+
+    When escape_aware, backslash escapes are expanded in a single pass, so an
+    escaped quote does not end the run and a literal backslash is never
+    re-interpreted. The caller decides when that applies: parsing a value
+    honours escapes in double quotes only, while recovering from an unclosed
+    quote honours them for either character.
     """
     chars = []
     index = 1
-    while index < len(value):
-        char = value[index]
-        if char == "\\" and quote == '"' and index + 1 < len(value):
-            following = value[index + 1]
-            chars.append(_ESCAPES.get(following, "\\" + following))
+    while index < len(text):
+        char = text[index]
+        if escape_aware and char == "\\" and index + 1 < len(text):
+            following = text[index + 1]
+            decoded = _ESCAPES.get(quote, {})
+            chars.append(decoded.get(following, "\\" + following))
             index += 2
             continue
         if char == quote:
-            return "".join(chars), True
+            return "".join(chars), True, index + 1
         chars.append(char)
         index += 1
-    return "".join(chars), False
+    return "".join(chars), False, index
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {
@@ -301,11 +416,11 @@ def is_set(values, key):
 
 
 
-def report_problems(problems):
+def report_items(heading, items):
     """Print each .env defect and how to fix it."""
     print()
-    print("Fix your .env before starting this task:")
-    for summary, advice in problems:
+    print(heading)
+    for summary, advice in items:
         print(f"\n  {summary}\n    {advice}")
 
 def main():
@@ -325,18 +440,19 @@ def main():
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
     problems = find_env_problems(env_path) if env_path.exists() else []
+    notes = find_env_notes(env_path) if env_path.exists() else []
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
     print()
 
-    # A malformed .env is reported on its own. Listing keys as OK/MISSING
-    # alongside it would either claim a broken file is fine, or point the
-    # learner at keys that are only "missing" because of the real defect.
+    # A BOM always corrupts the first setting's name, so the file cannot work
+    # whatever the task needs. Report it on its own: listing keys as OK/MISSING
+    # alongside it would either bless a broken file or point at the wrong thing.
     if problems:
         for summary, _ in problems:
             print(f"  [PROBLEM] {summary}")
-        report_problems(problems)
+        report_items("Fix your .env before starting this task:", problems)
         return 1
 
     missing = [key for key in required if not is_set(values, key)]
@@ -344,8 +460,19 @@ def main():
     for key in required:
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
+    for summary, _ in notes:
+        print(f"  [NOTE] {summary}")
 
+    # A malformed line only matters if it actually cost this task a setting.
+    # A stray quote with nothing after it to swallow leaves a working file, and
+    # failing that would be a false alarm in the other direction.
     if not missing:
+        if notes:
+            report_items(
+                "One line in your .env is malformed, but nothing this task "
+                "needs is affected:",
+                notes,
+            )
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
@@ -354,6 +481,8 @@ def main():
     print("Set the following before starting this task:")
     for key in missing:
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    if notes:
+        report_items("This may be why -- your .env has a malformed line:", notes)
     return 1
 
 

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
@@ -270,8 +270,14 @@ def _scan_for_close(text, quote):
         # statement. end still says where parsing resumes.
         return contents, True, end, False
 
-    recovered, closed, end = _read_quoted(text, quote, escape_aware=False)
-    return recovered, closed, end, False
+    # Recovery. python-dotenv's value pattern failed to match, and it then
+    # resynchronises on the LAST occurrence of the quote character rather than
+    # the first, so everything up to that point is lost. Measured: keys after
+    # that final occurrence survive, and if there are none, nothing does.
+    last = text.rfind(quote, 1)
+    if last == -1:
+        return "", False, len(text), False
+    return text[1:last], True, last + 1, False
 
 
 def _read_quoted(text, quote, escape_aware):

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
@@ -2,9 +2,17 @@
 Preflight check for the Tailwind Traders multi-agent lab.
 
 Each task in this lab can be completed on its own. Before you start a task,
-run this script to confirm your .env file has everything that task needs:
+run this script to confirm your .env file has everything that task needs.
 
-    python setup/check_env.py --task 1
+Run it from the lab's starter code folder —
+Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python, the folder you
+open in VS Code, where your virtual environment and .env live:
+
+    python ../setup/check_env.py --task 1
+
+This script uses only the Python standard library, so it works before you run
+'pip install' and without the lab virtual environment active. Keep it that way:
+it is the one script learners are most likely to run in a bare environment.
 
 It never changes anything — it only reads your .env and tells you what (if
 anything) is missing, so you can fix it before running the task.
@@ -23,7 +31,53 @@ import argparse
 import os
 from pathlib import Path
 
-from dotenv import dotenv_values
+# Keep this script dependency-free. It is a *preflight* check, so it runs before
+# 'pip install' and often on a bare system Python with no virtual environment
+# active. Importing anything outside the standard library (python-dotenv
+# included) would make it fail at exactly the moment it is most needed.
+
+
+def read_env_file(env_path):
+    """Parse a .env file into a dict, using only the standard library.
+
+    Mirrors python-dotenv's dotenv_values() for the syntax these labs use:
+    comments, blank lines, 'export KEY=value', single- and double-quoted values,
+    inline comments after unquoted values, and bare keys (value None). Reads as
+    utf-8-sig so a Notepad-saved .env carrying a UTF-8 BOM still resolves its
+    first key. Returns an empty dict if the file cannot be read.
+    """
+    values = {}
+    try:
+        text = Path(env_path).read_text(encoding="utf-8-sig")
+    except OSError:
+        return values
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export ") or line.startswith("export\t"):
+            line = line[len("export"):].lstrip()
+
+        key, separator, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        if not separator:
+            values[key] = None
+            continue
+
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            # Quoted: a '#' inside the quotes is data, not a comment.
+            value = value[1:-1]
+        else:
+            for comment_marker in (" #", "\t#"):
+                value = value.split(comment_marker, 1)[0]
+            value = value.strip()
+        values[key] = value
+
+    return values
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {
@@ -110,7 +164,7 @@ def load_values(env_path):
     """Merge real environment variables over .env file values (env wins)."""
     values = {}
     if env_path.exists():
-        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+        values.update({k: v for k, v in read_env_file(env_path).items() if v is not None})
     for key in ALL_KEYS:
         if os.environ.get(key):
             values[key] = os.environ[key]

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/check_env.py
@@ -68,9 +68,14 @@ def read_env_file(env_path):
             continue
 
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            # Quoted: a '#' inside the quotes is data, not a comment.
-            value = value[1:-1]
+        if value[:1] in ("'", '"'):
+            quote = value[0]
+            inner, closed = _read_quoted(value, quote)
+            if not closed:
+                # Unterminated quote: python-dotenv discards the whole entry.
+                continue
+            # Anything after the closing quote (such as ' # comment') is dropped.
+            value = inner
         else:
             for comment_marker in (" #", "\t#"):
                 value = value.split(comment_marker, 1)[0]
@@ -78,6 +83,27 @@ def read_env_file(env_path):
         values[key] = value
 
     return values
+
+
+def _read_quoted(value, quote):
+    """Return (contents, closed) for a value that starts with a quote character.
+
+    A '#' inside the quotes is data, not a comment. Backslash escapes are
+    honored inside double quotes, matching python-dotenv.
+    """
+    chars = []
+    index = 1
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and quote == '"' and index + 1 < len(value):
+            chars.append(value[index + 1])
+            index += 2
+            continue
+        if char == quote:
+            return "".join(chars), True
+        chars.append(char)
+        index += 1
+    return "".join(chars), False
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {


### PR DESCRIPTION
Fixes two bugs that block a learner at the very first command of the consolidated Labs A/B/C, plus a latent third found while validating. Bug fixes only — no restructuring, no pedagogy changes, no currency pass.

Both bugs were reported from four downstream repos modelled on these labs. **Both are confirmed present here at the source.**

## Bug 1 — `check_env.py` working-directory bug (CONFIRMED)

The pages say `python setup/check_env.py --task N`, but every page first has learners **Open Folder** on `Labfiles/<Lab>/Python` (where the venv and `.env` live), so their cwd is the code folder:

```
cwd: Labfiles/A-build-and-extend-ai-agents/Python
$ python setup/check_env.py --task 2
can't open file '...\Python\setup\check_env.py': [Errno 2] No such file or directory
exit=2
```

The surrounding prose also **named the lab root**, so fixing the command alone would have left a misleading sentence. Fixed the command and the prose on every page, and in the non-prose places a command-line-only sweep misses:

- module docstrings in all 3 `setup/check_env.py` and both `setup/bootstrap_agent.py`
- `FIX_HINTS` strings printed *to the learner* when a key is missing
- `Solution/README.md` setup-script bullets in all 3 labs
- the `write_env.ps1` / `write_env.sh` azd hook messages

21 command paths + 12 prose references. Repo-wide grep now finds **zero** un-prefixed `setup/check_env.py` or `setup/bootstrap_agent.py`.

**Ambiguity variant.** The `Solution/README.md` files live *in* `Solution/`, so a bare "the `Python/` folder" reads as `Solution/Python/`, from which `../setup/` resolves to a non-existent `Solution/setup/`. Setup-script references now say the **starter** `Python/` folder (not `Solution/Python/`); the venv-creation and run-the-app sections, which genuinely do mean the solution tree, now say `Solution/Python/` explicitly.

## Bug 2 — `check_env.py` depended on `python-dotenv` (CONFIRMED)

```
cwd: Labfiles/A-build-and-extend-ai-agents/Python, clean interpreter
$ python ../setup/check_env.py --task 1
ModuleNotFoundError: No module named 'dotenv'
```

Lab A **Task 1 is portal-only** and its page states no code and no `.env` are needed — so the one task advertising that it required nothing greeted the learner with a traceback. `--help` failed identically, which breaches validation gate item 5 ("`--help` must run cleanly"): the reference implementation that defines the gate was failing it on any clean interpreter.

Because these labs are **standalone-by-default**, task pages are the primary entry point and each puts the preflight in its opening callout *before any venv step appears on that page*. The modular design therefore increases exposure to this bug.

So the fix makes the preflight **dependency-free by design** rather than merely patched: `python-dotenv` was its only non-stdlib import, so `check_env.py` now has zero. The invariant is stated in the docstring so a future editor doesn't reintroduce one.

The stdlib parser handles comments, blank lines, `export KEY=value`, single- and double-quoted values, `#` inside quotes (not stripped), inline comments, bare keys (`None`), and returns `{}` for an unreadable file.

## Bug 3 — UTF-8 BOM breaks key lookup (found while validating, CONFIRMED)

`python-dotenv` does not strip a UTF-8 BOM, so a `.env` saved by Notepad parses its first key as `\ufeffPROJECT_ENDPOINT`:

```
$ python -c "from dotenv import dotenv_values; print(dotenv_values('bom.env'))"
{'\ufeffPROJECT_ENDPOINT': 'https://example.com', 'MODEL_DEPLOYMENT_NAME': 'gpt-4o'}
PROJECT_ENDPOINT found: False
```

The preflight would report a correctly-set key as **MISSING**. Reading as `utf-8-sig` fixes this unconditionally.

Also fixed a pre-existing em-dash in a `bootstrap_agent.py` `print()` string (ASCII console rule).

## Validation

Every command executed from the exact cwd its page implies, in the environment state the learner would actually have.

| Check | Result |
|---|---|
| 17 preflight invocations (3 labs × all tasks + `--help`) from each lab's starter `Python/` folder, **clean interpreter, nothing installed** | ALL PASS |
| Same 17 re-run **with `python-dotenv` installed** (regression) | ALL PASS |
| Parser parity vs real `python-dotenv` 1.2.2 — 3 `check_env.py` × (edge-case fixture + all 8 shipped `.env.example`) | **27 comparisons, 0 mismatches** |
| `py_compile` on all 5 changed `.py` | PASS |
| Un-prefixed `setup/*.py` references repo-wide | **zero** |
| Non-ASCII printed strings in Lab A/B/C `.py` | **zero** |
| `__pycache__` / venv / `.env` staged | none |

**On masking:** this machine's *system* Python has `python-dotenv` installed globally, so my first "no venv" run passed and masked Bug 2 entirely. I built a purpose-made interpreter with no packages and confirmed `import dotenv` genuinely fails there before drawing any conclusion. The parity comparison is likewise non-vacuous.

## Verified NOT broken here (clean negatives)

- **Media depth.** `../Media/anton-avatar.png` resolves correctly — the consolidated pages sit at the same depth as the legacy exercises (`Instructions/Exercises/` → `Instructions/Media/`), and the asset exists. Not affected by the downstream depth trap.
- **azd instructions.** `From the Labfiles/<Lab> folder, run azd up` is correct and intentionally left alone: `azure.yaml` lives at the lab root, and that step precedes the Open Folder step.


---

## Follow-up sweep (second commit)

### Parser divergence: quoted value + inline comment (fixed)

Differential-testing against real `python-dotenv` 1.2.2 found one case my original fixture missed:

```
INLINE_QUOTED="value" # comment
  real dotenv -> 'value'
  ours        -> '"value"'   (literal quotes retained)
```

The old check required first and last characters to both be the same quote; with a trailing comment the last char isn't a quote, so it fell to the unquoted branch and kept the quotes. **A learner whose `.env` used that form would be told a correctly-set key was MISSING** — a false negative in the diagnostic tool itself. Now the parser scans for the closing quote and discards what follows. Also matched `python-dotenv` on backslash escapes inside double quotes and on unterminated quotes (which it discards entirely).

`read_env_file()` and the new `_read_quoted()` are both **module-level**, so they're importable and testable directly rather than only reachable through the script's normal flow.

Re-validated: **7/7** targeted divergence cases in all 3 files (asserted by importing `read_env_file` directly on a dotenv-free interpreter); parity re-run with the fixture expanded to cover quoted-then-comment, single-quoted-then-comment, escaped quotes, spaced quotes and mid-value quotes: **27 comparisons, 0 mismatches**.

### On BOM handling and the two-path concern

This PR removes `python-dotenv` from `check_env.py` **entirely** rather than keeping it as the primary path with a fallback. There is therefore only one code path, and the "dotenv path and fallback must agree" class of bug cannot arise here by construction. Verified anyway: a BOM'd `.env` now reports keys **present** and gives **identical output** on a dotenv-equipped and a dotenv-free interpreter.

Worth recording: **the stdlib parser is more correct than the library it replaces** — `python-dotenv` corrupts the first key of any BOM'd file, which is what Windows Notepad writes by default.

### Path casing: verified CORRECT here (clean negative)

Checked against **git's case-sensitive index**, not the filesystem — my earlier `Test-Path` check was vacuous on Windows.

- The directory is `Instructions/Media` (capital M) and the asset is `Instructions/Media/anton-avatar.png`, so `../Media/anton-avatar.png` is **correct casing at the source**.
- Every local asset reference in the consolidated pages — Markdown images, `src=`/`href=` attributes, and CSS `url(...)` — resolves exactly, case-sensitively: **13 refs, 0 broken**.
- **94** internal page links resolve exactly (2 apparent hits were `**kwargs` inside a code block, not links).
- Asset paths referenced from *code* are cwd-independent (`Path(__file__).resolve().parent.parent / "Python"`), so they're immune to both the casing and the working-directory classes.

So the casing defect did **not** originate here — downstream repos introduced it by copying this pattern into repos whose directory is lowercase `media/`. The reference pattern is nonetheless a trap for anyone adapting these labs into a lowercase-`media` repo, since capital-M passes on Windows and 404s on GitHub Pages.

### `py_compile` sweep of all `Labfiles/` — 2 failures, both OUT OF SCOPE

Swept **86** Python files.

| File | Error | Status |
|---|---|---|
| `Labfiles/02-agent-custom-tools/Python/agent.py` | `IndentationError: unexpected indent` (line 38) | Pre-existing, **also fails on `origin/main`** |
| `Labfiles/07-agent-framework/python/agent-framework.py` | `IndentationError: expected an indented block after function definition` (line 27) | Pre-existing, **also fails on `origin/main`** |

Both are **legacy numbered labs**, not the consolidated Lab A/B/C, and `git diff origin/consolidate-labs-idea..HEAD` shows 0 changes from me in either. Confirmed live on `main` today (last touched by `87dd454` and `fd85209`).

Both are fill-in-the-blank starters where the removed code left a `while True:`/`async def` block with only comments, so the scaffold doesn't parse. **Reporting rather than fixing**, per bug-fix scope — these need an owner decision on whether starters are expected to compile (a `pass` or a `# TODO` stub would fix both). Filing separately is recommended.

**All consolidated Lab A/B/C Python files compile clean.**


---

## Third pass: preflight semantics now match the runtime

The earlier BOM fix was wrong in an instructive way, and fixing it properly exposed several more defects. The governing principle, arrived at the hard way: **the shipped apps load `.env` with `python-dotenv`, so whatever dotenv does defines what the learner's app sees.** The preflight must agree with that runtime — not be a "better" parser.

### The BOM fix is reversed — it created a false positive

Reading `utf-8-sig` made `check_env.py` tolerate a BOM. But measured against the real app startup (`load_dotenv()` + `os.getenv`) from the lab's `Python/` folder:

```
BOM'd .env, all three settings written correctly
  app sees PROJECT_ENDPOINT      = None      <-- app is broken
  app sees MODEL_DEPLOYMENT_NAME = 'gpt-4o'
  app sees AGENT_NAME            = 'tailwind-agent'
```

So it reported `[OK]` for a file the app cannot run — strictly worse than the false negative it replaced. The checker now detects the BOM from raw bytes, explains that Notepad writes it by default, gives the VS Code re-save steps, and exits non-zero.

### Unterminated quotes — measured, not assumed

dotenv discards the malformed statement then resumes, swallowing only until the next occurrence of the **same** character, located escape-aware first with a raw fallback. Nothing is exempt from the raw pass — a matching character inside a comment, inside a differently-quoted value, or in an unquoted value all close it. Multi-line quoted values are legitimate syntax and are **not** flagged.

### Gating on impact, not presence

A stray quote with nothing after it to swallow leaves a working file. Failing that would be a false alarm in the other direction, so:

- nothing the task needs is affected → `[NOTE]`, **exit 0**
- a needed key was eaten → `[MISSING]` + the offending line named, **exit 1**
- a BOM → always fatal (it always corrupts the first setting)

### New bug: placeholder detection didn't match the shipped `.env.example`

Lab A's `PLACEHOLDERS` listed `your-project-endpoint` (hyphens) while its own `.env.example` ships `your_project_endpoint_here` (underscores). A learner who copied the example and changed nothing was told:

```
  [OK ] PROJECT_ENDPOINT
  [OK ] MODEL_DEPLOYMENT_NAME
  You're ready to start Task 2.
```

The most likely learner mistake, blessed by the tool meant to catch it. Labs B and C happened to list both spellings — which is exactly how an exact-match list rots. Replaced with shape-based detection across all three labs.

### Quote and escape semantics

Differential testing turned up three more divergences, each able to report a key as present that the app never receives:

| case | dotenv | before |
|---|---|---|
| `"value" # comment` | `value` | `"value"` (quotes kept) |
| escaped quote during recovery | skipped | terminated the scan |
| `'a\'b'` | `a'b` | entry dropped |

Escape sets are **per quote character** and nested: single quotes decode `\'` and `\\` only; double quotes add `\a \b \f \n \r \t \v \"`. Escape-awareness during *recovery* applies to both characters — asymmetric with value parsing, and asserted via `inspect.getsource` rather than by eye.

## Final validation

| suite | result |
|---|---|
| **App-vs-preflight harness** (app is ground truth, malformed fixtures each paired with a control) | 16 fixtures × 2 interpreters, **0 mismatches** |
| Adjacency matrix (8 malformed × 132 filler pairs × 3 positions × 3 parsers) | 9,504 comparisons, **0 mismatches** |
| Escape codes (2 quote chars × 12 codes × 3 parsers) | 72, **0 mismatches** |
| Escape parse-vs-recovery, with controls | 36, **0 mismatches** |
| Well-formed corpus (incl. CRLF, duplicate keys, `export`+TAB) | 138, **0 mismatches** |
| Mixed-quote context exemptions | 6/6 |
| Unterminated shapes vs app | 7/7 |
| Preflight from learner cwd, clean interpreter / with dotenv | ALL PASS both |

**On non-vacuous verification.** Several checks in this PR would have passed for the wrong reason:
- This machine's system Python has `python-dotenv` installed globally, so the first "no venv" run masked the dependency bug entirely. A purpose-built empty interpreter was used, with `import dotenv` confirmed to fail, before any conclusion.
- `Test-Path` is case-insensitive on Windows, so the first casing check was meaningless; it was redone against git's case-sensitive index.
- The discriminating escape fixtures place the escaped quote in an **unquoted** value; the quoted form passes either way because that line's own quote closes the broken statement first. Both are kept — the quoted one as a control against over-decoding.


### Behavioural assertions for every deliberate divergence

Because `check_env.py` no longer imports `python-dotenv`, **every** difference between its parser and the library is a deliberate divergence — and parity testing structurally cannot police a deliberate divergence (a mutation that increases parity would go undetected). So each one carries a check-level assertion about what the preflight *does*, measured against what the shipped apps receive:

| assertion | expected |
|---|---|
| BOM'd `.env` | exit 1, encoding problem explained |
| unterminated quote eats a required key | exit 1, offending line named |
| unterminated quote affects nothing needed | exit 0 (impact gating) |
| single-quote recovery swallows a required key | exit 1, line named |
| apostrophe inside a double-quoted value | value survives, exit 0 |
| escaped delimiter, single- and double-quoted | value survives, exit 0 |
| unedited `.env.example` | exit 1 (placeholders) |
| well-formed control | exit 0 |

**9/9 pass on both a dotenv-equipped and a dotenv-free interpreter.** Each case also asserts that every value the app receives is byte-identical to the value the preflight parsed — presence alone is insufficient, since a truncated value can be "present" in both while differing in content.

**Mutation-validated.** An assertion that passes against a broken parser proves nothing, so the suite was run against five deliberately broken parsers: BOM detection removed, single quotes fully literal, impact gating removed, placeholder shape check removed, and recovery not escape-aware for single quotes. **5/5 caught.** (A sixth mutant was discarded as malformed — it changed `escape_aware=False` to `None`, which is semantically identical, so nothing could have caught it.)

**Residual divergences: none found**, across 9,504 adjacency comparisons, 138 well-formed, 72 escape codes, 36 escape-recovery, 6 mixed-quote and 7 unterminated shapes. No structural fail-safe guard was added, because with no residual divergence a guard could only introduce false negatives.


### Correction: a residual divergence did exist

A cross-repo review supplied a fixture my corpus did not contain — two or more **consecutive escape-only lines** beneath an unclosed quote:

```
BAD="oops
X1=has \" esc
X2=has \" esc
  dotenv -> {}      ours (before) -> {X2}
```

My earlier "0 residual divergences" was a **coverage gap, not a property of the parser**. Every malformed fixture in the 9,504-comparison adjacency corpus had at most one escape-only line after the unclosed quote — precisely the case where resyncing on the first occurrence and on the last one agree. A clean result from a corpus that cannot express the failure.

**The measured rule:** when the escape-aware value scan finds no close, `python-dotenv` resynchronises on the **last** occurrence of the quote character and resumes after that line. Confirmed against eight variants:

| shape | outcome |
|---|---|
| keys after the final occurrence | survive |
| no keys after the final occurrence | nothing survives |
| no occurrence anywhere | only the bad line is dropped |

That third row rules out "dotenv discards the rest of the file", and the successful-scan cases rule out "greedy to the last quote" — only the *failed*-scan path resyncs on the last occurrence. This matters because the swallowed span can contain a correctly-written key the task needs, which the app then never receives.

Fixed; the supplied fixture and eight variants now match **9/9**, with the full regression unchanged. **No structural fail-safe guard is needed** — with this shape handled, there is no residual divergence for one to protect against.

**The behavioural assertion for it had to be rewritten.** My first version exited 1 under both the first- and last-occurrence rules, so it passed while the mutation test still reported the mutant as MISSED. The working version makes the unterminated key one the task does *not* require, so first-occurrence recovery would report ready while last-occurrence blocks — the verdict flips. Behavioural assertions now **10/10**, mutation testing **6/6 caught**.
