### PR TITLE
Restore site styling by overriding the theme's broken stylesheet link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,47 @@
+<!--
+    TEMPORARY OVERRIDE of the layout from MicrosoftLearning/Jekyll-Theme.
+
+    Theme commit d6cdbff ("Fix typo", 13 Aug 2026) reformatted the theme's
+    _layouts/default.html and introduced a space inside the stylesheet string:
+
+        href="{{ " /assets/css/style.css?v=" | append: ... | relative_url }}"
+                 ^ here
+
+    relative_url then produces "/mslearn-ai-agents/ /assets/css/style.css",
+    which the browser requests as ".../%20/assets/css/style.css". That 404s, so
+    every page on the site renders unstyled.
+
+    This file is the theme's current layout with that single space removed, so
+    it also keeps the genuine fix from the same commit (page.lab.tile ->
+    page.lab.title, which had been blanking lab page titles).
+
+    Jekyll resolves local _layouts/ ahead of remote_theme, so this takes effect
+    for every page, including home.html which inherits from it.
+
+    DELETE THIS FILE once the fix is released upstream. The bug affects every
+    course repo using the theme, so it is worth fixing there rather than
+    carrying a copy here indefinitely.
+-->
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>
+        {% if page.title %}{{ page.title }} |
+        {% elsif page.lab.title %}{{ page.lab.title }} | {% endif %}
+        {{ site.title }}
+    </title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
+        integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/vs.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+</head>
+{{ content }}
+
+</html>


### PR DESCRIPTION
## The site is rendering unstyled, and it is not our doing

Every page on https://microsoftlearning.github.io/mslearn-ai-agents/ is currently loading without CSS.

The theme's layout builds the stylesheet URL from a string that begins with a space:

```liquid
href="{{ " /assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}"
         ^ here
```

`relative_url` turns that into `/mslearn-ai-agents/ /assets/css/style.css`, which the browser requests as `.../%20/assets/css/style.css`.

Confirmed directly:

| URL | Result |
| --- | --- |
| `/mslearn-ai-agents/%20/assets/css/style.css` | **404** |
| `/mslearn-ai-agents/assets/css/style.css` | 200, 4710 bytes |

## Where it came from

`MicrosoftLearning/Jekyll-Theme` commit **`d6cdbff`** — *"Fix typo"*, 13 August 2026 — reformatted `_layouts/default.html` and introduced the space.

Nothing in this repo caused it, and reverting our recent changes would not fix it. Because `remote_theme` pulls the theme at build time, this affects **every course repo using the theme**, not just this one.

## The fix here

A local `_layouts/default.html`: the theme's current layout with that one space removed.

- Jekyll resolves local `_layouts/` ahead of `remote_theme`
- `home.html` inherits from `default`, so this covers every page including the index
- Verified the override differs from upstream by **exactly that one line**, so it keeps the genuine fix from the same commit (`page.lab.tile` → `page.lab.title`, which had been blanking lab page titles)

Pinning `remote_theme` to the previous commit was the alternative, but that would reintroduce the blank-title bug and freeze all future theme updates.

## This is a stopgap

The real fix is one character upstream. Once it ships, **delete this file** — the header comment says so, with the reasoning.

Worth reporting to the theme owners regardless, since every repo using the theme is affected and most maintainers will not think to look at the theme when their own site loses its styling.

## Verification

All Tier 0 checks pass, plus `generate_lab_blocks.py --check` and `sync.py --check`.

Note the Pages build itself is now healthy again — `23a12fe` built successfully after #240 excluded `Labfiles/` and `tools/`. This is a separate problem: the build succeeds, but the page it produces has a broken stylesheet link.
