### PR TITLE
Remove pilot notes and stop Jekyll processing the lab source

### DIFF
--- a/Instructions/Consolidated/A-build-and-extend-ai-agents.md
+++ b/Instructions/Consolidated/A-build-and-extend-ai-agents.md
@@ -15,19 +15,6 @@ lab:
     status: 'draft'
 ---
 
-<!--
-PILOT NOTE (remove before publishing):
-This is a pilot of the new lab template (Core + Optional tasks) applied to
-"Lab A" = a consolidation of the current exercises 01, 02, and 03.
-Starter code lives in a single folder — Labfiles/A-build-and-extend-ai-agents/Python/ —
-shared by every task (one virtual environment, one .env). The completed reference code is
-in Labfiles/A-build-and-extend-ai-agents/Solution/Python/.
-
-This landing page is the lab overview. Setup lives in A0-getting-started.md and each task is
-its own page (A1–A5) so it can be completed on its own. Optional per-task fast-forward and
-provisioning scripts live in Labfiles/A-build-and-extend-ai-agents/setup/ and infra/.
--->
-
 # Build and extend AI agents
 
 **Level** ▰▰▰▱▱ **L300**  (**L100** beginner → **L500** expert)

--- a/Instructions/Consolidated/B-integrate-agents-with-enterprise-knowledge-and-m365.md
+++ b/Instructions/Consolidated/B-integrate-agents-with-enterprise-knowledge-and-m365.md
@@ -15,19 +15,6 @@ lab:
     status: 'draft'
 ---
 
-<!--
-PILOT NOTE (remove before publishing):
-This is a pilot of the new lab template (Core + Optional tasks) applied to
-"Lab B" = a consolidation of the current exercises 04, 05a, and 05b.
-Starter code lives in a single folder — Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Python/ —
-shared by every code task (one virtual environment, one .env). The completed reference code is
-in Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/Solution/Python/.
-
-This landing page is the lab overview. Setup lives in B0-getting-started.md and each task is
-its own page (B1–B4) so it can be completed on its own. Optional per-task fast-forward and
-provisioning scripts live in Labfiles/B-integrate-agents-with-enterprise-knowledge-and-m365/setup/ and infra/.
--->
-
 # Integrate agents with enterprise knowledge and Microsoft 365
 
 **Level** ▰▰▰▱▱ **L300**  (**L100** beginner → **L500** expert)

--- a/Instructions/Consolidated/C-build-multi-agent-solutions-with-agent-framework.md
+++ b/Instructions/Consolidated/C-build-multi-agent-solutions-with-agent-framework.md
@@ -15,19 +15,6 @@ lab:
     status: 'draft'
 ---
 
-<!--
-PILOT NOTE (remove before publishing):
-This is a pilot of the new lab template (Core + Optional tasks) applied to
-"Lab C" = a consolidation of the current exercises 07, 08, and 09.
-Starter code lives in a single folder — Labfiles/C-build-multi-agent-solutions-with-agent-framework/Python/ —
-shared by every task (one virtual environment, one .env). The completed reference code is
-in Labfiles/C-build-multi-agent-solutions-with-agent-framework/Solution/Python/.
-
-This landing page is the lab overview. Setup lives in C0-getting-started.md and each task is
-its own page (C1–C3) so it can be completed on its own. Optional provisioning scripts live in
-Labfiles/C-build-multi-agent-solutions-with-agent-framework/setup/ and infra/.
--->
-
 # Build multi-agent solutions with the Agent Framework
 
 **Level** ▰▰▰▱▱ **L300**  (**L100** beginner → **L500** expert)

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,11 @@ remote_theme: MicrosoftLearning/Jekyll-Theme
 exclude:
   - readme.md
   - .github/
+  # Lab source code is delivered by cloning the repo, not by the site. Jekyll
+  # was copying ~199 files from here into _site for no benefit, and processing
+  # content it was never meant to render.
+  - Labfiles/
+  - tools/
 header_pages:
   - index.html
 author: Microsoft Learning


### PR DESCRIPTION
## Two things

**1. Removes the pilot notes.** All three consolidated landing pages carried `PILOT NOTE (remove before publishing)` comment blocks. They described the folder layout, which the Getting started pages and `Labfiles/_shared/README.md` already cover.

**2. Stops Jekyll processing the lab source** — and this is most likely the Pages build fix.

## On the Pages failures

Builds have failed since **`874158e`**, with the last success at `5017f7f` on 14 August:

| Build | Commit | Status |
| --- | --- | --- |
| 14 Aug 18:33 | `5017f7f` | built |
| 17 Aug 14:45 | `874158e` (#232) | **errored** |
| 17 Aug 15:06 | `c8f028f` (#238) | **errored** |
| 17 Aug 15:09 | `b0ff1d4` (#233) | stuck *building* |

The telling detail: **#232 touched only `Labfiles/` and a workflow file — no `Instructions/` content at all.** So whatever Jekyll objected to is in lab source it was never meant to render.

`Labfiles/_shared/` is the prime suspect. It holds template files containing `{{LAB_FOLDER}}`, `{{AZD_NAME}}` and `{{LAB_HINT}}` placeholders — content that has no business reaching a Liquid renderer.

This excludes `Labfiles/` and `tools/` from the build. Neither should ever have been published: lab code reaches learners by cloning the repo, and Jekyll was copying about **199 files** from `Labfiles` into `_site` for no benefit. Faster build, smaller site, and the template placeholders are out of Liquid's reach.

## Safety of the exclusion

No page links into `Labfiles` by a site-relative path. The one reference — a data-folder link in B1 — is an absolute `github.com` URL and is unaffected.

## Honest caveat

I could not read the Pages build log; the API reports only *"Page build failed."* GitHub was also returning widespread 503s that day, and a build stuck *building* for hours points at infrastructure trouble too. So this is a well-reasoned fix, not a confirmed one — **the test is whether the build goes green after merge.**

If it doesn't, the next step is bisecting `_config.yml` exclusions, and it would be worth asking whoever owns Pages for the build log.

## Verification

All Tier 0 checks pass, plus `generate_lab_blocks.py --check` and `sync.py --check`. `_config.yml` parses, and both new exclusions are in place.
