### PR TITLE
Fix Foundry IQ tool approval instructions in Lab 04 and B1

### DIFF
--- a/Instructions/Consolidated/B1-create-a-foundry-iq-knowledge-agent.md
+++ b/Instructions/Consolidated/B1-create-a-foundry-iq-knowledge-agent.md
@@ -185,10 +185,10 @@ When you create an agent in the portal, its Foundry IQ (knowledge) tool runs **w
 
 1. Under **Microsoft Foundry Resources**, choose **Set Default Project** and select the project you created earlier.
 1. Expand the project section. Under **Prompt Agents**, select your `tailwind-knowledge-agent` agent to open the **Agent Builder** window.
-1. In the **Tools** section, add the **Azure AI Search** tool, and then select the connection and knowledge base you created earlier.
+1. In the **Tools** section, find the tool named with a `kb-knowledgebase` prefix followed by a unique ID (for example, `kb-knowledgebase677-7w5fj`). This is the Foundry IQ knowledge base tool, and it was added automatically when you connected Foundry IQ in the portal.
 
-    > **Note**: The agent may list more than one tool. The Foundry portal adds a **Web search** tool to new agents by default, so be sure to select the three dots on the **Azure AI Search** tool for your knowledge base rather than another tool.
-1. In the **Require approval before using tools** dropdown, select **Ask for approval for all tools**, and save your changes if you're prompted.
+    > **Note**: The agent lists more than one tool. The Foundry portal adds a **Web search** tool to new agents by default, and you may also see a standalone **Azure AI Search** tool. The agent actually calls the `kb-knowledgebase...` tool when it searches your knowledge base, so setting approval on any other tool has no effect.
+1. Select the three dots on the `kb-knowledgebase...` tool. Then, in the **Require approval before using tools** dropdown, select **Ask for approval for all tools**, and save your changes if you're prompted.
 
 Your agent will now request approval each time it uses Foundry IQ to search the knowledge base, which the client app you complete next will handle.
 

--- a/Instructions/Exercises/04-integrate-agent-with-foundry-iq.md
+++ b/Instructions/Exercises/04-integrate-agent-with-foundry-iq.md
@@ -160,11 +160,11 @@ When you create an agent in the portal, its Foundry IQ (knowledge) tool runs **w
 
 1. Under **Microsoft Foundry Resources**, choose **Set Default Project** and select the project you created earlier.
 1. Expand the project section. Under **Prompt Agents**, select your `product-expert-agent` agent to open the **Agent Builder** window.
-1. In the **Tools** section, you should already see the **Azure AI Search** tool for your knowledge base, since it was linked automatically when you connected Foundry IQ in the portal.
+1. In the **Tools** section, you should already see a tool named with a `kb-knowledgebase` prefix followed by a unique ID (for example, `kb-knowledgebase677-7w5fj`). This is the Foundry IQ knowledge base tool, and it was added automatically when you connected Foundry IQ in the portal.
 
-    > **Note**: The agent may list more than one tool. The Foundry portal adds a **Web search** tool to new agents by default, so be sure to select the ellipsis (**...**) on the **Azure AI Search** tool for your knowledge base rather than another tool.
+    > **Note**: The agent lists more than one tool. The Foundry portal adds a **Web search** tool to new agents by default, and you may also see a standalone **Azure AI Search** tool. The agent actually calls the `kb-knowledgebase...` tool when it searches your knowledge base, so setting approval on any other tool has no effect.
 
-1. Select the ellipsis (**...**) icon on the **Azure AI Search** tool, then select **Ask for approval for all tools**, and save your changes if you're prompted.
+1. Select the ellipsis (**...**) icon on the `kb-knowledgebase...` tool, then select **Ask for approval for all tools**, and save your changes if you're prompted.
 
 Your agent will now request approval each time it uses Foundry IQ to search the knowledge base, which the client app you complete next will handle.
 


### PR DESCRIPTION
Fixes #235

Lab 04 and consolidated lab B1 told students to set **Ask for approval for all tools** on the **Azure AI Search** tool, but Foundry IQ attaches a `kb-knowledgebase<unique-id>` tool that the agent actually invokes — so approval never fired and `agent_client.py` got no `mcp_approval_request`.

Updated both labs to target the `kb-knowledgebase...` tool and clarified the note about the other tools that may appear. Docs-only change.