### PR TITLE
State a definite Python version instead of contradicting ourselves

### DIFF
--- a/Instructions/Consolidated/A0-getting-started.md
+++ b/Instructions/Consolidated/A0-getting-started.md
@@ -32,11 +32,11 @@ Before starting, ensure you have:
 
 - An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 - Basic familiarity with Python
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Microsoft Foundry project
 

--- a/Instructions/Consolidated/B0-getting-started.md
+++ b/Instructions/Consolidated/B0-getting-started.md
@@ -33,11 +33,11 @@ Before starting, ensure you have:
 
 - An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 - Basic familiarity with Python
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 Some optional tasks have extra prerequisites (a Microsoft 365 account for Teams, a Microsoft 365
 Copilot license and Node.js for Work IQ). Each optional task page lists what it needs.

--- a/Instructions/Consolidated/C0-getting-started.md
+++ b/Instructions/Consolidated/C0-getting-started.md
@@ -33,11 +33,11 @@ Before starting, ensure you have:
 
 - An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 - Basic familiarity with Python
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Microsoft Foundry project
 

--- a/Instructions/Exercises/01-build-agent-portal-and-vscode.md
+++ b/Instructions/Exercises/01-build-agent-portal-and-vscode.md
@@ -22,11 +22,11 @@ Before starting this exercise, ensure you have:
 
 - An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 - Basic familiarity with Azure AI services and Python programming
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Microsoft Foundry Project
 

--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -24,10 +24,10 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 

--- a/Instructions/Exercises/03-mcp-integration.md
+++ b/Instructions/Exercises/03-mcp-integration.md
@@ -22,10 +22,10 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 

--- a/Instructions/Exercises/04-integrate-agent-with-foundry-iq.md
+++ b/Instructions/Exercises/04-integrate-agent-with-foundry-iq.md
@@ -24,9 +24,11 @@ Before starting this exercise, ensure you have:
 
 - An [Azure subscription](https://azure.microsoft.com/free/) with permissions to create AI resources
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 - Basic familiarity with the Microsoft Foundry portal and Python programming
+
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Foundry project
 

--- a/Instructions/Exercises/05b-work-iq-integration.md
+++ b/Instructions/Exercises/05b-work-iq-integration.md
@@ -24,9 +24,11 @@ Before starting this lab, ensure you have:
 - **Microsoft 365 with Copilot License**
 - IT admin approval for Work IQ (organizational accounts only)
 - [Node.js 18](https://nodejs.org/en/download/) or later installed
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed (authenticated with `az login`)
 - Active M365 data (emails, meetings, Teams chats) to query
+
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 > **Important:** Work IQ **only works** with Microsoft 365 Copilot-enabled accounts. You cannot complete this lab without Copilot.
 

--- a/Instructions/Exercises/06-build-workflow-ms-foundry.md
+++ b/Instructions/Exercises/06-build-workflow-ms-foundry.md
@@ -49,10 +49,10 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Foundry project
 

--- a/Instructions/Exercises/07-agent-framework.md
+++ b/Instructions/Exercises/07-agent-framework.md
@@ -22,10 +22,10 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit VS Code extension
 

--- a/Instructions/Exercises/08-agent-framework-multi-agents.md
+++ b/Instructions/Exercises/08-agent-framework-multi-agents.md
@@ -28,10 +28,10 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 

--- a/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
+++ b/Instructions/Exercises/09-multi-remote-agents-with-a2a.md
@@ -24,10 +24,10 @@ Before starting this exercise, ensure you have:
 
 - [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
 - An active [Azure subscription](https://azure.microsoft.com/free/)
-- [Python 3.13](https://www.python.org/downloads/) or later installed
+- [Python 3.13](https://www.python.org/downloads/) installed
 - [Git](https://git-scm.com/downloads) installed on your local machine
 
-> \* Python 3.14 is available, but some dependencies are not yet compiled for that release. The lab has been successfully tested with Python 3.13.12.
+> \* Python 3.14 isn't supported yet: some dependencies have no 3.14 build. This lab was tested with Python 3.13.12.
 
 ## Create a Foundry project with the Foundry Toolkit for VS Code extension
 


### PR DESCRIPTION
## What

Every lab asked for **"Python 3.13 or later"** and then warned that 3.14 dependencies aren't compiled yet — telling the learner to install a version the same page advises against.

**Before**
```
- [Python 3.13](https://www.python.org/downloads/) or later installed

> * Python 3.14 is available, but some dependencies are not yet compiled for that
>   release. The lab has been successfully tested with Python 3.13.12.
```

**After**
```
- [Python 3.13](https://www.python.org/downloads/) installed

> * Python 3.14 isn't supported yet: some dependencies have no 3.14 build.
>   This lab was tested with Python 3.13.12.
```

State a version, give the reason. This is the pattern Lab D already uses, arrived at independently because the `[redteam]` extra pulls PyRIT, which has no 3.14 wheel.

## Scope

12 files — A0/B0/C0 plus legacy labs 01–09.

**Labs 04 and 05b** stated the prerequisite with no note at all; they have one now.

This isn't hypothetical: `openai` 3.0.0 publishes no 3.14 distribution, which is exactly why the `httpx` break in #230 was invisible on a 3.14 machine and reproduced on 3.12. CI runs 3.13 for the same reason.

## One thing left alone

**Lab 03 still says it was tested with Python 3.12**, not 3.13.12. That's likely stale, but asserting a version nobody has verified would be worse than the inconsistency. Its Tier 1 contract job does pass on 3.13, so the dependencies resolve — that isn't the same as the lab having been run. Worth a maintainer confirming and updating.

## Verification

All Tier 0 checks pass, plus `generate_lab_blocks.py --check` and `sync.py --check`. Text-only change; no code, frontmatter or generated blocks touched.
