### PR TITLE
Fix labs broken by openai 3.x dropping httpx

### DIFF
--- a/Instructions/Exercises/01-build-agent-portal-and-vscode.md
+++ b/Instructions/Exercises/01-build-agent-portal-and-vscode.md
@@ -26,7 +26,7 @@ Before starting this exercise, ensure you have:
 - [Git](https://git-scm.com/downloads) installed on your local machine
 - Basic familiarity with Azure AI services and Python programming
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
 
 ## Create a Microsoft Foundry Project
 

--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -25,7 +25,7 @@ Before starting this exercise, ensure you have:
 - [Python 3.13](https://www.python.org/downloads/) or later installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.12.
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 

--- a/Instructions/Exercises/06-build-workflow-ms-foundry.md
+++ b/Instructions/Exercises/06-build-workflow-ms-foundry.md
@@ -52,7 +52,7 @@ Before starting this exercise, ensure you have:
 - [Python 3.13](https://www.python.org/downloads/) or later installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
 
 ## Create a Foundry project
 
@@ -413,7 +413,7 @@ Now you're ready to create a project that invokes a workflow. Let's get started!
 3. Find the comment **Specify the workflow** and add the following code:
 
     ```python
-   # Specify the workflow
+    # Specify the workflow
     workflow = {
         "name": "ContosoPay-Customer-Support-Triage"
     }

--- a/Instructions/Exercises/07-agent-framework.md
+++ b/Instructions/Exercises/07-agent-framework.md
@@ -25,7 +25,7 @@ Before starting this exercise, ensure you have:
 - [Python 3.13](https://www.python.org/downloads/) or later installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit VS Code extension
 

--- a/Instructions/Exercises/08-agent-framework-multi-agents.md
+++ b/Instructions/Exercises/08-agent-framework-multi-agents.md
@@ -31,7 +31,7 @@ Before starting this exercise, ensure you have:
 - [Python 3.13](https://www.python.org/downloads/) or later installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 

--- a/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
+++ b/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
@@ -27,7 +27,7 @@ Before starting this exercise, ensure you have:
 - [Python 3.13](https://www.python.org/downloads/) or later installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.13 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 

--- a/Labfiles/01-build-agent-portal-and-vscode/Python/requirements.txt
+++ b/Labfiles/01-build-agent-portal-and-vscode/Python/requirements.txt
@@ -1,3 +1,6 @@
 azure-ai-projects>=1.0.0
 azure-identity>=1.15.0
 python-dotenv>=1.0.0
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/02-agent-custom-tools/Python/requirements.txt
+++ b/Labfiles/02-agent-custom-tools/Python/requirements.txt
@@ -1,4 +1,6 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.3.0
-openai
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/03-mcp-integration/Python/requirements.txt
+++ b/Labfiles/03-mcp-integration/Python/requirements.txt
@@ -2,6 +2,8 @@ python-dotenv
 azure-identity
 uvicorn
 azure-ai-projects==2.3.0
-openai
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3
 mcp
 fastmcp

--- a/Labfiles/04-integrate-agent-with-foundry-iq/Python/requirements.txt
+++ b/Labfiles/04-integrate-agent-with-foundry-iq/Python/requirements.txt
@@ -1,3 +1,6 @@
 azure-ai-projects==2.3.0
 azure-identity
 python-dotenv
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/05a-m365-teams-integration/Python/requirements.txt
+++ b/Labfiles/05a-m365-teams-integration/Python/requirements.txt
@@ -1,3 +1,7 @@
 python-dotenv>=1.0.0
 azure-ai-projects>=1.0.0b4
 azure-identity>=1.19.0
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3
+azure-search-documents>=11.4.0

--- a/Labfiles/05b-work-iq-integration/Python/requirements.txt
+++ b/Labfiles/05b-work-iq-integration/Python/requirements.txt
@@ -2,3 +2,6 @@ python-dotenv>=1.0.0
 azure-ai-projects>=1.0.0b4
 azure-identity>=1.19.0
 mcp>=1.1.2
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/06-build-workflow-ms-foundry/Python/requirements.txt
+++ b/Labfiles/06-build-workflow-ms-foundry/Python/requirements.txt
@@ -2,3 +2,6 @@ python-dotenv
 azure-identity
 azure-ai-projects==2.3.0
 aiohttp
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/09-build-remote-agents-with-a2a/python/requirements.txt
+++ b/Labfiles/09-build-remote-agents-with-a2a/python/requirements.txt
@@ -8,3 +8,6 @@ fastapi
 azure-ai-projects 
 azure-ai-agents 
 a2a-sdk==0.3.26
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/A-build-and-extend-ai-agents/Python/hosted_agent/requirements.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/hosted_agent/requirements.txt
@@ -4,3 +4,6 @@ azure-identity==1.25.3
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# import httpx. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/A-build-and-extend-ai-agents/Python/requirements.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Python/requirements.txt
@@ -1,7 +1,9 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.3.0
-openai
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3
 mcp
 fastmcp
 uvicorn

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/hosted_agent/requirements.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/hosted_agent/requirements.txt
@@ -4,3 +4,6 @@ azure-identity==1.25.3
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# import httpx. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/A-build-and-extend-ai-agents/Solution/Python/requirements.txt
+++ b/Labfiles/A-build-and-extend-ai-agents/Solution/Python/requirements.txt
@@ -1,7 +1,9 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.3.0
-openai
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# import httpx. Pinned until azure-ai-projects supports openai 3.
+openai<3
 mcp
 fastmcp
 uvicorn

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/requirements.txt
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/requirements.txt
@@ -1,6 +1,8 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.3.0
-openai
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3
 mcp
 gradio==6.20.0

--- a/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/requirements.txt
+++ b/Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/requirements.txt
@@ -1,6 +1,8 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.3.0
-openai
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# import httpx. Pinned until azure-ai-projects supports openai 3.
+openai<3
 mcp
 gradio==6.20.0

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/requirements.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/requirements.txt
@@ -9,3 +9,6 @@ fastapi
 azure-ai-projects
 azure-ai-agents
 a2a-sdk==0.3.26
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# `import httpx`. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/requirements.txt
+++ b/Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/requirements.txt
@@ -9,3 +9,6 @@ fastapi
 azure-ai-projects
 azure-ai-agents
 a2a-sdk==0.3.26
+# openai 3.x replaced httpx with httpx2, which breaks azure-ai-projects'
+# import httpx. Pinned until azure-ai-projects supports openai 3.
+openai<3

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ View the exercises in the [GitHub Pages site for this repo](https://go.microsoft
 
 > **Note**: While you can complete these exercises on their own, they're designed to complement modules on [Microsoft Learn](https://learn.microsoft.com/training/paths/develop-ai-agents-azure/); in which you'll find a deeper dive into some of the underlying concepts on which these exercises are based.
 
-If you choose to run the code from applications in this repository locally, it will require Python 3.12+.
+If you choose to run the code from applications in this repository locally, it will require Python 3.13+.
 
 ## Reporting issues
 


### PR DESCRIPTION
## The labs are broken right now

`openai` 3.0.0 replaced its `httpx` dependency with **`httpx2`**. `azure-ai-projects` still does `import httpx` and relied on openai to supply it, so a fresh `pip install -r requirements.txt` now fails at import:

```
ModuleNotFoundError: No module named 'httpx'
```

Anyone starting labs **01, 02, 04, 05a, 05b or 06** today hits this immediately after install, before writing a line of code.

## Why pinning `azure-ai-projects` doesn't help

Labs 02, 04 and 06 already pin `azure-ai-projects==2.3.0` and still fail — openai arrives transitively, so the pin has no effect on which openai gets resolved. The constraint has to be on `openai` itself.

## Why this wasn't visible locally

It's Python-version dependent:

| Python | openai resolved | http library | Result |
| --- | --- | --- | --- |
| 3.12 | **3.0.0** | `httpx2` | **fails** |
| 3.14 | 2.53.0 | `httpx` | works |

openai 3.0.0 publishes no 3.14 distribution, so a local check on 3.14 silently passes while a learner on 3.12 is blocked.

## What this changes

- Constrains `openai<3` in **every** lab that depends on `azure-ai-projects`, with a comment explaining why.
- Adds `azure-search-documents>=11.4.0` to lab 05a, whose `setup_search.py` imports `azure.search.documents` but never declared it.

Labs **03, 09 and A** aren't failing today, but only because `fastmcp` happens to pull `httpx` in — accidental, and it would break the moment that dependency changed. They're constrained too, along with the `Solution/` and `hosted_agent/` requirements a learner may also install from. 16 files, all mechanical.

## How it was found

The Tier 1 SDK contract check in #229 caught it on its first run — six labs failing on a clean install, with no Azure resources or credentials needed to detect it.

## Verification

Diagnosis is confirmed directly from the CI install log:

```
Successfully installed ... httpcore2-2.10.0 httpx2-2.10.0 ... openai-3.0.0 ...
##[error]failed to import azure.ai.projects: ModuleNotFoundError: No module named 'httpx'
```

CI on this branch runs against Python 3.12, which is the configuration that reproduces the failure — so a green result here is the real proof that the fix works.

## Follow-up

`openai<3` is a holding measure. The underlying issue is that `azure-ai-projects` imports `httpx` without declaring it. Once it supports openai 3, the pin should be lifted — the comment in each file says so.


---

## Also in this PR: stated Python versions and one code block

**Self-contradictory version notes.** Six labs warned that *"Python **3.13** is available, but some dependencies are not yet compiled for that release"* and then stated *"successfully tested with Python **3.13.12**"* — warning against the very version they claim to be tested on.

Labs 02, A0, B0 and C0 carry the correct text, which warns about **3.14**. The wrong number had been copy-pasted into the older labs. Corrected in **01, 03, 06, 07, 08, 09**. All ten notes now read consistently.

Lab 03 still records that it was tested on Python 3.12 rather than 3.13.12. I left that alone deliberately rather than asserting a version nobody has verified — worth a human confirming.

**`readme.md` contradicted every lab.** It said the code requires Python 3.12+, while all lab prerequisites say "Python 3.13 or later". Aligned to 3.13+.

This also matters for CI: #229 now runs on 3.13 to match what learners are told to install.

**One code block fix.** In lab 06 a block indented its comment 3 spaces and its code 4, so it doesn't survive dedenting. Moved here from #229 to keep that PR purely tooling.

