### PR TITLE
Fix Lab 02 (Python): reset input_list per turn and resolve tool calls in conversation

### DIFF
--- a/Instructions/Exercises/02-agent-custom-tools.md
+++ b/Instructions/Exercises/02-agent-custom-tools.md
@@ -153,7 +153,6 @@ Now you're ready to create an AI agent that uses MCP server tools to access exte
     ```python
    # Add references
    from azure.ai.projects import AIProjectClient
-   from azure.ai.projects.models import FunctionTool
    from azure.identity import DefaultAzureCredential
    from azure.ai.projects.models import PromptAgentDefinition, FunctionTool
    from openai.types.responses.response_input_param import FunctionCallOutput, ResponseInputParam
@@ -312,6 +311,8 @@ Now that you've created the agent with the function tools, you can send messages
    input_list: ResponseInputParam = []
     ```
 
+    This list is created inside the chat loop so that each turn starts with a fresh set of function call outputs.
+
 1. Find the comment **Send a prompt to the agent** and add the following code:
 
     ```python
@@ -375,8 +376,8 @@ Now that you've created the agent with the function tools, you can send messages
    # Send function call outputs back to the model and retrieve a response
    if input_list:
        response = openai_client.responses.create(
+           conversation=conversation.id,
            input=input_list,
-           previous_response_id=response.id,
            extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
        )
    # Display the agent's response
@@ -384,6 +385,8 @@ Now that you've created the agent with the function tools, you can send messages
     ```
 
     This code checks if there are any function call outputs in the input list, and if so, it sends them back to the agent as input to retrieve an updated response. Finally, it prints the agent's response.
+
+    Note that the outputs are attached to the same **conversation**, so the function calls are resolved in conversation state and the agent's answer is saved to the chat history. Sending them back with `previous_response_id` instead would make the *next* message fail with *"No tool output found for function call"*.
 
 1. Find the comment **Delete the agent when done** and add the following code:
 

--- a/Labfiles/02-agent-custom-tools/Python/agent.py
+++ b/Labfiles/02-agent-custom-tools/Python/agent.py
@@ -32,14 +32,14 @@ def main():
         # Create a thread for the chat session
         
 
-        # Create a list to hold function call outputs that will be sent back as input to the agent
-        
-        
         while True:
             user_input = input("Enter a prompt for the astronomy agent. Use 'quit' to exit.\nUSER: ").strip()
             if user_input.lower() == "quit":
                 print("Exiting chat.")
                 break
+
+            # Create a list to hold function call outputs that will be sent back as input to the agent
+            
 
             # Send a prompt to the agent
            


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02 - Use a custom function in an AI agent (Python)

Fixes #245.

Changes proposed in this pull request:

- **Create `input_list` inside the chat loop instead of once before it.** The list was never cleared, so after the first turn that called a tool, every later turn re-sent function call outputs that had already been handled and always fired the follow-up request. On a turn with no tool call, `if input_list:` was still truthy and the extra response **overwrote** the real answer — asking the agent something that needs no tool returned a re-summary of the previous turn's tool data instead. The stale outputs were also stored again in the conversation on each turn, duplicating items and growing the request payload every turn. The comment in `agent.py` moved inside the loop so the existing "find the comment, add this code" step now lands in the right place.
- **Send function call outputs with `conversation=conversation.id` instead of `previous_response_id=response.id`.** With `previous_response_id`, the agent's answer after a tool call was never written to the conversation, and the turn's `function_call` items were left with no matching output in conversation state — a later request then fails with `400: No tool output found for function call <call_id>`. The lab only avoided that error because the unreset `input_list` accidentally back-filled the missing outputs on the next turn, so the two bugs masked each other and both had to be fixed together. This also matches the pattern already used (and explained) in `Instructions/Consolidated/A4-add-custom-function-tools.md`. Note the two parameters are mutually exclusive — passing both returns `400 invalid_payload: "Cannot provide both 'previous_response_id' and 'conversation' in the same request"`.
- **Remove the duplicate `FunctionTool` import** from the **Add references** snippet — it was imported on its own line and again as part of the `PromptAgentDefinition, FunctionTool` line.
- Added two short explanatory notes to the instructions covering why the list is per-turn and why the outputs attach to the conversation.

### Verification

Ran the completed lab app end-to-end against a live Foundry project (`azure-ai-projects==2.0.0b4`, `gpt-4.1-mini`), using the two prompts from the exercise walkthrough plus a third no-tool prompt.

Before the fix, turn 3 ("Just say hello, do not use any tools") returned a re-summary of the turn 1 telescope data instead of a greeting, and the conversation held each turn-1 `function_call_output` twice with only a single assistant message in the whole history.

After the fix, all three turns answer correctly, the no-tool turn skips the follow-up request, and the conversation state is a clean per-turn trace with no duplicates:

```
- message               role=assistant
- message               role=user
- message               role=assistant
- function_call_output  call_id=call_cPz5DreutVbRII0eR4tM1VcW
- function_call         name=generate_observation_report  call_id=call_cPz5DreutVbRII0eR4tM1VcW
- message               role=user
- message               role=assistant
- function_call_output  call_id=call_Gw4Z3R6Sdw1Y1h1KmkNm1Oj7
- function_call_output  call_id=call_pLhda4aNSxuCHoFutqH4STEJ
- function_call         name=calculate_observation_cost  call_id=call_Gw4Z3R6Sdw1Y1h1KmkNm1Oj7
- function_call         name=next_visible_event  call_id=call_pLhda4aNSxuCHoFutqH4STEJ
- message               role=user
```

### Note on other labs

`Instructions/Exercises/03-mcp-integration.md` and `Labfiles/03-mcp-integration/Python/client.py` have the same two patterns (`input_list` declared before the `while` loop, follow-up sent with `previous_response_id`). I've left Lab 03 out of this PR to keep it scoped to the linked issue and to what I verified end-to-end — happy to extend this PR or open a separate one if you'd like that fixed too.
