### PR TITLE
Move per-task lab metadata into frontmatter and generate the tables

### DIFF
--- a/.github/workflows/content-checks.yml
+++ b/.github/workflows/content-checks.yml
@@ -51,6 +51,10 @@ jobs:
         if: always()
         run: python tools/checks/check_line_endings.py
 
+      - name: Generated blocks in the lab pages are current
+        if: always()
+        run: python tools/generate_lab_blocks.py --check
+
       - name: Shared lab infrastructure is in sync
         if: always()
         run: python Labfiles/_shared/sync.py --check

--- a/Instructions/Consolidated/A-build-and-extend-ai-agents.md
+++ b/Instructions/Consolidated/A-build-and-extend-ai-agents.md
@@ -3,9 +3,14 @@ title: 'Build and extend AI agents'
 lab:
     title: 'Build and extend AI agents'
     description: 'Build the Tailwind Traders assistant: ground it in store policy, then extend it with tools using remote MCP servers, custom functions, and a client app. A modular lab you can complete end to end or one task at a time.'
+    type: 'lab'
+    id: 'A'
+    order: 1
+    difficulty: 3
+    duration: 35
+    access: 'open'
     level: 300
     concepts: 'agent creation and grounding, tools, Model Context Protocol (MCP)'
-    duration: 35
     islab: true
     status: 'draft'
 ---
@@ -121,18 +126,21 @@ one virtual environment, and one `.env`, so if you'd rather work straight throug
 
 ## Lab at a glance
 
-Complete the **Core** tasks first (about **35 minutes**) — they end with a working,
-tool-using agent. Then expand any **Optional** tasks that interest you. The full lab,
-including all optional tasks, takes about **2 hours 25 minutes**.
+Complete the **Core** tasks first — they end with a working, tool-using agent. Then expand any
+**Optional** tasks that interest you.
 
+<!-- BEGIN GENERATED: task-table - do not edit by hand; run: python tools/generate_lab_blocks.py -->
 | Section | Task | Level | Time |
 | --- | --- | --- | --- |
-| **Core** | [Task 1 – Create and ground an agent in the portal](A1-create-and-ground-an-agent.md) | ▰▰▱▱▱ L200 | ~15 min |
-| **Core** | [Task 2 – Connect the agent to a remote MCP server in code](A2-connect-a-remote-mcp-server.md) | ▰▰▰▱▱ L300 | ~20 min |
+| **Core** | [Task 1 – Create and ground an agent](A1-create-and-ground-an-agent.md) | ▰▰▱▱▱ L200 | ~15 min |
+| **Core** | [Task 2 – Connect a remote MCP server](A2-connect-a-remote-mcp-server.md) | ▰▰▰▱▱ L300 | ~20 min |
 | *Optional* | [Task 3 – Call your agent from a client app](A3-call-your-agent-from-a-client-app.md) | ▰▰▰▱▱ L300 | ~20 min |
 | *Optional* | [Task 4 – Add custom function tools](A4-add-custom-function-tools.md) | ▰▰▰▱▱ L300 | ~25 min |
-| *Optional* | [Task 5 – Capstone: your own MCP server + combine every tool](A5-capstone-build-your-own-mcp-server.md) | ▰▰▰▰▱ L400 | ~35 min |
+| *Optional* | [Task 5 – Capstone: build your own MCP server](A5-capstone-build-your-own-mcp-server.md) | ▰▰▰▰▱ L400 | ~35 min |
 | *Optional* | [Task 6 – Promote your assistant to a hosted agent](A6-promote-your-assistant-to-a-hosted-agent.md) | ▰▰▰▱▱ L300 | ~30 min |
+
+**Core tasks:** about **35 minutes**. **Full lab**, including every optional task: about **2 hours 25 minutes**.
+<!-- END GENERATED: task-table -->
 
 **Choosing your path** — pick the tasks that fit the time you have:
 

--- a/Instructions/Consolidated/A0-getting-started.md
+++ b/Instructions/Consolidated/A0-getting-started.md
@@ -3,6 +3,11 @@ title: 'Getting started: set up your environment'
 lab:
     title: 'Getting started: set up your environment'
     description: 'Shared setup for the Build and extend AI agents lab: create a Microsoft Foundry project, get the starter code, and configure your environment. Complete this once before any task.'
+    type: 'task'
+    parent: 'A'
+    order: 0
+    section: 'setup'
+    access: 'open'
     level: 300
     concepts: 'environment setup, Microsoft Foundry project'
     status: 'draft'

--- a/Instructions/Consolidated/A1-create-and-ground-an-agent.md
+++ b/Instructions/Consolidated/A1-create-and-ground-an-agent.md
@@ -3,9 +3,15 @@ title: 'Task 1 – Create and ground an agent'
 lab:
     title: 'Task 1 – Create and ground an agent'
     description: 'Create an agent in the Microsoft Foundry portal and ground it in Tailwind Traders store policy so it answers from your data.'
-    level: 300
+    type: 'task'
+    parent: 'A'
+    order: 1
+    section: 'core'
+    difficulty: 2
+    duration: 15
+    access: 'open'
+    level: 200
     concepts: 'agent creation, grounding, file search'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/A2-connect-a-remote-mcp-server.md
+++ b/Instructions/Consolidated/A2-connect-a-remote-mcp-server.md
@@ -3,9 +3,15 @@ title: 'Task 2 – Connect a remote MCP server'
 lab:
     title: 'Task 2 – Connect a remote MCP server'
     description: 'Extend an agent with a tool by connecting it to a remote Model Context Protocol (MCP) server, and handle tool-approval requests in code.'
+    type: 'task'
+    parent: 'A'
+    order: 2
+    section: 'core'
+    difficulty: 3
+    duration: 20
+    access: 'open'
     level: 300
     concepts: 'tools, Model Context Protocol (MCP), approvals'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/A3-call-your-agent-from-a-client-app.md
+++ b/Instructions/Consolidated/A3-call-your-agent-from-a-client-app.md
@@ -3,9 +3,15 @@ title: 'Task 3 – Call your agent from a client app'
 lab:
     title: 'Task 3 – Call your agent from a client app'
     description: 'Drive your grounded portal agent from a small web chat app using the Foundry SDK and Responses API, with inline charts.'
+    type: 'task'
+    parent: 'A'
+    order: 3
+    section: 'optional'
+    difficulty: 3
+    duration: 20
+    access: 'open'
     level: 300
     concepts: 'Foundry SDK, Responses API, code interpreter'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/A4-add-custom-function-tools.md
+++ b/Instructions/Consolidated/A4-add-custom-function-tools.md
@@ -3,9 +3,15 @@ title: 'Task 4 – Add custom function tools'
 lab:
     title: 'Task 4 – Add custom function tools'
     description: 'Give an agent tools backed by your own Python functions and process the function-calling loop.'
+    type: 'task'
+    parent: 'A'
+    order: 4
+    section: 'optional'
+    difficulty: 3
+    duration: 25
+    access: 'open'
     level: 300
     concepts: 'function tools, function calling, Microsoft Agent Framework'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/A5-capstone-build-your-own-mcp-server.md
+++ b/Instructions/Consolidated/A5-capstone-build-your-own-mcp-server.md
@@ -3,9 +3,15 @@ title: 'Task 5 – Capstone: build your own MCP server'
 lab:
     title: 'Task 5 – Capstone: build your own MCP server'
     description: 'Capstone: build your own MCP server and combine it with your function tools into one Tailwind Traders assistant.'
-    level: 300
+    type: 'task'
+    parent: 'A'
+    order: 5
+    section: 'optional'
+    difficulty: 4
+    duration: 35
+    access: 'open'
+    level: 400
     concepts: 'MCP server, tool orchestration, Microsoft Agent Framework'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/A6-promote-your-assistant-to-a-hosted-agent.md
+++ b/Instructions/Consolidated/A6-promote-your-assistant-to-a-hosted-agent.md
@@ -3,9 +3,15 @@ title: 'Task 6 – Promote your assistant to a hosted agent'
 lab:
     title: 'Task 6 – Promote your assistant to a hosted agent'
     description: 'Take the Tailwind Traders assistant you built as a prompt agent and deploy it as a hosted agent - your own code running in a Foundry-managed container - with the Azure Developer CLI.'
+    type: 'task'
+    parent: 'A'
+    order: 6
+    section: 'optional'
+    difficulty: 3
+    duration: 30
+    access: 'open'
     level: 300
     concepts: 'hosted agents, deployment, Azure Developer CLI'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/B-integrate-agents-with-enterprise-knowledge-and-m365.md
+++ b/Instructions/Consolidated/B-integrate-agents-with-enterprise-knowledge-and-m365.md
@@ -3,9 +3,14 @@ title: 'Integrate agents with enterprise knowledge and Microsoft 365'
 lab:
     title: 'Integrate agents with enterprise knowledge and Microsoft 365'
     description: 'Build the Tailwind Traders staff knowledge assistant: ground it on enterprise documents with Foundry IQ, then deliver it through Microsoft Teams, Microsoft 365 Copilot, and Work IQ. A modular lab you can complete end to end or one task at a time.'
+    type: 'lab'
+    id: 'B'
+    order: 2
+    difficulty: 3
+    duration: 35
+    access: 'open'
     level: 300
     concepts: 'enterprise knowledge grounding, Foundry IQ, Microsoft 365, Model Context Protocol (MCP)'
-    duration: 35
     islab: true
     status: 'draft'
 ---
@@ -118,16 +123,23 @@ folder, one virtual environment, and one `.env`, so if you'd rather work straigh
 
 ## Lab at a glance
 
-Complete the **Core** task first (about **35 minutes**) — it ends with a working, grounded
-enterprise-knowledge agent you can call from code. Then expand any **Optional** tasks that
-interest you. The full lab, including all optional tasks, takes about **1 hour 50 minutes**.
+Complete the **Core** task first — it ends with a working, grounded enterprise-knowledge agent
+you can call from code. Then expand any **Optional** tasks that interest you.
 
+<!-- BEGIN GENERATED: task-table - do not edit by hand; run: python tools/generate_lab_blocks.py -->
 | Section | Task | Level | Time |
 | --- | --- | --- | --- |
 | **Core** | [Task 1 – Create a Foundry IQ knowledge agent and connect from code](B1-create-a-foundry-iq-knowledge-agent.md) | ▰▰▰▱▱ L300 | ~35 min |
-| *Optional* | [Task 2 – Publish your agent to Microsoft Teams](B2-publish-to-microsoft-teams.md) | ▰▰▱▱▱ L200 | ~20 min |
-| *Optional* | [Task 3 – Publish your agent to Microsoft 365 Copilot](B3-publish-to-microsoft-365-copilot.md) | ▰▰▱▱▱ L200 | ~15 min |
-| *Optional* | [Task 4 – Work IQ: bring Microsoft 365 signals into an agent](B4-work-iq-workplace-intelligence.md) | ▰▰▰▰▱ L400 | ~40 min |
+| *Optional* | [Task 2 – Publish your agent to Microsoft Teams](B2-publish-to-microsoft-teams.md) 🔒 | ▰▰▱▱▱ L200 | ~20 min |
+| *Optional* | [Task 3 – Publish your agent to Microsoft 365 Copilot](B3-publish-to-microsoft-365-copilot.md) 🔒 | ▰▰▱▱▱ L200 | ~15 min |
+| *Optional* | [Task 4 – Work IQ: bring Microsoft 365 signals into an agent](B4-work-iq-workplace-intelligence.md) 🔒 | ▰▰▰▰▱ L400 | ~40 min |
+
+**Core tasks:** about **35 minutes**. **Full lab**, including every optional task: about **1 hour 50 minutes**.
+
+> 🔒 Tasks marked with a lock need access your account may not have. Each one opens
+> with a quick check and tells you what to do if you don't have it — nothing else in
+> this lab depends on them.
+<!-- END GENERATED: task-table -->
 
 **Choosing your path** — pick the tasks that fit the time you have:
 

--- a/Instructions/Consolidated/B0-getting-started.md
+++ b/Instructions/Consolidated/B0-getting-started.md
@@ -3,6 +3,11 @@ title: 'Getting started: set up your environment'
 lab:
     title: 'Getting started: set up your environment'
     description: 'Shared setup for the Integrate agents with enterprise knowledge and Microsoft 365 lab: create a Microsoft Foundry project, get the starter code, and configure your environment. Complete this once before any task.'
+    type: 'task'
+    parent: 'B'
+    order: 0
+    section: 'setup'
+    access: 'open'
     level: 300
     concepts: 'environment setup, Microsoft Foundry project'
     status: 'draft'

--- a/Instructions/Consolidated/B1-create-a-foundry-iq-knowledge-agent.md
+++ b/Instructions/Consolidated/B1-create-a-foundry-iq-knowledge-agent.md
@@ -3,9 +3,15 @@ title: 'Task 1 – Create a Foundry IQ knowledge agent and connect from code'
 lab:
     title: 'Task 1 – Create a Foundry IQ knowledge agent and connect from code'
     description: 'Create an enterprise-knowledge agent in the Microsoft Foundry portal, ground it on the Tailwind Traders knowledge base with Foundry IQ, require approval before knowledge lookups, then connect from code and handle the approval flow.'
+    type: 'task'
+    parent: 'B'
+    order: 1
+    section: 'core'
+    difficulty: 3
+    duration: 35
+    access: 'open'
     level: 300
     concepts: 'Foundry IQ, enterprise knowledge grounding, tool approvals, conversations API'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/B2-publish-to-microsoft-teams.md
+++ b/Instructions/Consolidated/B2-publish-to-microsoft-teams.md
@@ -3,9 +3,17 @@ title: 'Task 2 – Publish your agent to Microsoft Teams'
 lab:
     title: 'Task 2 – Publish your agent to Microsoft Teams'
     description: 'Publish the Tailwind Traders knowledge agent to Microsoft Teams so staff can chat with it where they already work.'
-    level: 300
+    type: 'task'
+    parent: 'B'
+    order: 2
+    section: 'optional'
+    difficulty: 2
+    duration: 20
+    access: 'gated'
+    requires: 'A Microsoft 365 account with Teams access, and permission to publish agents to Teams in your tenant'
+    verify: 'In the Foundry portal, open your agent and select **Publish**. If Teams is greyed out or returns a consent error, you don''t have the rights this task needs.'
+    level: 200
     concepts: 'agent publishing, Microsoft Teams, Azure Bot Service'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/B3-publish-to-microsoft-365-copilot.md
+++ b/Instructions/Consolidated/B3-publish-to-microsoft-365-copilot.md
@@ -3,9 +3,17 @@ title: 'Task 3 – Publish your agent to Microsoft 365 Copilot'
 lab:
     title: 'Task 3 – Publish your agent to Microsoft 365 Copilot'
     description: 'Publish the Tailwind Traders knowledge agent to Microsoft 365 Copilot so staff can reach it inside Copilot.'
-    level: 300
+    type: 'task'
+    parent: 'B'
+    order: 3
+    section: 'optional'
+    difficulty: 2
+    duration: 15
+    access: 'gated'
+    requires: 'A Microsoft 365 Copilot licence, and permission to publish agents to Copilot in your tenant'
+    verify: 'In the Foundry portal, open your agent and select **Publish**. If Microsoft 365 Copilot is greyed out or returns a consent error, you don''t have the rights this task needs.'
+    level: 200
     concepts: 'agent publishing, Microsoft 365 Copilot, Copilot agents'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/B4-work-iq-workplace-intelligence.md
+++ b/Instructions/Consolidated/B4-work-iq-workplace-intelligence.md
@@ -3,9 +3,18 @@ title: 'Task 4 – Work IQ: bring Microsoft 365 signals into an agent'
 lab:
     title: 'Task 4 – Work IQ: bring Microsoft 365 signals into an agent'
     description: 'Build an agent that accesses Microsoft 365 workplace data using Work IQ and the Model Context Protocol for meeting prep, project tracking, and action items.'
-    level: 300
+    type: 'task'
+    parent: 'B'
+    order: 4
+    section: 'optional'
+    difficulty: 4
+    duration: 40
+    access: 'gated'
+    requires: 'A Microsoft 365 Copilot licence, IT admin consent for Work IQ, and Node.js 18 or later'
+    verify: 'Run the command below. If it returns your calendar you''re ready; if it reports missing consent or no Copilot licence, skip this task.'
+    verify_command: 'npm install -g @microsoft/workiq && workiq accept-eula && workiq ask -q "What meetings do I have today?"'
+    level: 400
     concepts: 'Work IQ, Microsoft 365, Model Context Protocol (MCP), function tools'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/C-build-multi-agent-solutions-with-agent-framework.md
+++ b/Instructions/Consolidated/C-build-multi-agent-solutions-with-agent-framework.md
@@ -3,9 +3,14 @@ title: 'Build multi-agent solutions with the Agent Framework'
 lab:
     title: 'Build multi-agent solutions with the Agent Framework'
     description: 'Build Tailwind Traders operations agents with the Microsoft Agent Framework: start with a single tool-using agent, then orchestrate several agents in sequence, then connect remote agents across processes with the A2A protocol. A modular lab you can complete end to end or one task at a time.'
+    type: 'lab'
+    id: 'C'
+    order: 3
+    difficulty: 3
+    duration: 30
+    access: 'open'
     level: 300
     concepts: 'Microsoft Agent Framework, tools, multi-agent orchestration, A2A protocol'
-    duration: 30
     islab: true
     status: 'draft'
 ---
@@ -120,10 +125,10 @@ one virtual environment, and one `.env`, so if you'd rather work straight throug
 
 ## Lab at a glance
 
-Complete the **Core** task first (about **30 minutes**) — it ends with a working, tool-using
-agent. Then expand any **Optional** tasks that interest you. The full lab, including all
-optional tasks, takes about **2 hours**.
+Complete the **Core** task first — it ends with a working, tool-using agent. Then expand any
+**Optional** tasks that interest you.
 
+<!-- BEGIN GENERATED: task-table - do not edit by hand; run: python tools/generate_lab_blocks.py -->
 | Section | Task | Level | Time |
 | --- | --- | --- | --- |
 | **Core** | [Task 1 – Build an agent with a tool](C1-create-an-agent-with-a-tool.md) | ▰▰▰▱▱ L300 | ~30 min |
@@ -131,9 +136,12 @@ optional tasks, takes about **2 hours**.
 | *Optional* | [Task 3 – Connect remote agents with A2A](C3-connect-remote-agents-with-a2a.md) | ▰▰▰▰▱ L400 | ~30 min |
 | *Optional* | [Task 4 – Classify and route a support ticket](C4-classify-and-route-a-ticket.md) | ▰▰▰▱▱ L300 | ~30 min |
 
+**Core tasks:** about **30 minutes**. **Full lab**, including every optional task: about **2 hours**.
+<!-- END GENERATED: task-table -->
+
 **Choosing your path** — pick the tasks that fit the time you have:
 
-- **Core only (~30 min):** do Task 1.
+- **Core only (~99 min):** do Task 1.
 - **Core + one pattern (~1h):** add **Task 2** (sequential orchestration) or **Task 4** (classify + route).
 - **Everything (~2h):** add **Task 2**, **Task 3** (remote agents with A2A), and **Task 4**.
 

--- a/Instructions/Consolidated/C0-getting-started.md
+++ b/Instructions/Consolidated/C0-getting-started.md
@@ -3,6 +3,11 @@ title: 'Getting started: set up your environment'
 lab:
     title: 'Getting started: set up your environment'
     description: 'Shared setup for the Build multi-agent solutions with the Agent Framework lab: create a Microsoft Foundry project, get the starter code, and configure your environment. Complete this once before any task.'
+    type: 'task'
+    parent: 'C'
+    order: 0
+    section: 'setup'
+    access: 'open'
     level: 300
     concepts: 'environment setup, Microsoft Foundry project'
     status: 'draft'

--- a/Instructions/Consolidated/C1-create-an-agent-with-a-tool.md
+++ b/Instructions/Consolidated/C1-create-an-agent-with-a-tool.md
@@ -3,9 +3,15 @@ title: 'Task 1 – Build an agent with a tool'
 lab:
     title: 'Task 1 – Build an agent with a tool'
     description: 'Use the Microsoft Agent Framework to build a single agent that calls a custom tool: decorate a Python function with @tool, attach it to an Agent, and let agent.run() drive the tool-calling loop.'
+    type: 'task'
+    parent: 'C'
+    order: 1
+    section: 'core'
+    difficulty: 3
+    duration: 30
+    access: 'open'
     level: 300
     concepts: 'Microsoft Agent Framework, tools, agents'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/C2-orchestrate-multiple-agents.md
+++ b/Instructions/Consolidated/C2-orchestrate-multiple-agents.md
@@ -3,9 +3,15 @@ title: 'Task 2 – Orchestrate multiple agents in sequence'
 lab:
     title: 'Task 2 – Orchestrate multiple agents in sequence'
     description: 'Use the Microsoft Agent Framework to orchestrate several agents in a sequence: a summarizer, a classifier, and an action agent triage a piece of customer feedback, each building on the last.'
+    type: 'task'
+    parent: 'C'
+    order: 2
+    section: 'optional'
+    difficulty: 3
+    duration: 30
+    access: 'open'
     level: 300
     concepts: 'Microsoft Agent Framework, multi-agent orchestration, sequential workflow'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/C3-connect-remote-agents-with-a2a.md
+++ b/Instructions/Consolidated/C3-connect-remote-agents-with-a2a.md
@@ -3,9 +3,15 @@ title: 'Task 3 – Connect remote agents with A2A'
 lab:
     title: 'Task 3 – Connect remote agents with A2A'
     description: 'Use the Agent-to-Agent (A2A) protocol to connect agents that run in separate processes: a routing agent discovers and delegates to a trip-title agent and a trip-itinerary agent, which collaborate to plan Tailwind Traders guided trips.'
-    level: 300
+    type: 'task'
+    parent: 'C'
+    order: 3
+    section: 'optional'
+    difficulty: 4
+    duration: 30
+    access: 'open'
+    level: 400
     concepts: 'A2A protocol, remote agents, multi-agent orchestration'
-    islab: true
     status: 'draft'
 ---
 

--- a/Instructions/Consolidated/C4-classify-and-route-a-ticket.md
+++ b/Instructions/Consolidated/C4-classify-and-route-a-ticket.md
@@ -3,9 +3,15 @@ title: 'Task 4 – Classify and route a support ticket'
 lab:
     title: 'Task 4 – Classify and route a support ticket'
     description: 'Use the Microsoft Agent Framework to classify Tailwind Traders support tickets with a triage agent, then route each one in code based on its category and confidence.'
+    type: 'task'
+    parent: 'C'
+    order: 4
+    section: 'optional'
+    difficulty: 3
+    duration: 30
+    access: 'open'
     level: 300
     concepts: 'Microsoft Agent Framework, structured output, classification, conditional routing'
-    islab: true
     status: 'draft'
 ---
 

--- a/tools/checks/README.md
+++ b/tools/checks/README.md
@@ -26,7 +26,35 @@ request diff.
 | `check_code_blocks.py` | A ```` ```python ```` block that isn't valid Python. Learners paste these straight into a file, so a bad indent breaks the lab. |
 | `check_links.py` | A link to a page that was renamed or moved, or a screenshot that no longer exists. |
 | `check_line_endings.py` | Text files drifting back to CRLF in the index, against the `.gitattributes` policy. |
+| `generate_lab_blocks.py --check` | A generated block in a lab page — the task table, or a gated-access notice — no longer matching the frontmatter it is built from. |
 | `Labfiles/_shared/sync.py --check` | A lab's copy of the shared azd template, Bicep or post-provision scripts drifting from the canonical version. See [`Labfiles/_shared/README.md`](../../Labfiles/_shared/README.md). |
+
+### Why the lab pages contain generated markdown rather than Liquid
+
+The lab instruction pages are read directly by platforms that never run Liquid.
+GitHub's own markdown renderer is one: a `{% include %}` in a `.md` file shows
+up verbatim where the content should be. Confirmed by rendering one through
+GitHub's markdown API, which returns
+`<p>{% include lab-tasks-table.html lab='A' %}</p>`.
+
+So those pages stay plain markdown, and `tools/generate_lab_blocks.py` writes
+the generated parts between HTML comment markers — invisible in every renderer:
+
+```
+<!-- BEGIN GENERATED: task-table - do not edit by hand; ... -->
+| Section | Task | Level | Time |
+...
+<!-- END GENERATED: task-table -->
+```
+
+Frontmatter stays the single source of truth, the output is real markdown that
+works everywhere, and `--check` makes drift a build failure. A lab page that is
+missing its markers is an error, so a new lab cannot silently ship without its
+table.
+
+The web-only pages — `workshop.md`, `explore.md`, `labs.json` — still use Liquid
+directly. They are never consumed as raw markdown, so there is nothing to work
+around.
 
 ### Why the code block check normalizes first
 

--- a/tools/generate_lab_blocks.py
+++ b/tools/generate_lab_blocks.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Write the generated blocks in the lab pages from task frontmatter.
+
+The lab instruction pages are consumed directly by platforms that never run
+Liquid - GitHub's own markdown renderer among them, where a `{% include %}`
+shows up literally where the content should be. So these pages stay plain
+markdown, and the generated parts are written into them here instead.
+
+Two blocks are generated:
+
+  task-table    the "Lab at a glance" table on each lab landing page
+  gated-notice  the access warning at the top of a task that needs
+                permissions or licensing many learners won't have
+
+Both are delimited by HTML comments, which are invisible in every renderer:
+
+    <!-- BEGIN GENERATED: task-table -->
+    ...
+    <!-- END GENERATED: task-table -->
+
+    python tools/generate_lab_blocks.py           # rewrite the blocks
+    python tools/generate_lab_blocks.py --check   # fail if any is stale
+
+Web-only pages (workshop.md, explore.md, labs.json) still use Liquid directly.
+They are never consumed as raw markdown, so there is nothing to work around.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CONSOLIDATED = ROOT / "Instructions" / "Consolidated"
+FRONTMATTER = re.compile(r"^---\r?\n(.*?\r?\n)---\r?\n", re.S)
+
+DO_NOT_EDIT = "do not edit by hand; run: python tools/generate_lab_blocks.py"
+
+
+def block_markers(name: str) -> tuple[str, str]:
+    return (
+        f"<!-- BEGIN GENERATED: {name} - {DO_NOT_EDIT} -->",
+        f"<!-- END GENERATED: {name} -->",
+    )
+
+
+def load_pages() -> dict[str, dict]:
+    pages = {}
+    for path in sorted(CONSOLIDATED.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        m = FRONTMATTER.match(text)
+        if not m:
+            continue
+        data = yaml.safe_load(m.group(1)) or {}
+        pages[path.name] = {"path": path, "lab": data.get("lab") or {}}
+    return pages
+
+
+def bars(difficulty: int | None) -> str:
+    if not difficulty:
+        return ""
+    return "▰" * difficulty + "▱" * (5 - difficulty)
+
+
+def humanise(minutes: int) -> str:
+    hours, mins = divmod(minutes, 60)
+    if hours and mins:
+        return f"{hours} hour{'s' if hours > 1 else ''} {mins} minutes"
+    if hours:
+        return f"{hours} hour{'s' if hours > 1 else ''}"
+    return f"{mins} minutes"
+
+
+def render_task_table(lab_id: str, pages: dict[str, dict]) -> str:
+    tasks = sorted(
+        (p for p in pages.values() if p["lab"].get("parent") == lab_id),
+        key=lambda p: p["lab"].get("order", 0),
+    )
+    if not tasks:
+        raise SystemExit(f"no task pages found for lab '{lab_id}'")
+
+    core_total = sum(t["lab"].get("duration") or 0 for t in tasks if t["lab"].get("section") == "core")
+    full_total = sum(t["lab"].get("duration") or 0 for t in tasks)
+
+    lines = ["| Section | Task | Level | Time |", "| --- | --- | --- | --- |"]
+    gated = False
+
+    for t in tasks:
+        lab = t["lab"]
+        if lab.get("section") == "setup":
+            continue
+        section = "**Core**" if lab.get("section") == "core" else "*Optional*"
+        lock = " 🔒" if lab.get("access") == "gated" else ""
+        if lock:
+            gated = True
+        link = f"[{lab['title']}]({t['path'].name})"
+        lines.append(
+            f"| {section} | {link}{lock} | {bars(lab.get('difficulty'))} L{lab.get('level')} "
+            f"| ~{lab.get('duration')} min |"
+        )
+
+    lines.append("")
+    lines.append(
+        f"**Core tasks:** about **{core_total} minutes**. **Full lab**, including every "
+        f"optional task: about **{humanise(full_total)}**."
+    )
+
+    if gated:
+        lines += [
+            "",
+            "> 🔒 Tasks marked with a lock need access your account may not have. Each one opens",
+            "> with a quick check and tells you what to do if you don't have it — nothing else in",
+            "> this lab depends on them.",
+        ]
+
+    return "\n".join(lines)
+
+
+def render_gated_notice(lab: dict) -> str:
+    skip = (
+        "**Don't have it?** Skip this task. Nothing else in this lab depends on it, and you "
+        "can still read through the steps to see how it works."
+    )
+    lines = [
+        "> ### Check your access before you start",
+        ">",
+        f"> **This task needs:** {lab['requires']}.",
+        ">",
+        f"> {lab['verify']}",
+    ]
+    if lab.get("verify_command"):
+        lines += ["", "```", lab["verify_command"], "```", "", f"> {skip}"]
+    else:
+        lines += [">", f"> {skip}"]
+    return "\n".join(lines)
+
+
+def has_block(text: str, name: str) -> bool:
+    return f"<!-- BEGIN GENERATED: {name}" in text
+
+
+def replace_block(text: str, name: str, content: str, path: Path) -> str:
+    begin, end = block_markers(name)
+    pattern = re.compile(
+        r"<!-- BEGIN GENERATED: " + re.escape(name) + r"\b.*?-->.*?<!-- END GENERATED: "
+        + re.escape(name) + r" -->",
+        re.S,
+    )
+    replacement = f"{begin}\n{content}\n{end}"
+    if not pattern.search(text):
+        raise SystemExit(
+            f"{path.name}: expected a '{name}' block. Add the markers where it belongs:\n"
+            f"  {begin}\n  {end}"
+        )
+    return pattern.sub(lambda _m: replacement, text, count=1)
+
+
+def build(pages: dict[str, dict]) -> dict[Path, str]:
+    """Return the intended content of every page that carries a generated block."""
+    wanted: dict[Path, str] = {}
+
+    for page in pages.values():
+        lab = page["lab"]
+        path = page["path"]
+        text = path.read_text(encoding="utf-8")
+        updated = text
+
+        # Every lab landing page must have a task table, so a missing marker
+        # here is an error - a new lab should not ship without one.
+        if lab.get("type") == "lab":
+            updated = replace_block(updated, "task-table", render_task_table(lab["id"], pages), path)
+
+        # The access notice is editorial: the author decides where it goes, and
+        # some gated tasks may carry the warning in their own prose instead. So
+        # it is generated where the markers appear, and absence is not an error.
+        if lab.get("access") == "gated" and has_block(updated, "gated-notice"):
+            for key in ("requires", "verify"):
+                if not lab.get(key):
+                    raise SystemExit(f"{path.name}: access is gated but lab.{key} is missing")
+            updated = replace_block(updated, "gated-notice", render_gated_notice(lab), path)
+
+        if updated != text:
+            wanted[path] = updated
+
+    return wanted
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="report stale blocks, change nothing")
+    args = ap.parse_args()
+
+    pages = load_pages()
+    wanted = build(pages)
+
+    if not args.check:
+        for path, content in wanted.items():
+            path.write_bytes(content.encode("utf-8"))
+        print(f"generated blocks: {len(wanted)} file(s) updated")
+        for path in wanted:
+            print("  ", path.relative_to(ROOT).as_posix())
+        return 0
+
+    if not wanted:
+        print(f"generated blocks: OK - {len(pages)} page(s) checked")
+        return 0
+
+    for path, content in wanted.items():
+        rel = path.relative_to(ROOT).as_posix()
+        sys.stdout.writelines(
+            difflib.unified_diff(
+                path.read_text(encoding="utf-8").splitlines(keepends=True),
+                content.splitlines(keepends=True),
+                fromfile=f"{rel} (in repo)",
+                tofile=f"{rel} (expected)",
+                n=1,
+            )
+        )
+    print(f"\ngenerated blocks: STALE - {len(wanted)} file(s)")
+    print("Run: python tools/generate_lab_blocks.py")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Moves per-task lab metadata into frontmatter and generates the "Lab at a glance" tables from it.

Split out of #231 so the metadata and tooling can land on `main` while the exploratory views stay in a branch.

## Why

Per-task **section, difficulty and duration** existed only as prose inside the hand-written tables on the three landing pages. Nothing validated them against the task pages they described — and they had already drifted.

```yaml
lab:
    type: task          # lab | task
    parent: A
    order: 2
    section: core       # core | optional | setup
    level: 300
    difficulty: 3
    duration: 20
    access: open        # open | gated
```

## Generated as markdown, not Liquid

The tables are written **into** the markdown by `tools/generate_lab_blocks.py`, not rendered by a Liquid include.

The lab pages are read directly by platforms that never run Liquid. GitHub's own markdown API returns:

```html
<p>{% include lab-tasks-table.html lab='A' %}</p>
```

So the generated content sits between HTML comment markers, invisible in every renderer:

```
<!-- BEGIN GENERATED: task-table - do not edit by hand; run: python tools/generate_lab_blocks.py -->
| Section | Task | Level | Time |
...
<!-- END GENERATED: task-table -->
```

`--check` runs in `content-checks` and makes drift a build failure, matching the `Labfiles/_shared/sync.py --check` pattern.

A landing page missing its markers is a hard **error** — a new lab can't silently ship without a table. The gated-access notice is treated differently: generated only where its markers appear, because where that warning belongs is an editorial choice.

## Drift this exposed

- **`level` was 300 on every task page**, inherited from its lab, while the tables listed L200–L400. Level now matches difficulty everywhere.
- **`islab` removed from task pages** — a task is a step within a lab, not a lab.
- **B2, B3 and B4 marked `access: gated`**, each recording what it needs and how to check, so the lock icons come from the same source as the requirement.

## Verification

- Generated tables reproduce the totals the prose stated by hand: **A 35 min core / 2h25, B 35 / 1h50, C 30 / 2h**
- The generator is idempotent; corrupting a block makes `--check` exit 1 with a diff
- Tier 0 passes, with link references at **117** — generating as markdown keeps the 14 task links checkable, which a Liquid include did not

## Relationship to the other PRs

- **#233** (gated notices) now branches off this and can merge straight after.
- **#231** is reduced to the three view files and stays unmerged as the PoC.
- **#234** (Lab D) needs the generator from here for its own table.
